### PR TITLE
compress by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The general requirements and roadmap are as follows:
 * [x] Support chunked request
 * [x] Support chunked response
 * [x] Support streaming entity bodies (via chunking likely)
-* [x] Support compression
+* [x] Support compression (default and per response options)
 * [x] Support cookies in request and response
 * [x] Clean up HTTPRequest
 * [x] Support form data

--- a/src/main/java/io/fusionauth/http/io/DelegatingOutputStream.java
+++ b/src/main/java/io/fusionauth/http/io/DelegatingOutputStream.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2022, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.http.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import io.fusionauth.http.HTTPValues.ContentEncodings;
+import io.fusionauth.http.HTTPValues.Headers;
+import io.fusionauth.http.server.HTTPRequest;
+import io.fusionauth.http.server.HTTPResponse;
+
+/**
+ * A delegating output stream that can allow for latent configuration changes prior to writing to the underlying output stream.
+ *
+ * @author Daniel DeGroff
+ */
+public class DelegatingOutputStream extends OutputStream {
+  private final HTTPRequest request;
+
+  private final HTTPResponse response;
+
+  private final OutputStream unCompressingOutputStream;
+
+  private Boolean compress;
+
+  private boolean defaultCompress;
+
+  private String encoding;
+
+  private OutputStream outputStream;
+
+  // https://stackoverflow.com/questions/23228359/is-checking-a-boolean-faster-than-setting-a-boolean-in-java
+  // - This seems to indicate that if you only need to write once, and read a bunch, while more byte code is
+  //   produced by gating the write operation with a read, it should faster since you'll only write once, and
+  //   a read of a volatile is much faster than a write operation.
+  // See CompressionTest.volatileCheckPerformance for results.
+  private volatile boolean used;
+
+  public DelegatingOutputStream(HTTPRequest request, HTTPResponse response, OutputStream outputStream) {
+    this.request = request;
+    this.response = response;
+    this.outputStream = outputStream;
+    this.unCompressingOutputStream = outputStream;
+  }
+
+  @Override
+  public void close() throws IOException {
+    outputStream.close();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    outputStream.flush();
+  }
+
+  public boolean isCompress() {
+    return (compress != null && compress) || defaultCompress;
+  }
+
+  public void setCompress(boolean compress) {
+    // Too late, once you write bytes, we can no longer change the OutputStream configuration.
+    if (used) {
+      throw new IllegalStateException("The HTTPResponse compression configuration cannot be modified once bytes have been written to it.");
+    }
+
+    // Short circuit, no work to do.
+    if (this.compress != null && this.compress == compress) {
+      return;
+    }
+
+    if (compress) {
+      if (setContentEncodingHeader()) {
+        return;
+      }
+    }
+
+    // Fall through and disable compress, because:
+    // 1. Compress was equal to false
+    // 2. Compress was equal to true, and the acceptable encoding values did not contain [gzip, deflate]
+    this.compress = false;
+  }
+
+  public void setDefaultCompress(boolean defaultCompress) {
+    this.defaultCompress = defaultCompress;
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (!used) {
+      init();
+    }
+
+    outputStream.write(b, off, len);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    if (!used) {
+      init();
+    }
+
+    outputStream.write(b);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    if (!used) {
+      init();
+    }
+
+    outputStream.write(b);
+  }
+
+  private void init() {
+    // Initialize the actual OutputStream latent so that we can call setCompress more than once.
+    // - The GZIPOutputStream writes bytes to the OutputStream during construction which means we cannot build it
+    //   more than once. This is why we must wait until we know for certain we are going to write bytes to construct
+    //   the compressing OutputStream.
+    used = true;
+
+    // Short circuit if there is nothing to do
+    if ((compress != null && !compress) || !defaultCompress) {
+      return;
+    }
+
+    // If we have not yet set compress, we need to set the header now.
+    // - We need to wait this long so that we only write this header when we know there are bytes to write.
+    if (compress == null) {
+      setContentEncodingHeader();
+    }
+
+    if (encoding != null) {
+      if (encoding.equalsIgnoreCase(ContentEncodings.Gzip)) {
+        try {
+          outputStream = new GZIPOutputStream(unCompressingOutputStream);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      } else if (encoding.equalsIgnoreCase(ContentEncodings.Deflate)) {
+        outputStream = new DeflaterOutputStream(unCompressingOutputStream);
+      }
+    }
+  }
+
+  private boolean setContentEncodingHeader() {
+    // Attempt to honor the requested encoding(s) in order, taking the first match
+    for (String encoding : request.getAcceptEncodings()) {
+      if (encoding.equalsIgnoreCase(ContentEncodings.Gzip)) {
+        response.setHeader(Headers.ContentEncoding, ContentEncodings.Gzip);
+        this.compress = true;
+        this.encoding = encoding;
+        return true;
+      } else if (encoding.equalsIgnoreCase(ContentEncodings.Deflate)) {
+        response.setHeader(Headers.ContentEncoding, ContentEncodings.Deflate);
+        this.compress = true;
+        this.encoding = encoding;
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/io/fusionauth/http/server/Configurable.java
+++ b/src/main/java/io/fusionauth/http/server/Configurable.java
@@ -59,6 +59,18 @@ public interface Configurable<T extends Configurable<T>> {
   }
 
   /**
+   * Sets the default compression behavior for the HTTP response. This behavior can be optionally set per response. See
+   * {@link HTTPResponse#setCompress(boolean)}. Defaults to true.
+   *
+   * @param compressByDefault true if you want to compress by default, or false to not compress by default.
+   * @return This.
+   */
+  default T withCompressByDefault(boolean compressByDefault) {
+    configuration().withCompressByDefault(compressByDefault);
+    return (T) this;
+  }
+
+  /**
    * Sets the prefix of the URIs that this server handles. Technically, the server will accept all inbound connections, but if a context
    * path is set, it can assist the application with building URIs (in HTML for example). This value will be accessible via the
    * {@link HTTPRequest#getContextPath()} method.

--- a/src/main/java/io/fusionauth/http/server/HTTP11Processor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTP11Processor.java
@@ -64,8 +64,7 @@ public class HTTP11Processor implements HTTPProcessor {
     this.requestProcessor = new HTTPRequestProcessor(configuration, request);
 
     NonBlockingByteBufferOutputStream outputStream = new NonBlockingByteBufferOutputStream(notifier, configuration.getResponseBufferSize());
-    this.response = new HTTPResponse(outputStream, request);
-    this.response.setDefaultCompress(configuration.isCompressByDefault());
+    this.response = new HTTPResponse(outputStream, request, configuration.isCompressByDefault());
     this.responseProcessor = new HTTPResponseProcessor(configuration, request, response, outputStream);
   }
 

--- a/src/main/java/io/fusionauth/http/server/HTTP11Processor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTP11Processor.java
@@ -65,6 +65,7 @@ public class HTTP11Processor implements HTTPProcessor {
 
     NonBlockingByteBufferOutputStream outputStream = new NonBlockingByteBufferOutputStream(notifier, configuration.getResponseBufferSize());
     this.response = new HTTPResponse(outputStream, request);
+    this.response.setDefaultCompress(configuration.isCompressByDefault());
     this.responseProcessor = new HTTPResponseProcessor(configuration, request, response, outputStream);
   }
 

--- a/src/main/java/io/fusionauth/http/server/HTTPResponse.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponse.java
@@ -61,8 +61,8 @@ public class HTTPResponse {
 
   private Writer writer;
 
-  public HTTPResponse(OutputStream outputStream, HTTPRequest request) {
-    this.outputStream = new DelegatingOutputStream(request, this, outputStream);
+  public HTTPResponse(OutputStream outputStream, HTTPRequest request, boolean compressByDefault) {
+    this.outputStream = new DelegatingOutputStream(request, this, outputStream, compressByDefault);
   }
 
   public void addCookie(Cookie cookie) {
@@ -270,10 +270,6 @@ public class HTTPResponse {
 
   public void setDateHeader(String name, ZonedDateTime value) {
     addHeader(name, DateTimeFormatter.RFC_1123_DATE_TIME.format(value));
-  }
-
-  public void setDefaultCompress(boolean compress) {
-    outputStream.setDefaultCompress(compress);
   }
 
   /**

--- a/src/main/java/io/fusionauth/http/server/HTTPResponse.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponse.java
@@ -28,16 +28,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.GZIPOutputStream;
 
 import io.fusionauth.http.Cookie;
 import io.fusionauth.http.HTTPValues.Connections;
-import io.fusionauth.http.HTTPValues.ContentEncodings;
 import io.fusionauth.http.HTTPValues.ContentTypes;
 import io.fusionauth.http.HTTPValues.Headers;
 import io.fusionauth.http.HTTPValues.Status;
-import io.fusionauth.http.io.NonBlockingByteBufferOutputStream;
+import io.fusionauth.http.io.DelegatingOutputStream;
 import io.fusionauth.http.util.HTTPTools;
 import io.fusionauth.http.util.HTTPTools.HeaderValue;
 
@@ -52,17 +49,11 @@ public class HTTPResponse {
 
   private final Map<String, List<String>> headers = new HashMap<>();
 
-  private final NonBlockingByteBufferOutputStream originalOutputStream;
-
-  private final HTTPRequest request;
+  private final DelegatingOutputStream outputStream;
 
   private volatile boolean committed;
 
-  private boolean compress;
-
   private Throwable exception;
-
-  private OutputStream outputStream;
 
   private int status = 200;
 
@@ -70,10 +61,8 @@ public class HTTPResponse {
 
   private Writer writer;
 
-  public HTTPResponse(NonBlockingByteBufferOutputStream outputStream, HTTPRequest request) {
-    this.outputStream = outputStream;
-    this.originalOutputStream = outputStream;
-    this.request = request;
+  public HTTPResponse(OutputStream outputStream, HTTPRequest request) {
+    this.outputStream = new DelegatingOutputStream(request, this, outputStream);
   }
 
   public void addCookie(Cookie cookie) {
@@ -81,7 +70,23 @@ public class HTTPResponse {
     cookies.computeIfAbsent(path, key -> new HashMap<>()).put(cookie.name, cookie);
   }
 
+  /**
+   * Add a response header. Calling this method multiple times with the same name will result in multiple headers being written to the HTTP
+   * response.
+   * <p>
+   * Optionally call {@link #setHeader(String, String)} if you wish to only write a single header by name, overwriting any previously
+   * written headers.
+   * <p>
+   * If either parameter are null, the header will not be added to the response.
+   *
+   * @param name  the header name
+   * @param value the header value
+   */
   public void addHeader(String name, String value) {
+    if (name == null || value == null) {
+      return;
+    }
+
     headers.computeIfAbsent(name.toLowerCase(), key -> new ArrayList<>()).add(value);
   }
 
@@ -226,38 +231,23 @@ public class HTTPResponse {
     this.committed = committed;
   }
 
+  /**
+   * @return true if compression will be utilized when writing the HTTP OutputStream.
+   */
   public boolean isCompress() {
-    return compress;
+    return outputStream.isCompress();
   }
 
+  /**
+   * Provides runtime configuration for HTTP response compression. This can be called as many times as you wish prior to the first byte
+   * being written to the HTTP OutputStream.
+   * <p>
+   * An {@link IllegalStateException} will be thrown if you call this method after writing to the OutputStream.
+   *
+   * @param compress true to enable the response to be written back compressed.
+   */
   public void setCompress(boolean compress) {
-    if (outputStream instanceof NonBlockingByteBufferOutputStream nbbbos) {
-      if (!nbbbos.isEmpty()) {
-        throw new IllegalStateException("The HTTPResponse can't be set for compression because bytes have already been written to it");
-      }
-    }
-
-    if (compress) {
-      for (String encoding : request.getAcceptEncodings()) {
-        if (encoding.equalsIgnoreCase(ContentEncodings.Gzip)) {
-          try {
-            outputStream = new GZIPOutputStream(originalOutputStream);
-            setHeader(Headers.ContentEncoding, ContentEncodings.Gzip);
-            this.compress = true;
-            break;
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        } else if (encoding.equalsIgnoreCase(ContentEncodings.Deflate)) {
-          outputStream = new DeflaterOutputStream(originalOutputStream);
-          setHeader(Headers.ContentEncoding, ContentEncodings.Deflate);
-          this.compress = true;
-          break;
-        }
-      }
-    } else {
-      outputStream = originalOutputStream;
-    }
+    outputStream.setCompress(compress);
   }
 
   /**
@@ -282,12 +272,25 @@ public class HTTPResponse {
     addHeader(name, DateTimeFormatter.RFC_1123_DATE_TIME.format(value));
   }
 
+  public void setDefaultCompress(boolean compress) {
+    outputStream.setDefaultCompress(compress);
+  }
+
+  /**
+   * Set the header, replacing any existing header values. If you wish to add to existing response headers, use the
+   * {@link #addHeader(String, String)} instead.
+   * <p>
+   * If either parameter are null, the header will not be added to the response.
+   *
+   * @param name  the header name
+   * @param value the header value
+   */
   public void setHeader(String name, String value) {
     if (name == null || value == null) {
       return;
     }
 
-    addHeader(name, value);
+    headers.put(name.toLowerCase(), new ArrayList<>(List.of(value)));
   }
 }
 

--- a/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
@@ -189,7 +189,7 @@ public class HTTPResponseProcessor {
 
     for (Cookie cookie : response.getCookies()) {
       String value = cookie.toResponseHeader();
-      response.setHeader(Headers.SetCookie, value);
+      response.addHeader(Headers.SetCookie, value);
     }
   }
 }

--- a/src/main/java/io/fusionauth/http/server/HTTPServerConfiguration.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPServerConfiguration.java
@@ -31,6 +31,8 @@ public class HTTPServerConfiguration implements Configurable<HTTPServerConfigura
 
   private Duration clientTimeoutDuration = Duration.ofSeconds(20);
 
+  private boolean compressByDefault = true;
+
   private String contextPath = "";
 
   private ExpectValidator expectValidator;
@@ -123,6 +125,10 @@ public class HTTPServerConfiguration implements Configurable<HTTPServerConfigura
     return shutdownDuration;
   }
 
+  public boolean isCompressByDefault() {
+    return compressByDefault;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -144,6 +150,15 @@ public class HTTPServerConfiguration implements Configurable<HTTPServerConfigura
 
 
     this.clientTimeoutDuration = duration;
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public HTTPServerConfiguration withCompressByDefault(boolean compressByDefault) {
+    this.compressByDefault = compressByDefault;
     return this;
   }
 

--- a/src/test/java/io/fusionauth/http/CompressionTest.java
+++ b/src/test/java/io/fusionauth/http/CompressionTest.java
@@ -281,7 +281,7 @@ public class CompressionTest extends BaseTest {
     System.out.println("Read gate:   " + (end - start) + "ms");
 
     // Notes on results:
-    // With very higher iteration counts, it becomes noticeable that the read gate improves performance. This gain
+    // With a very high iteration counts, it becomes noticeable that the read gate improves performance. This gain
     // is not likely measurable during normal runtime.
     //
     // 250,000,000 iterations

--- a/src/test/java/io/fusionauth/http/CompressionTest.java
+++ b/src/test/java/io/fusionauth/http/CompressionTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.DecimalFormat;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -37,6 +38,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * Tests the HTTP server handles compression properly.
@@ -45,6 +47,12 @@ import static org.testng.Assert.assertNull;
  */
 public class CompressionTest extends BaseTest {
   private final Path file = Paths.get("src/test/java/io/fusionauth/http/ChunkedTest.java");
+
+  @SuppressWarnings({"FieldCanBeLocal", "unused"})
+  private volatile boolean test1;
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private volatile boolean test2;
 
   @DataProvider(name = "chunkedSchemes")
   public Object[][] chunkedSchemes() {
@@ -56,10 +64,16 @@ public class CompressionTest extends BaseTest {
     };
   }
 
-  @Test(dataProvider = "chunkedSchemes")
-  public void compressDeflate(boolean chunked, String scheme) throws Exception {
+  @Test(dataProvider = "compressedChunkedSchemes")
+  public void compress(String encoding, boolean chunked, String scheme) throws Exception {
     HTTPHandler handler = (req, res) -> {
+      // Testing an indecisive user, can't make up their mind... this is allowed as long as you have not written ay bytes.
       res.setCompress(true);
+      res.setCompress(false);
+      res.setCompress(true);
+      res.setCompress(false);
+      res.setCompress(true);
+
       res.setHeader(Headers.ContentType, "text/plain");
       res.setStatus(200);
 
@@ -70,6 +84,14 @@ public class CompressionTest extends BaseTest {
       try (InputStream is = Files.newInputStream(file)) {
         OutputStream outputStream = res.getOutputStream();
         is.transferTo(outputStream);
+
+        // Try to call setCompress, expect an exception - we cannot change modes once we've written to the OutputStream.
+        try {
+          res.setCompress(false);
+          fail("Expected setCompress(false) to fail hard!");
+        } catch (IllegalStateException expected) {
+        }
+
         outputStream.close();
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -81,21 +103,25 @@ public class CompressionTest extends BaseTest {
       URI uri = makeURI(scheme, "");
       var client = makeClient(scheme, null);
       var response = client.send(
-          HttpRequest.newBuilder().header(Headers.AcceptEncoding, "deflate, gzip").uri(uri).GET().build(),
+          HttpRequest.newBuilder().header(Headers.AcceptEncoding, encoding).uri(uri).GET().build(),
           r -> BodySubscribers.ofInputStream()
       );
 
-      var result = new String(new InflaterInputStream(response.body()).readAllBytes(), StandardCharsets.UTF_8);
-      assertEquals(response.headers().firstValue(Headers.ContentEncoding).orElse(null), ContentEncodings.Deflate);
+      var result = new String(
+          encoding.equals(ContentEncodings.Deflate)
+              ? new InflaterInputStream(response.body()).readAllBytes()
+              : new GZIPInputStream(response.body()).readAllBytes(), StandardCharsets.UTF_8);
+
+      assertEquals(response.headers().firstValue(Headers.ContentEncoding).orElse(null), encoding);
       assertEquals(response.statusCode(), 200);
       assertEquals(result, Files.readString(file));
     }
   }
 
-  @Test(dataProvider = "chunkedSchemes")
-  public void compressGzip(boolean chunked, String scheme) throws Exception {
+  @Test(dataProvider = "compressedChunkedSchemes")
+  public void compress_onByDefault(String encoding, boolean chunked, String scheme) throws Exception {
     HTTPHandler handler = (req, res) -> {
-      res.setCompress(true);
+      // Use case, do not call response.setCompress(true)
       res.setHeader(Headers.ContentType, "text/plain");
       res.setStatus(200);
 
@@ -117,19 +143,48 @@ public class CompressionTest extends BaseTest {
       URI uri = makeURI(scheme, "");
       var client = makeClient(scheme, null);
       var response = client.send(
-          HttpRequest.newBuilder().header(Headers.AcceptEncoding, "gzip, deflate").uri(uri).GET().build(),
+          HttpRequest.newBuilder().header(Headers.AcceptEncoding, encoding).uri(uri).GET().build(),
           r -> BodySubscribers.ofInputStream()
       );
 
-      var result = new String(new GZIPInputStream(response.body()).readAllBytes(), StandardCharsets.UTF_8);
-      assertEquals(response.headers().firstValue(Headers.ContentEncoding).orElse(null), ContentEncodings.Gzip);
+      var result = new String(
+          encoding.equals(ContentEncodings.Deflate)
+              ? new InflaterInputStream(response.body()).readAllBytes()
+              : new GZIPInputStream(response.body()).readAllBytes(), StandardCharsets.UTF_8);
+
+      assertEquals(response.headers().firstValue(Headers.ContentEncoding).orElse(null), encoding);
       assertEquals(response.statusCode(), 200);
       assertEquals(result, Files.readString(file));
     }
+  }
+
+  @DataProvider(name = "compressedChunkedSchemes")
+  public Object[][] compressedChunkedSchemes() {
+    return new Object[][]{
+        // encoding, chunked, schema
+
+        // Chunked http
+        {ContentEncodings.Deflate, true, "http"},
+        {ContentEncodings.Gzip, true, "http"},
+
+        // Chunked https
+        {ContentEncodings.Deflate, true, "https"},
+        {ContentEncodings.Gzip, true, "https"},
+
+        // Non chunked http
+        {ContentEncodings.Deflate, false, "http"},
+        {ContentEncodings.Gzip, false, "http"},
+
+        // Non chunked https
+        {ContentEncodings.Deflate, false, "https"},
+        {ContentEncodings.Gzip, false, "https"}
+    };
   }
 
   @Test(dataProvider = "chunkedSchemes")
   public void requestedButNotAccepted(boolean chunked, String scheme) throws Exception {
+    // Use case: setCompress(true), but the request does not contain the 'Accept-Encoding' header.
+    //     Result: no compression
     HTTPHandler handler = (req, res) -> {
       res.setCompress(true);
       res.setHeader(Headers.ContentType, "text/plain");
@@ -161,5 +216,77 @@ public class CompressionTest extends BaseTest {
       assertEquals(response.statusCode(), 200);
       assertEquals(response.body(), Files.readString(file));
     }
+  }
+
+  @Test(dataProvider = "chunkedSchemes")
+  public void requestedButNotAccepted_unSupportedEncoding(boolean chunked, String scheme) throws Exception {
+    // Use case: setCompress(true), and 'Accept-Encoding: br' which is valid, but not yet supported
+    //     Result: no compression
+    HTTPHandler handler = (req, res) -> {
+      res.setCompress(true);
+      res.setHeader(Headers.ContentType, "text/plain");
+      res.setStatus(200);
+
+      if (!chunked) {
+        res.setContentLength(Files.size(file));
+      }
+
+      try (InputStream is = Files.newInputStream(file)) {
+        OutputStream outputStream = res.getOutputStream();
+        is.transferTo(outputStream);
+        outputStream.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    CountingInstrumenter instrumenter = new CountingInstrumenter();
+    try (HTTPServer ignore = makeServer(scheme, handler, instrumenter).start()) {
+      URI uri = makeURI(scheme, "");
+      var client = makeClient(scheme, null);
+      var response = client.send(
+          HttpRequest.newBuilder().header(Headers.AcceptEncoding, "br").uri(uri).GET().build(),
+          r -> BodySubscribers.ofString(StandardCharsets.UTF_8)
+      );
+
+      assertNull(response.headers().firstValue(Headers.ContentEncoding).orElse(null));
+      assertEquals(response.statusCode(), 200);
+      assertEquals(response.body(), Files.readString(file));
+    }
+  }
+
+  @Test(enabled = false)
+  public void volatileCheckPerformance() {
+    long start = System.currentTimeMillis();
+    int count = 250_000_000;
+
+    System.out.println(new DecimalFormat("#,###").format(count) + " iterations");
+    System.out.println("------------------------");
+
+    for (int i = 0; i < count; i++) {
+      test1 = true;
+    }
+
+    long end = System.currentTimeMillis();
+    System.out.println("Write:       " + (end - start) + "ms");
+
+    start = System.currentTimeMillis();
+    for (int i = 0; i < count; i++) {
+      if (!test2) {
+        test2 = true;
+      }
+    }
+
+    end = System.currentTimeMillis();
+    System.out.println("Read gate:   " + (end - start) + "ms");
+
+    // Notes on results:
+    // With very higher iteration counts, it becomes noticeable that the read gate improves performance. This gain
+    // is not likely measurable during normal runtime.
+    //
+    // 250,000,000 iterations
+    // ------------------------
+    // Write:       92ms
+    // Read gate:   142ms
   }
 }

--- a/src/test/java/io/fusionauth/http/CoreTest.java
+++ b/src/test/java/io/fusionauth/http/CoreTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
+import java.util.zip.InflaterInputStream;
 
 import com.inversoft.net.ssl.SSLTools;
 import com.inversoft.rest.RESTClient;
@@ -396,7 +397,7 @@ public class CoreTest extends BaseTest {
       assertEquals(req.getURLParameter("foo "), "bar ");
 
       res.setHeader(Headers.ContentType, "text/plain");
-      res.setHeader("Content-Length", "16");
+      // Compression is on by default, don't write a Content-Length header it will be wrong.
       res.setStatus(200);
 
       try {
@@ -421,10 +422,12 @@ public class CoreTest extends BaseTest {
                                        .header(Headers.UserAgent, "java-http test")
                                        .GET()
                                        .build();
-      var response = client.send(request, r -> BodySubscribers.ofString(StandardCharsets.UTF_8));
+
+      var response = client.send(request, r -> BodySubscribers.ofInputStream());
 
       assertEquals(response.statusCode(), 200);
-      assertEquals(response.body(), ExpectedResponse);
+      var result = new String(new InflaterInputStream(response.body()).readAllBytes(), StandardCharsets.UTF_8);
+      assertEquals(result, ExpectedResponse);
     }
   }
 


### PR DESCRIPTION
1. Allow the server to be configured to compress by default, and still allow the HTTP response to enable or disable compression. 
2. Change behavior of setHeader and addHeader in HTTPResonse, needs discussion.
3. Javadoc