### PR TITLE
degroff/flush test

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.2", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.3", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.13", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.2", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.5", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.6", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.3", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.4", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.5", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.14", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.1.14-RC.4", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fusionauth</groupId>
   <artifactId>java-http</artifactId>
-  <version>0.1.14</version>
+  <version>0.1.14-RC.4</version>
   <packaging>jar</packaging>
 
   <name>Java HTTP library (client and server)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fusionauth</groupId>
   <artifactId>java-http</artifactId>
-  <version>0.1.13</version>
+  <version>0.1.14-RC.1</version>
   <packaging>jar</packaging>
 
   <name>Java HTTP library (client and server)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fusionauth</groupId>
   <artifactId>java-http</artifactId>
-  <version>0.1.14-RC.1</version>
+  <version>0.1.14</version>
   <packaging>jar</packaging>
 
   <name>Java HTTP library (client and server)</name>

--- a/src/main/java/io/fusionauth/http/body/response/ChunkedBodyProcessor.java
+++ b/src/main/java/io/fusionauth/http/body/response/ChunkedBodyProcessor.java
@@ -40,12 +40,15 @@ public class ChunkedBodyProcessor implements BodyProcessor {
 
   @Override
   public ByteBuffer[] currentBuffers() {
-    ByteBuffer buffer = outputStream.readableBuffer();
-    if (buffer != null && currentBuffers[1] != buffer) {
-      buildChunk(buffer);
+    // If the current chunk still has data, write it
+    if (currentBuffers[1] != null && (currentBuffers[0].hasRemaining() || currentBuffers[1].hasRemaining() || currentBuffers[2].hasRemaining())) {
+      return currentBuffers;
     }
 
+    // Otherwise, get the next chunk if any is ready to go
+    ByteBuffer buffer = outputStream.readableBuffer();
     if (buffer != null) {
+      buildChunk(buffer);
       return currentBuffers;
     }
 
@@ -62,7 +65,7 @@ public class ChunkedBodyProcessor implements BodyProcessor {
 
   @Override
   public boolean isComplete() {
-    return outputStream.isClosed();
+    return outputStream.isClosed() && !Final[0].hasRemaining();
   }
 
   private void buildChunk(ByteBuffer buffer) {

--- a/src/main/java/io/fusionauth/http/body/response/ContentLengthBodyProcessor.java
+++ b/src/main/java/io/fusionauth/http/body/response/ContentLengthBodyProcessor.java
@@ -35,6 +35,10 @@ public class ContentLengthBodyProcessor implements BodyProcessor {
 
   @Override
   public ByteBuffer[] currentBuffers() {
+    if (currentBuffers[0] != null && currentBuffers[0].hasRemaining()) {
+      return currentBuffers;
+    }
+
     currentBuffers[0] = outputStream.readableBuffer();
     return currentBuffers[0] != null ? currentBuffers : null;
   }

--- a/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
+++ b/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@ import io.fusionauth.http.server.Notifier;
  * @author Brian Pontarelli
  */
 public class NonBlockingByteBufferOutputStream extends OutputStream {
-  private static final boolean IgnoreFlush;
-
   private final int bufferSize;
 
   // Shared between writer and reader threads. No one blocks using this.
@@ -46,12 +44,6 @@ public class NonBlockingByteBufferOutputStream extends OutputStream {
   private ByteBuffer currentBuffer;
 
   private volatile boolean used;
-
-  static {
-    String prop = System.getenv("JAVA_HTTP_IGNORE_FLUSH");
-    IgnoreFlush = Boolean.parseBoolean(prop);
-    System.out.println("\nJAVA_HTTP_IGNORE_FLUSH=" + IgnoreFlush + "\n");
-  }
 
   public NonBlockingByteBufferOutputStream(Notifier notifier, int bufferSize) {
     this.notifier = notifier;
@@ -86,10 +78,6 @@ public class NonBlockingByteBufferOutputStream extends OutputStream {
    * created. And finally, this notifies the selector to wake up.
    */
   public void flush() {
-    if (IgnoreFlush) {
-      return;
-    }
-
     if (currentBuffer != null && currentBuffer.remaining() < (currentBuffer.capacity() / 10)) {
       addBuffer(true);
     }

--- a/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
+++ b/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class NonBlockingByteBufferOutputStream extends OutputStream {
   static {
     String prop = System.getenv("JAVA_HTTP_IGNORE_FLUSH");
     IgnoreFlush = Boolean.parseBoolean(prop);
-    System.out.println("\n\nJAVA_HTTP_IGNORE_FLUSH=" + IgnoreFlush + "\n\n");
+    System.out.println("\nJAVA_HTTP_IGNORE_FLUSH=" + IgnoreFlush + "\n");
   }
 
   public NonBlockingByteBufferOutputStream(Notifier notifier, int bufferSize) {

--- a/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
+++ b/src/main/java/io/fusionauth/http/io/NonBlockingByteBufferOutputStream.java
@@ -50,6 +50,7 @@ public class NonBlockingByteBufferOutputStream extends OutputStream {
   static {
     String prop = System.getenv("JAVA_HTTP_IGNORE_FLUSH");
     IgnoreFlush = Boolean.parseBoolean(prop);
+    System.out.println("\n\nJAVA_HTTP_IGNORE_FLUSH=" + IgnoreFlush + "\n\n");
   }
 
   public NonBlockingByteBufferOutputStream(Notifier notifier, int bufferSize) {

--- a/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
@@ -64,7 +64,7 @@ public class HTTPResponseProcessor {
     if (state == ResponseState.Preamble || state == ResponseState.Expect) {
       // We can't write the preamble under normal conditions if the worker thread is still working. Expect handling is different and the
       // client is waiting for a pre-canned response
-      if (state != ResponseState.Expect && outputStream.readableBuffer() == null && !outputStream.isClosed()) {
+      if (state != ResponseState.Expect && !outputStream.hasReadableBuffer() && !outputStream.isClosed()) {
         return null;
       }
 

--- a/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
@@ -16,7 +16,6 @@
 package io.fusionauth.http.server;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import io.fusionauth.http.Cookie;
 import io.fusionauth.http.HTTPValues.Connections;
@@ -36,10 +35,6 @@ import io.fusionauth.http.util.HTTPTools;
  * @author Brian Pontarelli
  */
 public class HTTPResponseProcessor {
-  private final AtomicInteger LoopCount = new AtomicInteger();
-
-  private final int YieldEveryNth = 25;
-
   private final HTTPServerConfiguration configuration;
 
   private final Logger logger;
@@ -140,10 +135,6 @@ public class HTTPResponseProcessor {
         state = response.isKeepAlive() ? ResponseState.KeepAlive : ResponseState.Close;
         logger.debug("No more bytes from worker thread. Changing state to [{}]", state);
       } else {
-        if (LoopCount.incrementAndGet() % YieldEveryNth == 0) {
-          Thread.yield();
-        }
-
         // Just some debugging
         logger.debug("Nothing to write from the worker thread but the OutputStream isn't closed");
       }

--- a/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
@@ -246,9 +246,9 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
 
                   StringBuilder threadDump = new StringBuilder();
                   for (Map.Entry<Thread, StackTraceElement[]> entry : Thread.getAllStackTraces().entrySet()) {
-                    threadDump.append(entry.getKey() + " " + entry.getKey().getState()).append("\n");
+                    threadDump.append(entry.getKey()).append(" ").append(entry.getKey().getState()).append("\n");
                     for (StackTraceElement ste : entry.getValue()) {
-                      threadDump.append("\tat " + ste).append("\n");
+                      threadDump.append("\tat ").append(ste).append("\n");
                     }
                     threadDump.append("\n");
                   }
@@ -278,6 +278,7 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
       if (buffer != null) {
         int num = client.read(buffer);
         if (num < 0) {
+          logger.debug("Client terminated the connection. Num bytes is [{}]. Closing connection", num);
           state = processor.close(true);
         } else {
           logger.debug("Read [{}] bytes from client", num);
@@ -312,6 +313,7 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
       }
 
       if (num < 0) {
+        logger.debug("Client refused bytes or terminated the connection. Num bytes is [{}]. Closing connection", num);
         state = processor.close(true);
       } else {
         if (num > 0) {

--- a/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,16 +238,21 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
             .filter(key -> key.attachment() != null)
             .filter(key -> ((HTTPProcessor) key.attachment()).lastUsed() < now - clientTimeout.toMillis())
             .forEach(key -> {
-              if (logger.isDebuggable()) {
-                var client = (SocketChannel) key.channel();
-                try {
-                  logger.debug("Closing client connection [{}] due to inactivity", client.getRemoteAddress().toString());
-                } catch (IOException e) {
-                  // Ignore because we are just debugging
+              try {
+                if (logger.isDebuggable()) {
+                  var client = (SocketChannel) key.channel();
+                  try {
+                    logger.debug("Closing client connection [{}] due to inactivity", client.getRemoteAddress().toString());
+                  } catch (IOException e) {
+                    // Ignore because we are just debugging
+                  }
                 }
-              }
 
-              cancelAndCloseKey(key);
+                cancelAndCloseKey(key);
+              } catch (Throwable e) {
+                System.out.println("\n\nHoly crap! This blew chunks super hard. Exception [" + e.getClass().getSimpleName() + "] Message [" + e.getMessage() + "]");
+                logger.error("Holy crap! This blew chunks super hard.", e);
+              }
             });
   }
 

--- a/src/test/resources/negative-one-status-code.log
+++ b/src/test/resources/negative-one-status-code.log
@@ -1,0 +1,10656 @@
+/Users/bpontarelli/dev/java/jdk-17.0.3+7/Contents/Home/bin/java -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:55922,suspend=y,server=n -ea -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/groovyHotSwap/gragent.jar -javaagent:/Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/captureAgent/debugger-agent.jar -Dfile.encoding=UTF-8 -classpath /Users/bpontarelli/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/231.8770.65/IntelliJ IDEA.app/Contents/lib/idea_rt.jar:/Users/bpontarelli/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/231.8770.65/IntelliJ IDEA.app/Contents/plugins/testng/lib/testng-rt.jar:/Users/bpontarelli/dev/os/prime/prime-mvc/build/classes/test:/Users/bpontarelli/dev/os/prime/prime-mvc/build/classes/main:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0.jar:/Users/bpontarelli/.savant/cache/com/google/inject/guice/5.1.0/guice-5.1.0.jar:/Users/bpontarelli/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar:/Users/bpontarelli/.savant/cache/com/inversoft/restify/4.1.2/restify-4.1.2.jar:/Users/bpontarelli/.savant/cache/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6.jar:/Users/bpontarelli/.savant/cache/io/fusionauth/fusionauth-jwt/5.1.0/fusionauth-jwt-5.1.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.14.0/jackson-databind-2.14.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.14.0/jackson-annotations-2.14.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.14.0/jackson-core-2.14.0.jar:/Users/bpontarelli/.savant/cache/io/fusionauth/java-http/0.1.14-RC.5.{integration}/java-http-0.1.14-RC.5.{integration}.jar:/Users/bpontarelli/.savant/cache/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar:/Users/bpontarelli/.savant/cache/org/ow2/asm/asm/9.2.0/asm-9.2.0.jar:/Users/bpontarelli/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/Users/bpontarelli/.savant/cache/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.jar:/Users/bpontarelli/.savant/cache/org/easymock/easymock/5.0.1/easymock-5.0.1.jar:/Users/bpontarelli/.savant/cache/org/objenesis/objenesis/3.3.0/objenesis-3.3.0.jar:/Users/bpontarelli/.savant/cache/org/testng/testng/7.7.1/testng-7.7.1.jar:/Users/bpontarelli/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0.jar:/Users/bpontarelli/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar:/Users/bpontarelli/.savant/cache/org/jsoup/jsoup/1.15.3/jsoup-1.15.3.jar:/Users/bpontarelli/.savant/cache/ch/qos/logback/logback-classic/1.4.4/logback-classic-1.4.4.jar:/Users/bpontarelli/.savant/cache/ch/qos/logback/logback-core/1.4.4/logback-core-1.4.4.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/btf/1.3.0/btf-1.3.0.jar:/Users/bpontarelli/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar:/Users/bpontarelli/.savant/cache/com/google/guava/guava/30.1.0-jre/guava-30.1.0-jre.jar:/Users/bpontarelli/.savant/cache/com/google/guava/listenablefuture/9999.0.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0.0-empty-to-avoid-conflict-with-guava.jar:/Users/bpontarelli/.savant/cache/com/google/j2objc/j2objc-annotations/1.3.0/j2objc-annotations-1.3.0.jar:/Users/bpontarelli/.savant/cache/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.jar:/Users/bpontarelli/.savant/cache/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/Users/bpontarelli/.savant/cache/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar:/Users/bpontarelli/.savant/cache/com/inversoft/jackson5/3.0.1/jackson5-3.0.1.jar com.intellij.rt.testng.RemoteTestNGStarter -listener org.primeframework.mvc.PrimeBaseTest$TestListener -usedefaultlisteners false -socket55921 @w@/private/var/folders/z6/t_y9tpcj1p57_r4dy67d5_j40000gn/T/idea_working_dirs_testng.tmp -temp /private/var/folders/z6/t_y9tpcj1p57_r4dy67d5_j40000gn/T/idea_testng.tmp
+Connected to the target VM, address: '127.0.0.1:55922', transport: 'socket'
+May 12, 2023 11:17:26.789 AM INFO  org.testng.internal.Utils - [TestNG] Running:
+  /Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/temp-testng-customsuite.xml
+
+May 12, 2023 11:17:27.028 AM INFO  org.primeframework.mvc.PrimeMVCRequestHandler - Initializing Prime
+May 12, 2023 11:17:27.334 AM INFO  org.primeframework.mvc.TestPrimeMainThread - Prime HTTP server started
+[1] org.primeframework.mvc.PerformanceTest.get
+0
+100
+200
+300
+
+java.lang.AssertionError: Status code [-1] was not equal to [200]
+
+Redirect: [null]
+Response body:
+
+
+	at org.primeframework.mvc.test.RequestResult.assertStatusCode(RequestResult.java:1175)
+	at org.primeframework.mvc.PerformanceTest.get(PerformanceTest.java:31)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
+	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
+	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:677)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:221)
+	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
+	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:969)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:194)
+	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:148)
+	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
+	at org.testng.TestRunner.privateRun(TestRunner.java:829)
+	at org.testng.TestRunner.run(TestRunner.java:602)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:431)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:391)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:330)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1256)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1176)
+	at org.testng.TestNG.runSuites(TestNG.java:1099)
+	at org.testng.TestNG.run(TestNG.java:1067)
+	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
+	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
+
+
+
+
+Test failure
+-----------------
+Exception: AssertionError
+Message: Status code [-1] was not equal to [200]
+
+Redirect: [null]
+Response body:
+
+
+HTTP Trace:
+
+     | 1683911847430 (HTTPS-A)
+     | 1683911847430 (A)
+     | 1683911847430 Accepted connection from client [/127.0.0.1:55927]
+     | 1683911847431 Read [336] bytes from client
+     | 1683911847431 (R)
+     | 1683911847431 (RP)
+     | 1683911847433 Preamble successfully parsed
+     | 1683911847433 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847433 (RWo)
+     | 1683911847435 (RC)
+     | 1683911847592 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847596 Preamble is [198] bytes long
+     | 1683911847596 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847596 Still writing preamble
+     | 1683911847597 Wrote [198] bytes to the client
+     | 1683911847597 (W)
+     | 1683911847597 Writing back bytes
+     | 1683911847597 Wrote [160] bytes to the client
+     | 1683911847598 (W)
+     | 1683911847598 Writing back bytes
+     | 1683911847598 Wrote [5] bytes to the client
+     | 1683911847598 (W)
+     | 1683911847598 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847598 (WKA)
+     | 1683911847601 Read [336] bytes from client
+     | 1683911847601 (R)
+     | 1683911847601 (RP)
+     | 1683911847601 Preamble successfully parsed
+     | 1683911847601 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847601 (RWo)
+     | 1683911847601 (RC)
+     | 1683911847605 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847605 Preamble is [198] bytes long
+     | 1683911847605 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847605 Still writing preamble
+     | 1683911847605 Wrote [198] bytes to the client
+     | 1683911847605 (W)
+     | 1683911847605 Writing back bytes
+     | 1683911847605 Wrote [249] bytes to the client
+     | 1683911847605 (W)
+     | 1683911847605 Writing back bytes
+     | 1683911847605 Wrote [5] bytes to the client
+     | 1683911847605 (W)
+     | 1683911847605 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847605 (WKA)
+     | 1683911847606 Read [336] bytes from client
+     | 1683911847606 (R)
+     | 1683911847606 (RP)
+     | 1683911847606 Preamble successfully parsed
+     | 1683911847606 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847606 (RWo)
+     | 1683911847606 (RC)
+     | 1683911847609 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847609 Preamble is [198] bytes long
+     | 1683911847609 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847609 Still writing preamble
+     | 1683911847609 Wrote [198] bytes to the client
+     | 1683911847609 (W)
+     | 1683911847609 Writing back bytes
+     | 1683911847609 Wrote [339] bytes to the client
+     | 1683911847609 (W)
+     | 1683911847609 Writing back bytes
+     | 1683911847609 Wrote [5] bytes to the client
+     | 1683911847609 (W)
+     | 1683911847609 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847609 (WKA)
+     | 1683911847610 Read [336] bytes from client
+     | 1683911847610 (R)
+     | 1683911847610 (RP)
+     | 1683911847610 Preamble successfully parsed
+     | 1683911847610 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847610 (RWo)
+     | 1683911847610 (RC)
+     | 1683911847613 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847613 Preamble is [198] bytes long
+     | 1683911847613 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847613 Still writing preamble
+     | 1683911847613 Wrote [198] bytes to the client
+     | 1683911847613 (W)
+     | 1683911847613 Writing back bytes
+     | 1683911847614 Wrote [428] bytes to the client
+     | 1683911847614 (W)
+     | 1683911847614 Writing back bytes
+     | 1683911847614 Wrote [5] bytes to the client
+     | 1683911847614 (W)
+     | 1683911847614 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847614 (WKA)
+     | 1683911847614 Read [336] bytes from client
+     | 1683911847614 (R)
+     | 1683911847614 (RP)
+     | 1683911847614 Preamble successfully parsed
+     | 1683911847614 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847614 (RWo)
+     | 1683911847614 (RC)
+     | 1683911847621 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847621 Preamble is [198] bytes long
+     | 1683911847621 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847621 Still writing preamble
+     | 1683911847622 Wrote [198] bytes to the client
+     | 1683911847622 (W)
+     | 1683911847622 Writing back bytes
+     | 1683911847622 Wrote [517] bytes to the client
+     | 1683911847622 (W)
+     | 1683911847622 Writing back bytes
+     | 1683911847622 Wrote [5] bytes to the client
+     | 1683911847622 (W)
+     | 1683911847622 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847622 (WKA)
+     | 1683911847622 Read [336] bytes from client
+     | 1683911847622 (R)
+     | 1683911847622 (RP)
+     | 1683911847622 Preamble successfully parsed
+     | 1683911847622 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847622 (RWo)
+     | 1683911847622 (RC)
+     | 1683911847625 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847625 Preamble is [198] bytes long
+     | 1683911847625 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847625 Still writing preamble
+     | 1683911847625 Wrote [198] bytes to the client
+     | 1683911847625 (W)
+     | 1683911847625 Writing back bytes
+     | 1683911847625 Wrote [606] bytes to the client
+     | 1683911847625 (W)
+     | 1683911847625 Writing back bytes
+     | 1683911847625 Wrote [5] bytes to the client
+     | 1683911847625 (W)
+     | 1683911847625 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847625 (WKA)
+     | 1683911847626 Read [336] bytes from client
+     | 1683911847626 (R)
+     | 1683911847626 (RP)
+     | 1683911847626 Preamble successfully parsed
+     | 1683911847626 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847626 (RWo)
+     | 1683911847626 (RC)
+     | 1683911847629 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847629 Preamble is [198] bytes long
+     | 1683911847629 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847629 Still writing preamble
+     | 1683911847629 Wrote [198] bytes to the client
+     | 1683911847629 (W)
+     | 1683911847629 Writing back bytes
+     | 1683911847629 Wrote [695] bytes to the client
+     | 1683911847629 (W)
+     | 1683911847629 Writing back bytes
+     | 1683911847629 Wrote [5] bytes to the client
+     | 1683911847629 (W)
+     | 1683911847629 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847629 (WKA)
+     | 1683911847629 Read [336] bytes from client
+     | 1683911847629 (R)
+     | 1683911847629 (RP)
+     | 1683911847629 Preamble successfully parsed
+     | 1683911847629 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847629 (RWo)
+     | 1683911847629 (RC)
+     | 1683911847632 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847632 Preamble is [198] bytes long
+     | 1683911847632 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847632 Still writing preamble
+     | 1683911847632 Wrote [198] bytes to the client
+     | 1683911847632 (W)
+     | 1683911847632 Writing back bytes
+     | 1683911847632 Wrote [784] bytes to the client
+     | 1683911847632 (W)
+     | 1683911847632 Writing back bytes
+     | 1683911847632 Wrote [5] bytes to the client
+     | 1683911847632 (W)
+     | 1683911847632 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847632 (WKA)
+     | 1683911847633 Read [336] bytes from client
+     | 1683911847633 (R)
+     | 1683911847633 (RP)
+     | 1683911847633 Preamble successfully parsed
+     | 1683911847633 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847633 (RWo)
+     | 1683911847633 (RC)
+     | 1683911847635 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847635 Preamble is [198] bytes long
+     | 1683911847635 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847635 Still writing preamble
+     | 1683911847635 Wrote [198] bytes to the client
+     | 1683911847635 (W)
+     | 1683911847635 Writing back bytes
+     | 1683911847635 Wrote [873] bytes to the client
+     | 1683911847635 (W)
+     | 1683911847635 Writing back bytes
+     | 1683911847635 Wrote [5] bytes to the client
+     | 1683911847635 (W)
+     | 1683911847635 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847635 (WKA)
+     | 1683911847636 Read [336] bytes from client
+     | 1683911847636 (R)
+     | 1683911847636 (RP)
+     | 1683911847636 Preamble successfully parsed
+     | 1683911847636 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847636 (RWo)
+     | 1683911847636 (RC)
+     | 1683911847638 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847638 Preamble is [198] bytes long
+     | 1683911847638 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847638 Still writing preamble
+     | 1683911847638 Wrote [198] bytes to the client
+     | 1683911847638 (W)
+     | 1683911847638 Writing back bytes
+     | 1683911847638 Wrote [962] bytes to the client
+     | 1683911847638 (W)
+     | 1683911847638 Writing back bytes
+     | 1683911847638 Wrote [5] bytes to the client
+     | 1683911847638 (W)
+     | 1683911847638 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847638 (WKA)
+     | 1683911847639 Read [336] bytes from client
+     | 1683911847639 (R)
+     | 1683911847639 (RP)
+     | 1683911847639 Preamble successfully parsed
+     | 1683911847639 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847639 (RWo)
+     | 1683911847639 (RC)
+     | 1683911847641 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847641 Preamble is [198] bytes long
+     | 1683911847641 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847641 Still writing preamble
+     | 1683911847641 Wrote [198] bytes to the client
+     | 1683911847641 (W)
+     | 1683911847641 Writing back bytes
+     | 1683911847641 Wrote [1056] bytes to the client
+     | 1683911847641 (W)
+     | 1683911847641 Writing back bytes
+     | 1683911847641 Wrote [5] bytes to the client
+     | 1683911847641 (W)
+     | 1683911847641 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847641 (WKA)
+     | 1683911847642 Read [336] bytes from client
+     | 1683911847642 (R)
+     | 1683911847642 (RP)
+     | 1683911847642 Preamble successfully parsed
+     | 1683911847642 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847642 (RWo)
+     | 1683911847642 (RC)
+     | 1683911847644 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847644 Preamble is [198] bytes long
+     | 1683911847645 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847645 Still writing preamble
+     | 1683911847645 Wrote [198] bytes to the client
+     | 1683911847645 (W)
+     | 1683911847645 Writing back bytes
+     | 1683911847645 Wrote [1150] bytes to the client
+     | 1683911847645 (W)
+     | 1683911847645 Writing back bytes
+     | 1683911847645 Wrote [5] bytes to the client
+     | 1683911847645 (W)
+     | 1683911847645 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847645 (WKA)
+     | 1683911847645 Read [336] bytes from client
+     | 1683911847645 (R)
+     | 1683911847645 (RP)
+     | 1683911847645 Preamble successfully parsed
+     | 1683911847645 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847645 (RWo)
+     | 1683911847645 (RC)
+     | 1683911847647 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847647 Preamble is [198] bytes long
+     | 1683911847647 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847647 Still writing preamble
+     | 1683911847647 Wrote [198] bytes to the client
+     | 1683911847647 (W)
+     | 1683911847647 Writing back bytes
+     | 1683911847647 Wrote [1244] bytes to the client
+     | 1683911847647 (W)
+     | 1683911847647 Writing back bytes
+     | 1683911847647 Wrote [5] bytes to the client
+     | 1683911847647 (W)
+     | 1683911847647 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847647 (WKA)
+     | 1683911847648 Read [336] bytes from client
+     | 1683911847648 (R)
+     | 1683911847648 (RP)
+     | 1683911847648 Preamble successfully parsed
+     | 1683911847648 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847648 (RWo)
+     | 1683911847648 (RC)
+     | 1683911847650 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847650 Preamble is [198] bytes long
+     | 1683911847650 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847650 Still writing preamble
+     | 1683911847650 Wrote [198] bytes to the client
+     | 1683911847650 (W)
+     | 1683911847650 Writing back bytes
+     | 1683911847650 Wrote [1338] bytes to the client
+     | 1683911847650 (W)
+     | 1683911847650 Writing back bytes
+     | 1683911847650 Wrote [5] bytes to the client
+     | 1683911847650 (W)
+     | 1683911847650 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847650 (WKA)
+     | 1683911847651 Read [336] bytes from client
+     | 1683911847651 (R)
+     | 1683911847651 (RP)
+     | 1683911847651 Preamble successfully parsed
+     | 1683911847651 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847651 (RWo)
+     | 1683911847651 (RC)
+     | 1683911847653 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847653 Preamble is [198] bytes long
+     | 1683911847653 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847653 Still writing preamble
+     | 1683911847653 Wrote [198] bytes to the client
+     | 1683911847653 (W)
+     | 1683911847653 Writing back bytes
+     | 1683911847653 Wrote [1432] bytes to the client
+     | 1683911847653 (W)
+     | 1683911847653 Writing back bytes
+     | 1683911847653 Wrote [5] bytes to the client
+     | 1683911847653 (W)
+     | 1683911847653 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847653 (WKA)
+     | 1683911847653 Read [336] bytes from client
+     | 1683911847653 (R)
+     | 1683911847653 (RP)
+     | 1683911847654 Preamble successfully parsed
+     | 1683911847654 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847654 (RWo)
+     | 1683911847654 (RC)
+     | 1683911847656 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847656 Preamble is [198] bytes long
+     | 1683911847656 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847656 Still writing preamble
+     | 1683911847656 Wrote [198] bytes to the client
+     | 1683911847656 (W)
+     | 1683911847656 Writing back bytes
+     | 1683911847656 Wrote [1526] bytes to the client
+     | 1683911847656 (W)
+     | 1683911847656 Writing back bytes
+     | 1683911847656 Wrote [5] bytes to the client
+     | 1683911847656 (W)
+     | 1683911847656 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847656 (WKA)
+     | 1683911847658 Read [336] bytes from client
+     | 1683911847658 (R)
+     | 1683911847658 (RP)
+     | 1683911847658 Preamble successfully parsed
+     | 1683911847658 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847658 (RWo)
+     | 1683911847659 (RC)
+     | 1683911847661 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847661 Preamble is [198] bytes long
+     | 1683911847661 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847661 Still writing preamble
+     | 1683911847661 Wrote [198] bytes to the client
+     | 1683911847661 (W)
+     | 1683911847661 Writing back bytes
+     | 1683911847661 Wrote [1620] bytes to the client
+     | 1683911847661 (W)
+     | 1683911847661 Writing back bytes
+     | 1683911847661 Wrote [5] bytes to the client
+     | 1683911847661 (W)
+     | 1683911847661 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847661 (WKA)
+     | 1683911847661 Read [336] bytes from client
+     | 1683911847661 (R)
+     | 1683911847661 (RP)
+     | 1683911847662 Preamble successfully parsed
+     | 1683911847662 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847662 (RWo)
+     | 1683911847662 (RC)
+     | 1683911847664 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847664 Preamble is [198] bytes long
+     | 1683911847664 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847664 Still writing preamble
+     | 1683911847664 Wrote [198] bytes to the client
+     | 1683911847664 (W)
+     | 1683911847664 Writing back bytes
+     | 1683911847664 Wrote [1714] bytes to the client
+     | 1683911847664 (W)
+     | 1683911847664 Writing back bytes
+     | 1683911847664 Wrote [5] bytes to the client
+     | 1683911847664 (W)
+     | 1683911847664 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847664 (WKA)
+     | 1683911847664 Read [336] bytes from client
+     | 1683911847664 (R)
+     | 1683911847664 (RP)
+     | 1683911847664 Preamble successfully parsed
+     | 1683911847664 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847664 (RWo)
+     | 1683911847664 (RC)
+     | 1683911847671 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847671 Preamble is [198] bytes long
+     | 1683911847671 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847671 Still writing preamble
+     | 1683911847671 Wrote [198] bytes to the client
+     | 1683911847671 (W)
+     | 1683911847671 Writing back bytes
+     | 1683911847671 Wrote [1808] bytes to the client
+     | 1683911847671 (W)
+     | 1683911847671 Writing back bytes
+     | 1683911847671 Wrote [5] bytes to the client
+     | 1683911847671 (W)
+     | 1683911847671 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847671 (WKA)
+     | 1683911847671 Read [336] bytes from client
+     | 1683911847671 (R)
+     | 1683911847671 (RP)
+     | 1683911847672 Preamble successfully parsed
+     | 1683911847672 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847672 (RWo)
+     | 1683911847672 (RC)
+     | 1683911847674 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847674 Preamble is [198] bytes long
+     | 1683911847674 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847674 Still writing preamble
+     | 1683911847674 Wrote [198] bytes to the client
+     | 1683911847674 (W)
+     | 1683911847674 Writing back bytes
+     | 1683911847674 Wrote [1902] bytes to the client
+     | 1683911847674 (W)
+     | 1683911847674 Writing back bytes
+     | 1683911847674 Wrote [5] bytes to the client
+     | 1683911847674 (W)
+     | 1683911847674 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847674 (WKA)
+     | 1683911847674 Read [336] bytes from client
+     | 1683911847674 (R)
+     | 1683911847674 (RP)
+     | 1683911847674 Preamble successfully parsed
+     | 1683911847674 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847674 (RWo)
+     | 1683911847674 (RC)
+     | 1683911847676 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847676 Preamble is [198] bytes long
+     | 1683911847676 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847676 Still writing preamble
+     | 1683911847676 Wrote [198] bytes to the client
+     | 1683911847676 (W)
+     | 1683911847676 Writing back bytes
+     | 1683911847676 Wrote [1996] bytes to the client
+     | 1683911847676 (W)
+     | 1683911847676 Writing back bytes
+     | 1683911847676 Wrote [5] bytes to the client
+     | 1683911847676 (W)
+     | 1683911847676 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847676 (WKA)
+     | 1683911847677 Read [336] bytes from client
+     | 1683911847677 (R)
+     | 1683911847677 (RP)
+     | 1683911847677 Preamble successfully parsed
+     | 1683911847677 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847677 (RWo)
+     | 1683911847677 (RC)
+     | 1683911847679 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847679 Preamble is [198] bytes long
+     | 1683911847679 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847679 Still writing preamble
+     | 1683911847679 Wrote [198] bytes to the client
+     | 1683911847679 (W)
+     | 1683911847679 Writing back bytes
+     | 1683911847679 Wrote [2090] bytes to the client
+     | 1683911847679 (W)
+     | 1683911847679 Writing back bytes
+     | 1683911847679 Wrote [5] bytes to the client
+     | 1683911847679 (W)
+     | 1683911847679 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847679 (WKA)
+     | 1683911847680 Read [336] bytes from client
+     | 1683911847680 (R)
+     | 1683911847680 (RP)
+     | 1683911847680 Preamble successfully parsed
+     | 1683911847680 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847680 (RWo)
+     | 1683911847680 (RC)
+     | 1683911847682 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847682 Preamble is [198] bytes long
+     | 1683911847682 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847682 Still writing preamble
+     | 1683911847682 Wrote [198] bytes to the client
+     | 1683911847682 (W)
+     | 1683911847682 Writing back bytes
+     | 1683911847682 Wrote [2184] bytes to the client
+     | 1683911847682 (W)
+     | 1683911847682 Writing back bytes
+     | 1683911847682 Wrote [5] bytes to the client
+     | 1683911847682 (W)
+     | 1683911847682 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847682 (WKA)
+     | 1683911847682 Read [336] bytes from client
+     | 1683911847682 (R)
+     | 1683911847682 (RP)
+     | 1683911847682 Preamble successfully parsed
+     | 1683911847682 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847682 (RWo)
+     | 1683911847682 (RC)
+     | 1683911847684 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847684 Preamble is [198] bytes long
+     | 1683911847684 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847684 Still writing preamble
+     | 1683911847684 Wrote [198] bytes to the client
+     | 1683911847684 (W)
+     | 1683911847684 Writing back bytes
+     | 1683911847684 Wrote [2278] bytes to the client
+     | 1683911847684 (W)
+     | 1683911847684 Writing back bytes
+     | 1683911847684 Wrote [5] bytes to the client
+     | 1683911847684 (W)
+     | 1683911847684 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847684 (WKA)
+     | 1683911847685 Read [336] bytes from client
+     | 1683911847685 (R)
+     | 1683911847685 (RP)
+     | 1683911847685 Preamble successfully parsed
+     | 1683911847685 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847685 (RWo)
+     | 1683911847685 (RC)
+     | 1683911847687 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847687 Preamble is [198] bytes long
+     | 1683911847687 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847687 Still writing preamble
+     | 1683911847687 Wrote [198] bytes to the client
+     | 1683911847687 (W)
+     | 1683911847687 Writing back bytes
+     | 1683911847687 Wrote [2372] bytes to the client
+     | 1683911847687 (W)
+     | 1683911847687 Writing back bytes
+     | 1683911847687 Wrote [5] bytes to the client
+     | 1683911847687 (W)
+     | 1683911847687 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847687 (WKA)
+     | 1683911847688 Read [336] bytes from client
+     | 1683911847688 (R)
+     | 1683911847688 (RP)
+     | 1683911847688 Preamble successfully parsed
+     | 1683911847688 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847688 (RWo)
+     | 1683911847688 (RC)
+     | 1683911847690 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847690 Preamble is [198] bytes long
+     | 1683911847690 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847690 Still writing preamble
+     | 1683911847690 Wrote [198] bytes to the client
+     | 1683911847690 (W)
+     | 1683911847690 Writing back bytes
+     | 1683911847690 Wrote [2466] bytes to the client
+     | 1683911847690 (W)
+     | 1683911847690 Writing back bytes
+     | 1683911847690 Wrote [5] bytes to the client
+     | 1683911847690 (W)
+     | 1683911847690 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847690 (WKA)
+     | 1683911847690 Read [336] bytes from client
+     | 1683911847690 (R)
+     | 1683911847690 (RP)
+     | 1683911847690 Preamble successfully parsed
+     | 1683911847690 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847690 (RWo)
+     | 1683911847690 (RC)
+     | 1683911847692 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847692 Preamble is [198] bytes long
+     | 1683911847692 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847692 Still writing preamble
+     | 1683911847692 Wrote [198] bytes to the client
+     | 1683911847692 (W)
+     | 1683911847692 Writing back bytes
+     | 1683911847692 Wrote [2560] bytes to the client
+     | 1683911847692 (W)
+     | 1683911847692 Writing back bytes
+     | 1683911847692 Wrote [5] bytes to the client
+     | 1683911847692 (W)
+     | 1683911847692 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847692 (WKA)
+     | 1683911847693 Read [336] bytes from client
+     | 1683911847693 (R)
+     | 1683911847693 (RP)
+     | 1683911847693 Preamble successfully parsed
+     | 1683911847693 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847693 (RWo)
+     | 1683911847693 (RC)
+     | 1683911847696 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847696 Preamble is [198] bytes long
+     | 1683911847696 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847696 Still writing preamble
+     | 1683911847696 Wrote [198] bytes to the client
+     | 1683911847696 (W)
+     | 1683911847696 Writing back bytes
+     | 1683911847696 Wrote [2654] bytes to the client
+     | 1683911847696 (W)
+     | 1683911847696 Writing back bytes
+     | 1683911847696 Wrote [5] bytes to the client
+     | 1683911847696 (W)
+     | 1683911847696 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847696 (WKA)
+     | 1683911847696 Read [336] bytes from client
+     | 1683911847696 (R)
+     | 1683911847696 (RP)
+     | 1683911847696 Preamble successfully parsed
+     | 1683911847696 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847696 (RWo)
+     | 1683911847696 (RC)
+     | 1683911847698 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847698 Preamble is [198] bytes long
+     | 1683911847698 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847698 Still writing preamble
+     | 1683911847698 Wrote [198] bytes to the client
+     | 1683911847698 (W)
+     | 1683911847698 Writing back bytes
+     | 1683911847698 Wrote [2748] bytes to the client
+     | 1683911847698 (W)
+     | 1683911847698 Writing back bytes
+     | 1683911847698 Wrote [5] bytes to the client
+     | 1683911847698 (W)
+     | 1683911847698 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847698 (WKA)
+     | 1683911847699 Read [336] bytes from client
+     | 1683911847699 (R)
+     | 1683911847699 (RP)
+     | 1683911847699 Preamble successfully parsed
+     | 1683911847699 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847699 (RWo)
+     | 1683911847699 (RC)
+     | 1683911847701 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847701 Preamble is [198] bytes long
+     | 1683911847701 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847701 Still writing preamble
+     | 1683911847701 Wrote [198] bytes to the client
+     | 1683911847701 (W)
+     | 1683911847701 Writing back bytes
+     | 1683911847701 Wrote [2842] bytes to the client
+     | 1683911847701 (W)
+     | 1683911847701 Writing back bytes
+     | 1683911847701 Wrote [5] bytes to the client
+     | 1683911847701 (W)
+     | 1683911847701 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847701 (WKA)
+     | 1683911847701 Read [336] bytes from client
+     | 1683911847701 (R)
+     | 1683911847701 (RP)
+     | 1683911847701 Preamble successfully parsed
+     | 1683911847701 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847701 (RWo)
+     | 1683911847701 (RC)
+     | 1683911847703 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847703 Preamble is [198] bytes long
+     | 1683911847703 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847703 Still writing preamble
+     | 1683911847703 Wrote [198] bytes to the client
+     | 1683911847703 (W)
+     | 1683911847703 Writing back bytes
+     | 1683911847703 Wrote [2936] bytes to the client
+     | 1683911847703 (W)
+     | 1683911847703 Writing back bytes
+     | 1683911847703 Wrote [5] bytes to the client
+     | 1683911847703 (W)
+     | 1683911847703 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847703 (WKA)
+     | 1683911847704 Read [336] bytes from client
+     | 1683911847704 (R)
+     | 1683911847704 (RP)
+     | 1683911847704 Preamble successfully parsed
+     | 1683911847704 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847704 (RWo)
+     | 1683911847704 (RC)
+     | 1683911847706 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847706 Preamble is [198] bytes long
+     | 1683911847706 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847706 Still writing preamble
+     | 1683911847706 Wrote [198] bytes to the client
+     | 1683911847706 (W)
+     | 1683911847706 Writing back bytes
+     | 1683911847706 Wrote [3030] bytes to the client
+     | 1683911847706 (W)
+     | 1683911847706 Writing back bytes
+     | 1683911847706 Wrote [5] bytes to the client
+     | 1683911847706 (W)
+     | 1683911847706 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847706 (WKA)
+     | 1683911847706 Read [336] bytes from client
+     | 1683911847706 (R)
+     | 1683911847706 (RP)
+     | 1683911847706 Preamble successfully parsed
+     | 1683911847706 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847706 (RWo)
+     | 1683911847707 (RC)
+     | 1683911847708 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847708 Preamble is [198] bytes long
+     | 1683911847708 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847708 Still writing preamble
+     | 1683911847708 Wrote [198] bytes to the client
+     | 1683911847708 (W)
+     | 1683911847708 Writing back bytes
+     | 1683911847708 Wrote [3124] bytes to the client
+     | 1683911847708 (W)
+     | 1683911847708 Writing back bytes
+     | 1683911847708 Wrote [5] bytes to the client
+     | 1683911847708 (W)
+     | 1683911847708 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847708 (WKA)
+     | 1683911847709 Read [336] bytes from client
+     | 1683911847709 (R)
+     | 1683911847709 (RP)
+     | 1683911847709 Preamble successfully parsed
+     | 1683911847709 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847709 (RWo)
+     | 1683911847709 (RC)
+     | 1683911847711 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847711 Preamble is [198] bytes long
+     | 1683911847711 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847711 Still writing preamble
+     | 1683911847711 Wrote [198] bytes to the client
+     | 1683911847711 (W)
+     | 1683911847711 Writing back bytes
+     | 1683911847711 Wrote [3218] bytes to the client
+     | 1683911847711 (W)
+     | 1683911847711 Writing back bytes
+     | 1683911847711 Wrote [5] bytes to the client
+     | 1683911847711 (W)
+     | 1683911847711 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847711 (WKA)
+     | 1683911847711 Read [336] bytes from client
+     | 1683911847711 (R)
+     | 1683911847711 (RP)
+     | 1683911847711 Preamble successfully parsed
+     | 1683911847711 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847711 (RWo)
+     | 1683911847712 (RC)
+     | 1683911847713 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847713 Preamble is [198] bytes long
+     | 1683911847713 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847713 Still writing preamble
+     | 1683911847713 Wrote [198] bytes to the client
+     | 1683911847713 (W)
+     | 1683911847713 Writing back bytes
+     | 1683911847713 Wrote [3312] bytes to the client
+     | 1683911847713 (W)
+     | 1683911847713 Writing back bytes
+     | 1683911847713 Wrote [5] bytes to the client
+     | 1683911847713 (W)
+     | 1683911847713 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847713 (WKA)
+     | 1683911847714 Read [336] bytes from client
+     | 1683911847714 (R)
+     | 1683911847714 (RP)
+     | 1683911847714 Preamble successfully parsed
+     | 1683911847714 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847714 (RWo)
+     | 1683911847714 (RC)
+     | 1683911847716 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847716 Preamble is [198] bytes long
+     | 1683911847716 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847716 Still writing preamble
+     | 1683911847716 Wrote [198] bytes to the client
+     | 1683911847716 (W)
+     | 1683911847716 Writing back bytes
+     | 1683911847716 Wrote [3406] bytes to the client
+     | 1683911847716 (W)
+     | 1683911847716 Writing back bytes
+     | 1683911847716 Wrote [5] bytes to the client
+     | 1683911847716 (W)
+     | 1683911847716 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847716 (WKA)
+     | 1683911847717 Read [336] bytes from client
+     | 1683911847717 (R)
+     | 1683911847717 (RP)
+     | 1683911847717 Preamble successfully parsed
+     | 1683911847717 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847717 (RWo)
+     | 1683911847717 (RC)
+     | 1683911847719 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847719 Preamble is [198] bytes long
+     | 1683911847719 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847719 Still writing preamble
+     | 1683911847719 Wrote [198] bytes to the client
+     | 1683911847719 (W)
+     | 1683911847719 Writing back bytes
+     | 1683911847719 Wrote [3500] bytes to the client
+     | 1683911847719 (W)
+     | 1683911847719 Writing back bytes
+     | 1683911847719 Wrote [5] bytes to the client
+     | 1683911847719 (W)
+     | 1683911847719 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847719 (WKA)
+     | 1683911847720 Read [336] bytes from client
+     | 1683911847720 (R)
+     | 1683911847720 (RP)
+     | 1683911847720 Preamble successfully parsed
+     | 1683911847720 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847720 (RWo)
+     | 1683911847720 (RC)
+     | 1683911847722 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847722 Preamble is [198] bytes long
+     | 1683911847722 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847722 Still writing preamble
+     | 1683911847722 Wrote [198] bytes to the client
+     | 1683911847722 (W)
+     | 1683911847722 Writing back bytes
+     | 1683911847722 Wrote [3594] bytes to the client
+     | 1683911847722 (W)
+     | 1683911847722 Writing back bytes
+     | 1683911847722 Wrote [5] bytes to the client
+     | 1683911847722 (W)
+     | 1683911847722 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847722 (WKA)
+     | 1683911847722 Read [336] bytes from client
+     | 1683911847722 (R)
+     | 1683911847722 (RP)
+     | 1683911847722 Preamble successfully parsed
+     | 1683911847722 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847722 (RWo)
+     | 1683911847722 (RC)
+     | 1683911847724 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847724 Preamble is [198] bytes long
+     | 1683911847724 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847724 Still writing preamble
+     | 1683911847724 Wrote [198] bytes to the client
+     | 1683911847724 (W)
+     | 1683911847724 Writing back bytes
+     | 1683911847724 Wrote [3688] bytes to the client
+     | 1683911847724 (W)
+     | 1683911847724 Writing back bytes
+     | 1683911847724 Wrote [5] bytes to the client
+     | 1683911847724 (W)
+     | 1683911847724 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847724 (WKA)
+     | 1683911847725 Read [336] bytes from client
+     | 1683911847725 (R)
+     | 1683911847725 (RP)
+     | 1683911847725 Preamble successfully parsed
+     | 1683911847725 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847725 (RWo)
+     | 1683911847725 (RC)
+     | 1683911847726 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847726 Preamble is [198] bytes long
+     | 1683911847726 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847726 Still writing preamble
+     | 1683911847726 Wrote [198] bytes to the client
+     | 1683911847727 (W)
+     | 1683911847727 Writing back bytes
+     | 1683911847727 Wrote [3782] bytes to the client
+     | 1683911847727 (W)
+     | 1683911847727 Writing back bytes
+     | 1683911847727 Wrote [5] bytes to the client
+     | 1683911847727 (W)
+     | 1683911847727 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847727 (WKA)
+     | 1683911847727 Read [336] bytes from client
+     | 1683911847727 (R)
+     | 1683911847727 (RP)
+     | 1683911847727 Preamble successfully parsed
+     | 1683911847727 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847727 (RWo)
+     | 1683911847727 (RC)
+     | 1683911847729 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847729 Preamble is [198] bytes long
+     | 1683911847729 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847729 Still writing preamble
+     | 1683911847729 Wrote [198] bytes to the client
+     | 1683911847729 (W)
+     | 1683911847729 Writing back bytes
+     | 1683911847729 Wrote [3876] bytes to the client
+     | 1683911847729 (W)
+     | 1683911847729 Writing back bytes
+     | 1683911847729 Wrote [5] bytes to the client
+     | 1683911847729 (W)
+     | 1683911847729 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847729 (WKA)
+     | 1683911847729 Read [336] bytes from client
+     | 1683911847729 (R)
+     | 1683911847729 (RP)
+     | 1683911847729 Preamble successfully parsed
+     | 1683911847729 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847729 (RWo)
+     | 1683911847730 (RC)
+     | 1683911847731 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847731 Preamble is [198] bytes long
+     | 1683911847731 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847731 Still writing preamble
+     | 1683911847731 Wrote [198] bytes to the client
+     | 1683911847731 (W)
+     | 1683911847731 Writing back bytes
+     | 1683911847731 Wrote [3970] bytes to the client
+     | 1683911847731 (W)
+     | 1683911847731 Writing back bytes
+     | 1683911847731 Wrote [5] bytes to the client
+     | 1683911847731 (W)
+     | 1683911847731 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847731 (WKA)
+     | 1683911847732 Read [336] bytes from client
+     | 1683911847732 (R)
+     | 1683911847732 (RP)
+     | 1683911847732 Preamble successfully parsed
+     | 1683911847732 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847732 (RWo)
+     | 1683911847732 (RC)
+     | 1683911847733 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847733 Preamble is [198] bytes long
+     | 1683911847733 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847733 Still writing preamble
+     | 1683911847733 Wrote [198] bytes to the client
+     | 1683911847733 (W)
+     | 1683911847733 Writing back bytes
+     | 1683911847733 Wrote [4064] bytes to the client
+     | 1683911847733 (W)
+     | 1683911847733 Writing back bytes
+     | 1683911847733 Wrote [5] bytes to the client
+     | 1683911847733 (W)
+     | 1683911847733 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847733 (WKA)
+     | 1683911847734 Read [336] bytes from client
+     | 1683911847734 (R)
+     | 1683911847734 (RP)
+     | 1683911847734 Preamble successfully parsed
+     | 1683911847734 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847734 (RWo)
+     | 1683911847734 (RC)
+     | 1683911847736 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847736 Preamble is [198] bytes long
+     | 1683911847736 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847736 Still writing preamble
+     | 1683911847736 Wrote [198] bytes to the client
+     | 1683911847736 (W)
+     | 1683911847736 Writing back bytes
+     | 1683911847736 Wrote [4159] bytes to the client
+     | 1683911847736 (W)
+     | 1683911847736 Writing back bytes
+     | 1683911847736 Wrote [5] bytes to the client
+     | 1683911847736 (W)
+     | 1683911847736 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847736 (WKA)
+     | 1683911847736 Read [336] bytes from client
+     | 1683911847736 (R)
+     | 1683911847736 (RP)
+     | 1683911847736 Preamble successfully parsed
+     | 1683911847736 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847736 (RWo)
+     | 1683911847736 (RC)
+     | 1683911847738 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847738 Preamble is [198] bytes long
+     | 1683911847738 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847738 Still writing preamble
+     | 1683911847738 Wrote [198] bytes to the client
+     | 1683911847738 (W)
+     | 1683911847738 Writing back bytes
+     | 1683911847738 Wrote [4253] bytes to the client
+     | 1683911847738 (W)
+     | 1683911847738 Writing back bytes
+     | 1683911847738 Wrote [5] bytes to the client
+     | 1683911847738 (W)
+     | 1683911847738 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847738 (WKA)
+     | 1683911847739 Read [336] bytes from client
+     | 1683911847739 (R)
+     | 1683911847739 (RP)
+     | 1683911847739 Preamble successfully parsed
+     | 1683911847739 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847739 (RWo)
+     | 1683911847739 (RC)
+     | 1683911847741 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847741 Preamble is [198] bytes long
+     | 1683911847741 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847741 Still writing preamble
+     | 1683911847741 Wrote [198] bytes to the client
+     | 1683911847741 (W)
+     | 1683911847741 Writing back bytes
+     | 1683911847741 Wrote [4347] bytes to the client
+     | 1683911847741 (W)
+     | 1683911847741 Writing back bytes
+     | 1683911847741 Wrote [5] bytes to the client
+     | 1683911847741 (W)
+     | 1683911847741 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847741 (WKA)
+     | 1683911847741 Read [336] bytes from client
+     | 1683911847741 (R)
+     | 1683911847741 (RP)
+     | 1683911847741 Preamble successfully parsed
+     | 1683911847741 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847741 (RWo)
+     | 1683911847741 (RC)
+     | 1683911847743 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847743 Preamble is [198] bytes long
+     | 1683911847743 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847743 Still writing preamble
+     | 1683911847743 Wrote [198] bytes to the client
+     | 1683911847743 (W)
+     | 1683911847743 Writing back bytes
+     | 1683911847743 Wrote [4441] bytes to the client
+     | 1683911847743 (W)
+     | 1683911847743 Writing back bytes
+     | 1683911847743 Wrote [5] bytes to the client
+     | 1683911847743 (W)
+     | 1683911847743 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847743 (WKA)
+     | 1683911847744 Read [336] bytes from client
+     | 1683911847744 (R)
+     | 1683911847744 (RP)
+     | 1683911847744 Preamble successfully parsed
+     | 1683911847744 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847744 (RWo)
+     | 1683911847744 (RC)
+     | 1683911847746 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847746 Preamble is [198] bytes long
+     | 1683911847746 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847746 Still writing preamble
+     | 1683911847746 Wrote [198] bytes to the client
+     | 1683911847746 (W)
+     | 1683911847746 Writing back bytes
+     | 1683911847746 Wrote [4535] bytes to the client
+     | 1683911847746 (W)
+     | 1683911847746 Writing back bytes
+     | 1683911847746 Wrote [5] bytes to the client
+     | 1683911847746 (W)
+     | 1683911847746 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847746 (WKA)
+     | 1683911847746 Read [336] bytes from client
+     | 1683911847746 (R)
+     | 1683911847746 (RP)
+     | 1683911847746 Preamble successfully parsed
+     | 1683911847746 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847746 (RWo)
+     | 1683911847746 (RC)
+     | 1683911847748 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847748 Preamble is [198] bytes long
+     | 1683911847748 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847748 Still writing preamble
+     | 1683911847748 Wrote [198] bytes to the client
+     | 1683911847748 (W)
+     | 1683911847748 Writing back bytes
+     | 1683911847748 Wrote [4629] bytes to the client
+     | 1683911847748 (W)
+     | 1683911847748 Writing back bytes
+     | 1683911847748 Wrote [5] bytes to the client
+     | 1683911847748 (W)
+     | 1683911847748 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847748 (WKA)
+     | 1683911847749 Read [336] bytes from client
+     | 1683911847749 (R)
+     | 1683911847749 (RP)
+     | 1683911847749 Preamble successfully parsed
+     | 1683911847749 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847749 (RWo)
+     | 1683911847749 (RC)
+     | 1683911847751 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847751 Preamble is [198] bytes long
+     | 1683911847751 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847751 Still writing preamble
+     | 1683911847751 Wrote [198] bytes to the client
+     | 1683911847751 (W)
+     | 1683911847751 Writing back bytes
+     | 1683911847751 Wrote [4723] bytes to the client
+     | 1683911847751 (W)
+     | 1683911847751 Writing back bytes
+     | 1683911847751 Wrote [5] bytes to the client
+     | 1683911847751 (W)
+     | 1683911847751 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847751 (WKA)
+     | 1683911847751 Read [336] bytes from client
+     | 1683911847751 (R)
+     | 1683911847751 (RP)
+     | 1683911847751 Preamble successfully parsed
+     | 1683911847751 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847751 (RWo)
+     | 1683911847751 (RC)
+     | 1683911847753 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847753 Preamble is [198] bytes long
+     | 1683911847753 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847753 Still writing preamble
+     | 1683911847753 Wrote [198] bytes to the client
+     | 1683911847753 (W)
+     | 1683911847753 Writing back bytes
+     | 1683911847753 Wrote [4817] bytes to the client
+     | 1683911847753 (W)
+     | 1683911847753 Writing back bytes
+     | 1683911847753 Wrote [5] bytes to the client
+     | 1683911847753 (W)
+     | 1683911847753 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847753 (WKA)
+     | 1683911847753 Read [336] bytes from client
+     | 1683911847753 (R)
+     | 1683911847753 (RP)
+     | 1683911847754 Preamble successfully parsed
+     | 1683911847754 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847754 (RWo)
+     | 1683911847754 (RC)
+     | 1683911847755 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847755 Preamble is [198] bytes long
+     | 1683911847755 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847755 Still writing preamble
+     | 1683911847755 Wrote [198] bytes to the client
+     | 1683911847755 (W)
+     | 1683911847755 Writing back bytes
+     | 1683911847755 Wrote [4911] bytes to the client
+     | 1683911847755 (W)
+     | 1683911847755 Writing back bytes
+     | 1683911847755 Wrote [5] bytes to the client
+     | 1683911847755 (W)
+     | 1683911847755 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847755 (WKA)
+     | 1683911847756 Read [336] bytes from client
+     | 1683911847756 (R)
+     | 1683911847756 (RP)
+     | 1683911847756 Preamble successfully parsed
+     | 1683911847756 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847756 (RWo)
+     | 1683911847756 (RC)
+     | 1683911847758 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847758 Preamble is [198] bytes long
+     | 1683911847758 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847758 Still writing preamble
+     | 1683911847758 Wrote [198] bytes to the client
+     | 1683911847758 (W)
+     | 1683911847758 Writing back bytes
+     | 1683911847758 Wrote [5005] bytes to the client
+     | 1683911847758 (W)
+     | 1683911847758 Writing back bytes
+     | 1683911847758 Wrote [5] bytes to the client
+     | 1683911847758 (W)
+     | 1683911847758 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847758 (WKA)
+     | 1683911847758 Read [336] bytes from client
+     | 1683911847758 (R)
+     | 1683911847758 (RP)
+     | 1683911847758 Preamble successfully parsed
+     | 1683911847758 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847758 (RWo)
+     | 1683911847758 (RC)
+     | 1683911847760 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847760 Preamble is [198] bytes long
+     | 1683911847760 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847760 Still writing preamble
+     | 1683911847760 Wrote [198] bytes to the client
+     | 1683911847760 (W)
+     | 1683911847760 Writing back bytes
+     | 1683911847760 Wrote [5099] bytes to the client
+     | 1683911847760 (W)
+     | 1683911847760 Writing back bytes
+     | 1683911847760 Wrote [5] bytes to the client
+     | 1683911847760 (W)
+     | 1683911847760 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847760 (WKA)
+     | 1683911847760 Read [336] bytes from client
+     | 1683911847760 (R)
+     | 1683911847760 (RP)
+     | 1683911847761 Preamble successfully parsed
+     | 1683911847761 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847761 (RWo)
+     | 1683911847761 (RC)
+     | 1683911847763 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847763 Preamble is [198] bytes long
+     | 1683911847763 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847763 Still writing preamble
+     | 1683911847763 Wrote [198] bytes to the client
+     | 1683911847763 (W)
+     | 1683911847763 Writing back bytes
+     | 1683911847763 Wrote [5193] bytes to the client
+     | 1683911847763 (W)
+     | 1683911847763 Writing back bytes
+     | 1683911847763 Wrote [5] bytes to the client
+     | 1683911847763 (W)
+     | 1683911847763 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847763 (WKA)
+     | 1683911847763 Read [336] bytes from client
+     | 1683911847763 (R)
+     | 1683911847763 (RP)
+     | 1683911847763 Preamble successfully parsed
+     | 1683911847763 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847763 (RWo)
+     | 1683911847763 (RC)
+     | 1683911847765 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847765 Preamble is [198] bytes long
+     | 1683911847765 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847765 Still writing preamble
+     | 1683911847765 Wrote [198] bytes to the client
+     | 1683911847765 (W)
+     | 1683911847765 Writing back bytes
+     | 1683911847765 Wrote [5287] bytes to the client
+     | 1683911847765 (W)
+     | 1683911847765 Writing back bytes
+     | 1683911847765 Wrote [5] bytes to the client
+     | 1683911847765 (W)
+     | 1683911847765 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847765 (WKA)
+     | 1683911847765 Read [336] bytes from client
+     | 1683911847765 (R)
+     | 1683911847765 (RP)
+     | 1683911847765 Preamble successfully parsed
+     | 1683911847765 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847765 (RWo)
+     | 1683911847765 (RC)
+     | 1683911847767 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847767 Preamble is [198] bytes long
+     | 1683911847767 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847767 Still writing preamble
+     | 1683911847767 Wrote [198] bytes to the client
+     | 1683911847767 (W)
+     | 1683911847767 Writing back bytes
+     | 1683911847767 Wrote [5381] bytes to the client
+     | 1683911847767 (W)
+     | 1683911847767 Writing back bytes
+     | 1683911847767 Wrote [5] bytes to the client
+     | 1683911847767 (W)
+     | 1683911847768 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847768 (WKA)
+     | 1683911847768 Read [336] bytes from client
+     | 1683911847768 (R)
+     | 1683911847768 (RP)
+     | 1683911847768 Preamble successfully parsed
+     | 1683911847768 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847768 (RWo)
+     | 1683911847768 (RC)
+     | 1683911847769 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847769 Preamble is [198] bytes long
+     | 1683911847769 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847769 Still writing preamble
+     | 1683911847769 Wrote [198] bytes to the client
+     | 1683911847769 (W)
+     | 1683911847769 Writing back bytes
+     | 1683911847769 Wrote [5475] bytes to the client
+     | 1683911847769 (W)
+     | 1683911847769 Writing back bytes
+     | 1683911847769 Wrote [5] bytes to the client
+     | 1683911847769 (W)
+     | 1683911847769 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847769 (WKA)
+     | 1683911847770 Read [336] bytes from client
+     | 1683911847770 (R)
+     | 1683911847770 (RP)
+     | 1683911847770 Preamble successfully parsed
+     | 1683911847770 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847770 (RWo)
+     | 1683911847770 (RC)
+     | 1683911847771 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847771 Preamble is [198] bytes long
+     | 1683911847771 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847771 Still writing preamble
+     | 1683911847771 Wrote [198] bytes to the client
+     | 1683911847771 (W)
+     | 1683911847771 Writing back bytes
+     | 1683911847771 Wrote [5569] bytes to the client
+     | 1683911847771 (W)
+     | 1683911847771 Writing back bytes
+     | 1683911847771 Wrote [5] bytes to the client
+     | 1683911847771 (W)
+     | 1683911847771 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847771 (WKA)
+     | 1683911847772 Read [336] bytes from client
+     | 1683911847772 (R)
+     | 1683911847772 (RP)
+     | 1683911847772 Preamble successfully parsed
+     | 1683911847772 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847772 (RWo)
+     | 1683911847772 (RC)
+     | 1683911847773 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847773 Preamble is [198] bytes long
+     | 1683911847773 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847773 Still writing preamble
+     | 1683911847773 Wrote [198] bytes to the client
+     | 1683911847773 (W)
+     | 1683911847773 Writing back bytes
+     | 1683911847773 Wrote [5663] bytes to the client
+     | 1683911847773 (W)
+     | 1683911847773 Writing back bytes
+     | 1683911847773 Wrote [5] bytes to the client
+     | 1683911847773 (W)
+     | 1683911847773 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847773 (WKA)
+     | 1683911847773 Read [336] bytes from client
+     | 1683911847773 (R)
+     | 1683911847773 (RP)
+     | 1683911847774 Preamble successfully parsed
+     | 1683911847774 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847774 (RWo)
+     | 1683911847774 (RC)
+     | 1683911847775 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847775 Preamble is [198] bytes long
+     | 1683911847775 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847775 Still writing preamble
+     | 1683911847775 Wrote [198] bytes to the client
+     | 1683911847775 (W)
+     | 1683911847775 Writing back bytes
+     | 1683911847775 Wrote [5757] bytes to the client
+     | 1683911847775 (W)
+     | 1683911847775 Writing back bytes
+     | 1683911847775 Wrote [5] bytes to the client
+     | 1683911847775 (W)
+     | 1683911847775 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847775 (WKA)
+     | 1683911847775 Read [336] bytes from client
+     | 1683911847775 (R)
+     | 1683911847775 (RP)
+     | 1683911847775 Preamble successfully parsed
+     | 1683911847775 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847775 (RWo)
+     | 1683911847775 (RC)
+     | 1683911847777 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847777 Preamble is [198] bytes long
+     | 1683911847777 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847777 Still writing preamble
+     | 1683911847777 Wrote [198] bytes to the client
+     | 1683911847777 (W)
+     | 1683911847777 Writing back bytes
+     | 1683911847777 Wrote [5851] bytes to the client
+     | 1683911847777 (W)
+     | 1683911847777 Writing back bytes
+     | 1683911847777 Wrote [5] bytes to the client
+     | 1683911847777 (W)
+     | 1683911847777 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847777 (WKA)
+     | 1683911847777 Read [336] bytes from client
+     | 1683911847777 (R)
+     | 1683911847777 (RP)
+     | 1683911847777 Preamble successfully parsed
+     | 1683911847777 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847777 (RWo)
+     | 1683911847777 (RC)
+     | 1683911847778 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847779 Preamble is [198] bytes long
+     | 1683911847779 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847779 Still writing preamble
+     | 1683911847779 Wrote [198] bytes to the client
+     | 1683911847779 (W)
+     | 1683911847779 Writing back bytes
+     | 1683911847779 Wrote [5945] bytes to the client
+     | 1683911847779 (W)
+     | 1683911847779 Writing back bytes
+     | 1683911847779 Wrote [5] bytes to the client
+     | 1683911847779 (W)
+     | 1683911847779 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847779 (WKA)
+     | 1683911847779 Read [336] bytes from client
+     | 1683911847779 (R)
+     | 1683911847779 (RP)
+     | 1683911847779 Preamble successfully parsed
+     | 1683911847779 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847779 (RWo)
+     | 1683911847779 (RC)
+     | 1683911847781 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847781 Preamble is [198] bytes long
+     | 1683911847781 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847781 Still writing preamble
+     | 1683911847781 Wrote [198] bytes to the client
+     | 1683911847781 (W)
+     | 1683911847781 Writing back bytes
+     | 1683911847781 Wrote [6039] bytes to the client
+     | 1683911847781 (W)
+     | 1683911847781 Writing back bytes
+     | 1683911847781 Wrote [5] bytes to the client
+     | 1683911847781 (W)
+     | 1683911847781 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847781 (WKA)
+     | 1683911847781 Read [336] bytes from client
+     | 1683911847781 (R)
+     | 1683911847781 (RP)
+     | 1683911847781 Preamble successfully parsed
+     | 1683911847781 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847781 (RWo)
+     | 1683911847781 (RC)
+     | 1683911847782 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847782 Preamble is [198] bytes long
+     | 1683911847782 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847782 Still writing preamble
+     | 1683911847782 Wrote [198] bytes to the client
+     | 1683911847782 (W)
+     | 1683911847782 Writing back bytes
+     | 1683911847782 Wrote [6133] bytes to the client
+     | 1683911847782 (W)
+     | 1683911847782 Writing back bytes
+     | 1683911847782 Wrote [5] bytes to the client
+     | 1683911847782 (W)
+     | 1683911847782 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847782 (WKA)
+     | 1683911847783 Read [336] bytes from client
+     | 1683911847783 (R)
+     | 1683911847783 (RP)
+     | 1683911847783 Preamble successfully parsed
+     | 1683911847783 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847783 (RWo)
+     | 1683911847783 (RC)
+     | 1683911847784 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847784 Preamble is [198] bytes long
+     | 1683911847784 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847784 Still writing preamble
+     | 1683911847784 Wrote [198] bytes to the client
+     | 1683911847784 (W)
+     | 1683911847784 Writing back bytes
+     | 1683911847784 Wrote [6227] bytes to the client
+     | 1683911847784 (W)
+     | 1683911847784 Writing back bytes
+     | 1683911847784 Wrote [5] bytes to the client
+     | 1683911847784 (W)
+     | 1683911847784 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847784 (WKA)
+     | 1683911847784 Read [336] bytes from client
+     | 1683911847784 (R)
+     | 1683911847784 (RP)
+     | 1683911847785 Preamble successfully parsed
+     | 1683911847785 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847785 (RWo)
+     | 1683911847785 (RC)
+     | 1683911847786 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847786 Preamble is [198] bytes long
+     | 1683911847786 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847786 Still writing preamble
+     | 1683911847786 Wrote [198] bytes to the client
+     | 1683911847786 (W)
+     | 1683911847786 Writing back bytes
+     | 1683911847786 Wrote [6321] bytes to the client
+     | 1683911847786 (W)
+     | 1683911847786 Writing back bytes
+     | 1683911847786 Wrote [5] bytes to the client
+     | 1683911847786 (W)
+     | 1683911847786 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847786 (WKA)
+     | 1683911847786 Read [336] bytes from client
+     | 1683911847786 (R)
+     | 1683911847786 (RP)
+     | 1683911847786 Preamble successfully parsed
+     | 1683911847786 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847786 (RWo)
+     | 1683911847786 (RC)
+     | 1683911847787 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847788 Preamble is [198] bytes long
+     | 1683911847788 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847788 Still writing preamble
+     | 1683911847788 Wrote [198] bytes to the client
+     | 1683911847788 (W)
+     | 1683911847788 Writing back bytes
+     | 1683911847788 Wrote [6415] bytes to the client
+     | 1683911847788 (W)
+     | 1683911847788 Writing back bytes
+     | 1683911847788 Wrote [5] bytes to the client
+     | 1683911847788 (W)
+     | 1683911847788 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847788 (WKA)
+     | 1683911847788 Read [336] bytes from client
+     | 1683911847788 (R)
+     | 1683911847788 (RP)
+     | 1683911847788 Preamble successfully parsed
+     | 1683911847788 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847788 (RWo)
+     | 1683911847788 (RC)
+     | 1683911847789 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847789 Preamble is [198] bytes long
+     | 1683911847789 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847789 Still writing preamble
+     | 1683911847789 Wrote [198] bytes to the client
+     | 1683911847789 (W)
+     | 1683911847789 Writing back bytes
+     | 1683911847789 Wrote [6509] bytes to the client
+     | 1683911847789 (W)
+     | 1683911847789 Writing back bytes
+     | 1683911847789 Wrote [5] bytes to the client
+     | 1683911847789 (W)
+     | 1683911847789 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847789 (WKA)
+     | 1683911847790 Read [336] bytes from client
+     | 1683911847790 (R)
+     | 1683911847790 (RP)
+     | 1683911847790 Preamble successfully parsed
+     | 1683911847790 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847790 (RWo)
+     | 1683911847790 (RC)
+     | 1683911847791 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847791 Preamble is [198] bytes long
+     | 1683911847791 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847791 Still writing preamble
+     | 1683911847791 Wrote [198] bytes to the client
+     | 1683911847791 (W)
+     | 1683911847791 Writing back bytes
+     | 1683911847791 Wrote [6603] bytes to the client
+     | 1683911847791 (W)
+     | 1683911847791 Writing back bytes
+     | 1683911847791 Wrote [5] bytes to the client
+     | 1683911847791 (W)
+     | 1683911847791 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847791 (WKA)
+     | 1683911847791 Read [336] bytes from client
+     | 1683911847791 (R)
+     | 1683911847791 (RP)
+     | 1683911847791 Preamble successfully parsed
+     | 1683911847791 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847791 (RWo)
+     | 1683911847791 (RC)
+     | 1683911847793 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847793 Preamble is [198] bytes long
+     | 1683911847793 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847793 Still writing preamble
+     | 1683911847793 Wrote [198] bytes to the client
+     | 1683911847793 (W)
+     | 1683911847793 Writing back bytes
+     | 1683911847793 Wrote [6697] bytes to the client
+     | 1683911847793 (W)
+     | 1683911847793 Writing back bytes
+     | 1683911847793 Wrote [5] bytes to the client
+     | 1683911847793 (W)
+     | 1683911847793 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847793 (WKA)
+     | 1683911847793 Read [336] bytes from client
+     | 1683911847793 (R)
+     | 1683911847793 (RP)
+     | 1683911847793 Preamble successfully parsed
+     | 1683911847793 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847793 (RWo)
+     | 1683911847793 (RC)
+     | 1683911847794 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847794 Preamble is [198] bytes long
+     | 1683911847794 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847794 Still writing preamble
+     | 1683911847794 Wrote [198] bytes to the client
+     | 1683911847794 (W)
+     | 1683911847794 Writing back bytes
+     | 1683911847794 Wrote [6791] bytes to the client
+     | 1683911847794 (W)
+     | 1683911847794 Writing back bytes
+     | 1683911847794 Wrote [5] bytes to the client
+     | 1683911847794 (W)
+     | 1683911847794 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847794 (WKA)
+     | 1683911847795 Read [336] bytes from client
+     | 1683911847795 (R)
+     | 1683911847795 (RP)
+     | 1683911847795 Preamble successfully parsed
+     | 1683911847795 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847795 (RWo)
+     | 1683911847795 (RC)
+     | 1683911847796 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847796 Preamble is [198] bytes long
+     | 1683911847796 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847796 Still writing preamble
+     | 1683911847796 Wrote [198] bytes to the client
+     | 1683911847796 (W)
+     | 1683911847796 Writing back bytes
+     | 1683911847796 Wrote [6885] bytes to the client
+     | 1683911847796 (W)
+     | 1683911847796 Writing back bytes
+     | 1683911847796 Wrote [5] bytes to the client
+     | 1683911847796 (W)
+     | 1683911847796 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847796 (WKA)
+     | 1683911847797 Read [336] bytes from client
+     | 1683911847797 (R)
+     | 1683911847797 (RP)
+     | 1683911847797 Preamble successfully parsed
+     | 1683911847797 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847797 (RWo)
+     | 1683911847797 (RC)
+     | 1683911847798 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847798 Preamble is [198] bytes long
+     | 1683911847798 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847798 Still writing preamble
+     | 1683911847798 Wrote [198] bytes to the client
+     | 1683911847798 (W)
+     | 1683911847798 Writing back bytes
+     | 1683911847798 Wrote [6979] bytes to the client
+     | 1683911847798 (W)
+     | 1683911847798 Writing back bytes
+     | 1683911847798 Wrote [5] bytes to the client
+     | 1683911847798 (W)
+     | 1683911847798 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847798 (WKA)
+     | 1683911847799 Read [336] bytes from client
+     | 1683911847799 (R)
+     | 1683911847799 (RP)
+     | 1683911847799 Preamble successfully parsed
+     | 1683911847799 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847799 (RWo)
+     | 1683911847799 (RC)
+     | 1683911847800 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847800 Preamble is [198] bytes long
+     | 1683911847800 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847800 Still writing preamble
+     | 1683911847800 Wrote [198] bytes to the client
+     | 1683911847800 (W)
+     | 1683911847800 Writing back bytes
+     | 1683911847800 Wrote [7073] bytes to the client
+     | 1683911847800 (W)
+     | 1683911847800 Writing back bytes
+     | 1683911847800 Wrote [5] bytes to the client
+     | 1683911847800 (W)
+     | 1683911847800 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847800 (WKA)
+     | 1683911847800 Read [336] bytes from client
+     | 1683911847800 (R)
+     | 1683911847800 (RP)
+     | 1683911847800 Preamble successfully parsed
+     | 1683911847800 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847800 (RWo)
+     | 1683911847800 (RC)
+     | 1683911847801 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847802 Preamble is [198] bytes long
+     | 1683911847802 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847802 Still writing preamble
+     | 1683911847802 Wrote [198] bytes to the client
+     | 1683911847802 (W)
+     | 1683911847802 Writing back bytes
+     | 1683911847802 Wrote [7167] bytes to the client
+     | 1683911847802 (W)
+     | 1683911847802 Writing back bytes
+     | 1683911847802 Wrote [5] bytes to the client
+     | 1683911847802 (W)
+     | 1683911847802 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847802 (WKA)
+     | 1683911847802 Read [336] bytes from client
+     | 1683911847802 (R)
+     | 1683911847802 (RP)
+     | 1683911847802 Preamble successfully parsed
+     | 1683911847802 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847802 (RWo)
+     | 1683911847802 (RC)
+     | 1683911847803 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847803 Preamble is [198] bytes long
+     | 1683911847803 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847803 Still writing preamble
+     | 1683911847803 Wrote [198] bytes to the client
+     | 1683911847803 (W)
+     | 1683911847803 Writing back bytes
+     | 1683911847803 Wrote [7261] bytes to the client
+     | 1683911847803 (W)
+     | 1683911847803 Writing back bytes
+     | 1683911847803 Wrote [5] bytes to the client
+     | 1683911847803 (W)
+     | 1683911847803 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847803 (WKA)
+     | 1683911847804 Read [336] bytes from client
+     | 1683911847804 (R)
+     | 1683911847804 (RP)
+     | 1683911847804 Preamble successfully parsed
+     | 1683911847804 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847804 (RWo)
+     | 1683911847804 (RC)
+     | 1683911847805 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847805 Preamble is [198] bytes long
+     | 1683911847805 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847805 Still writing preamble
+     | 1683911847805 Wrote [198] bytes to the client
+     | 1683911847805 (W)
+     | 1683911847805 Writing back bytes
+     | 1683911847805 Wrote [7355] bytes to the client
+     | 1683911847805 (W)
+     | 1683911847805 Writing back bytes
+     | 1683911847805 Wrote [5] bytes to the client
+     | 1683911847805 (W)
+     | 1683911847805 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847805 (WKA)
+     | 1683911847805 Read [336] bytes from client
+     | 1683911847805 (R)
+     | 1683911847805 (RP)
+     | 1683911847805 Preamble successfully parsed
+     | 1683911847805 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847805 (RWo)
+     | 1683911847805 (RC)
+     | 1683911847807 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847807 Preamble is [198] bytes long
+     | 1683911847807 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847807 Still writing preamble
+     | 1683911847807 Wrote [198] bytes to the client
+     | 1683911847807 (W)
+     | 1683911847807 Writing back bytes
+     | 1683911847807 Wrote [7449] bytes to the client
+     | 1683911847807 (W)
+     | 1683911847807 Writing back bytes
+     | 1683911847807 Wrote [5] bytes to the client
+     | 1683911847807 (W)
+     | 1683911847807 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847807 (WKA)
+     | 1683911847807 Read [336] bytes from client
+     | 1683911847807 (R)
+     | 1683911847807 (RP)
+     | 1683911847807 Preamble successfully parsed
+     | 1683911847807 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847807 (RWo)
+     | 1683911847807 (RC)
+     | 1683911847808 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847809 Preamble is [198] bytes long
+     | 1683911847809 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847809 Still writing preamble
+     | 1683911847809 Wrote [198] bytes to the client
+     | 1683911847809 (W)
+     | 1683911847809 Writing back bytes
+     | 1683911847809 Wrote [7543] bytes to the client
+     | 1683911847809 (W)
+     | 1683911847809 Writing back bytes
+     | 1683911847809 Wrote [5] bytes to the client
+     | 1683911847809 (W)
+     | 1683911847809 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847809 (WKA)
+     | 1683911847809 Read [336] bytes from client
+     | 1683911847809 (R)
+     | 1683911847809 (RP)
+     | 1683911847809 Preamble successfully parsed
+     | 1683911847809 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847809 (RWo)
+     | 1683911847809 (RC)
+     | 1683911847810 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847810 Preamble is [198] bytes long
+     | 1683911847810 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847810 Still writing preamble
+     | 1683911847810 Wrote [198] bytes to the client
+     | 1683911847810 (W)
+     | 1683911847810 Writing back bytes
+     | 1683911847810 Wrote [7637] bytes to the client
+     | 1683911847810 (W)
+     | 1683911847810 Writing back bytes
+     | 1683911847810 Wrote [5] bytes to the client
+     | 1683911847810 (W)
+     | 1683911847810 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847810 (WKA)
+     | 1683911847811 Read [336] bytes from client
+     | 1683911847811 (R)
+     | 1683911847811 (RP)
+     | 1683911847811 Preamble successfully parsed
+     | 1683911847811 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847811 (RWo)
+     | 1683911847811 (RC)
+     | 1683911847812 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847812 Preamble is [198] bytes long
+     | 1683911847812 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847812 Still writing preamble
+     | 1683911847812 Wrote [198] bytes to the client
+     | 1683911847812 (W)
+     | 1683911847812 Writing back bytes
+     | 1683911847812 Wrote [7731] bytes to the client
+     | 1683911847812 (W)
+     | 1683911847812 Writing back bytes
+     | 1683911847812 Wrote [5] bytes to the client
+     | 1683911847812 (W)
+     | 1683911847812 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847812 (WKA)
+     | 1683911847812 Read [336] bytes from client
+     | 1683911847812 (R)
+     | 1683911847812 (RP)
+     | 1683911847813 Preamble successfully parsed
+     | 1683911847813 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847813 (RWo)
+     | 1683911847813 (RC)
+     | 1683911847814 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847814 Preamble is [198] bytes long
+     | 1683911847814 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847814 Still writing preamble
+     | 1683911847814 Wrote [198] bytes to the client
+     | 1683911847814 (W)
+     | 1683911847814 Writing back bytes
+     | 1683911847814 Wrote [7825] bytes to the client
+     | 1683911847814 (W)
+     | 1683911847814 Writing back bytes
+     | 1683911847814 Wrote [5] bytes to the client
+     | 1683911847814 (W)
+     | 1683911847814 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847814 (WKA)
+     | 1683911847814 Read [336] bytes from client
+     | 1683911847814 (R)
+     | 1683911847814 (RP)
+     | 1683911847814 Preamble successfully parsed
+     | 1683911847814 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847814 (RWo)
+     | 1683911847814 (RC)
+     | 1683911847815 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847815 Preamble is [198] bytes long
+     | 1683911847815 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847815 Still writing preamble
+     | 1683911847815 Wrote [198] bytes to the client
+     | 1683911847815 (W)
+     | 1683911847815 Writing back bytes
+     | 1683911847815 Wrote [7919] bytes to the client
+     | 1683911847815 (W)
+     | 1683911847815 Writing back bytes
+     | 1683911847815 Wrote [5] bytes to the client
+     | 1683911847815 (W)
+     | 1683911847815 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847815 (WKA)
+     | 1683911847816 Read [336] bytes from client
+     | 1683911847816 (R)
+     | 1683911847816 (RP)
+     | 1683911847816 Preamble successfully parsed
+     | 1683911847816 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847816 (RWo)
+     | 1683911847816 (RC)
+     | 1683911847817 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847817 Preamble is [198] bytes long
+     | 1683911847817 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847817 Still writing preamble
+     | 1683911847817 Wrote [198] bytes to the client
+     | 1683911847817 (W)
+     | 1683911847817 Writing back bytes
+     | 1683911847817 Wrote [8013] bytes to the client
+     | 1683911847817 (W)
+     | 1683911847817 Writing back bytes
+     | 1683911847817 Wrote [5] bytes to the client
+     | 1683911847817 (W)
+     | 1683911847817 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847817 (WKA)
+     | 1683911847817 Read [336] bytes from client
+     | 1683911847817 (R)
+     | 1683911847817 (RP)
+     | 1683911847817 Preamble successfully parsed
+     | 1683911847817 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847817 (RWo)
+     | 1683911847817 (RC)
+     | 1683911847819 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847819 Preamble is [198] bytes long
+     | 1683911847819 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847819 Still writing preamble
+     | 1683911847819 Wrote [198] bytes to the client
+     | 1683911847819 (W)
+     | 1683911847819 Writing back bytes
+     | 1683911847819 Wrote [8107] bytes to the client
+     | 1683911847819 (W)
+     | 1683911847819 Writing back bytes
+     | 1683911847819 Wrote [5] bytes to the client
+     | 1683911847819 (W)
+     | 1683911847819 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847819 (WKA)
+     | 1683911847819 Read [336] bytes from client
+     | 1683911847819 (R)
+     | 1683911847819 (RP)
+     | 1683911847819 Preamble successfully parsed
+     | 1683911847819 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847819 (RWo)
+     | 1683911847819 (RC)
+     | 1683911847820 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847820 Preamble is [198] bytes long
+     | 1683911847820 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847820 Still writing preamble
+     | 1683911847821 Wrote [198] bytes to the client
+     | 1683911847821 (W)
+     | 1683911847821 Writing back bytes
+     | 1683911847821 Wrote [8201] bytes to the client
+     | 1683911847821 (W)
+     | 1683911847821 Writing back bytes
+     | 1683911847821 Wrote [5] bytes to the client
+     | 1683911847821 (W)
+     | 1683911847821 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847821 (WKA)
+     | 1683911847821 Read [336] bytes from client
+     | 1683911847821 (R)
+     | 1683911847821 (RP)
+     | 1683911847821 Preamble successfully parsed
+     | 1683911847821 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847821 (RWo)
+     | 1683911847821 (RC)
+     | 1683911847822 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847822 Preamble is [198] bytes long
+     | 1683911847822 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847822 Still writing preamble
+     | 1683911847822 Wrote [198] bytes to the client
+     | 1683911847822 (W)
+     | 1683911847822 Writing back bytes
+     | 1683911847822 Wrote [8295] bytes to the client
+     | 1683911847822 (W)
+     | 1683911847822 Writing back bytes
+     | 1683911847822 Wrote [5] bytes to the client
+     | 1683911847822 (W)
+     | 1683911847822 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847822 (WKA)
+     | 1683911847823 Read [336] bytes from client
+     | 1683911847823 (R)
+     | 1683911847823 (RP)
+     | 1683911847823 Preamble successfully parsed
+     | 1683911847823 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847823 (RWo)
+     | 1683911847823 (RC)
+     | 1683911847824 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847824 Preamble is [198] bytes long
+     | 1683911847824 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847824 Still writing preamble
+     | 1683911847824 Wrote [198] bytes to the client
+     | 1683911847824 (W)
+     | 1683911847824 Writing back bytes
+     | 1683911847824 Wrote [8389] bytes to the client
+     | 1683911847824 (W)
+     | 1683911847824 Writing back bytes
+     | 1683911847824 Wrote [5] bytes to the client
+     | 1683911847824 (W)
+     | 1683911847824 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847824 (WKA)
+     | 1683911847824 Read [336] bytes from client
+     | 1683911847824 (R)
+     | 1683911847824 (RP)
+     | 1683911847824 Preamble successfully parsed
+     | 1683911847824 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847824 (RWo)
+     | 1683911847824 (RC)
+     | 1683911847826 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847826 Preamble is [198] bytes long
+     | 1683911847826 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847826 Still writing preamble
+     | 1683911847826 Wrote [198] bytes to the client
+     | 1683911847826 (W)
+     | 1683911847826 Writing back bytes
+     | 1683911847826 Wrote [8483] bytes to the client
+     | 1683911847826 (W)
+     | 1683911847826 Writing back bytes
+     | 1683911847826 Wrote [5] bytes to the client
+     | 1683911847826 (W)
+     | 1683911847826 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847826 (WKA)
+     | 1683911847826 Read [336] bytes from client
+     | 1683911847826 (R)
+     | 1683911847826 (RP)
+     | 1683911847826 Preamble successfully parsed
+     | 1683911847826 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847826 (RWo)
+     | 1683911847826 (RC)
+     | 1683911847827 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847827 Preamble is [198] bytes long
+     | 1683911847827 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847827 Still writing preamble
+     | 1683911847827 Wrote [198] bytes to the client
+     | 1683911847827 (W)
+     | 1683911847827 Writing back bytes
+     | 1683911847827 Wrote [8577] bytes to the client
+     | 1683911847827 (W)
+     | 1683911847827 Writing back bytes
+     | 1683911847827 Wrote [5] bytes to the client
+     | 1683911847827 (W)
+     | 1683911847827 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847827 (WKA)
+     | 1683911847828 Read [336] bytes from client
+     | 1683911847828 (R)
+     | 1683911847828 (RP)
+     | 1683911847828 Preamble successfully parsed
+     | 1683911847828 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847828 (RWo)
+     | 1683911847828 (RC)
+     | 1683911847830 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847830 Preamble is [198] bytes long
+     | 1683911847830 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847830 Still writing preamble
+     | 1683911847830 Wrote [198] bytes to the client
+     | 1683911847830 (W)
+     | 1683911847830 Writing back bytes
+     | 1683911847830 Wrote [8671] bytes to the client
+     | 1683911847830 (W)
+     | 1683911847830 Writing back bytes
+     | 1683911847830 Wrote [5] bytes to the client
+     | 1683911847830 (W)
+     | 1683911847830 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847830 (WKA)
+     | 1683911847830 Read [336] bytes from client
+     | 1683911847830 (R)
+     | 1683911847830 (RP)
+     | 1683911847830 Preamble successfully parsed
+     | 1683911847830 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847830 (RWo)
+     | 1683911847830 (RC)
+     | 1683911847831 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847831 Preamble is [198] bytes long
+     | 1683911847831 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847831 Still writing preamble
+     | 1683911847831 Wrote [198] bytes to the client
+     | 1683911847831 (W)
+     | 1683911847831 Writing back bytes
+     | 1683911847831 Wrote [8765] bytes to the client
+     | 1683911847831 (W)
+     | 1683911847831 Writing back bytes
+     | 1683911847831 Wrote [5] bytes to the client
+     | 1683911847831 (W)
+     | 1683911847831 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847831 (WKA)
+     | 1683911847832 Read [336] bytes from client
+     | 1683911847832 (R)
+     | 1683911847832 (RP)
+     | 1683911847832 Preamble successfully parsed
+     | 1683911847832 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847832 (RWo)
+     | 1683911847832 (RC)
+     | 1683911847833 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847833 Preamble is [198] bytes long
+     | 1683911847833 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847833 Still writing preamble
+     | 1683911847833 Wrote [198] bytes to the client
+     | 1683911847833 (W)
+     | 1683911847833 Writing back bytes
+     | 1683911847833 Wrote [8859] bytes to the client
+     | 1683911847833 (W)
+     | 1683911847833 Writing back bytes
+     | 1683911847833 Wrote [5] bytes to the client
+     | 1683911847833 (W)
+     | 1683911847833 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847833 (WKA)
+     | 1683911847834 Read [336] bytes from client
+     | 1683911847834 (R)
+     | 1683911847834 (RP)
+     | 1683911847834 Preamble successfully parsed
+     | 1683911847834 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847834 (RWo)
+     | 1683911847834 (RC)
+     | 1683911847835 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847835 Preamble is [198] bytes long
+     | 1683911847835 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847835 Still writing preamble
+     | 1683911847835 Wrote [198] bytes to the client
+     | 1683911847835 (W)
+     | 1683911847835 Writing back bytes
+     | 1683911847835 Wrote [8953] bytes to the client
+     | 1683911847835 (W)
+     | 1683911847835 Writing back bytes
+     | 1683911847835 Wrote [5] bytes to the client
+     | 1683911847835 (W)
+     | 1683911847835 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847835 (WKA)
+     | 1683911847835 Read [336] bytes from client
+     | 1683911847835 (R)
+     | 1683911847835 (RP)
+     | 1683911847836 Preamble successfully parsed
+     | 1683911847836 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847836 (RWo)
+     | 1683911847836 (RC)
+     | 1683911847837 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847837 Preamble is [198] bytes long
+     | 1683911847837 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847837 Still writing preamble
+     | 1683911847837 Wrote [198] bytes to the client
+     | 1683911847837 (W)
+     | 1683911847837 Writing back bytes
+     | 1683911847837 Wrote [9047] bytes to the client
+     | 1683911847837 (W)
+     | 1683911847837 Writing back bytes
+     | 1683911847837 Wrote [5] bytes to the client
+     | 1683911847837 (W)
+     | 1683911847837 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847837 (WKA)
+     | 1683911847837 Read [336] bytes from client
+     | 1683911847837 (R)
+     | 1683911847837 (RP)
+     | 1683911847837 Preamble successfully parsed
+     | 1683911847837 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847837 (RWo)
+     | 1683911847837 (RC)
+     | 1683911847838 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847838 Preamble is [198] bytes long
+     | 1683911847838 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847838 Still writing preamble
+     | 1683911847838 Wrote [198] bytes to the client
+     | 1683911847838 (W)
+     | 1683911847838 Writing back bytes
+     | 1683911847838 Wrote [9141] bytes to the client
+     | 1683911847838 (W)
+     | 1683911847838 Writing back bytes
+     | 1683911847838 Wrote [5] bytes to the client
+     | 1683911847838 (W)
+     | 1683911847838 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847838 (WKA)
+     | 1683911847839 Read [336] bytes from client
+     | 1683911847839 (R)
+     | 1683911847839 (RP)
+     | 1683911847839 Preamble successfully parsed
+     | 1683911847839 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847839 (RWo)
+     | 1683911847839 (RC)
+     | 1683911847840 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847840 Preamble is [198] bytes long
+     | 1683911847840 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847840 Still writing preamble
+     | 1683911847840 Wrote [198] bytes to the client
+     | 1683911847840 (W)
+     | 1683911847840 Writing back bytes
+     | 1683911847840 Wrote [9235] bytes to the client
+     | 1683911847840 (W)
+     | 1683911847840 Writing back bytes
+     | 1683911847840 Wrote [5] bytes to the client
+     | 1683911847840 (W)
+     | 1683911847840 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847840 (WKA)
+     | 1683911847840 Read [336] bytes from client
+     | 1683911847840 (R)
+     | 1683911847840 (RP)
+     | 1683911847840 Preamble successfully parsed
+     | 1683911847840 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847840 (RWo)
+     | 1683911847840 (RC)
+     | 1683911847842 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847842 Preamble is [198] bytes long
+     | 1683911847842 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847842 Still writing preamble
+     | 1683911847842 Wrote [198] bytes to the client
+     | 1683911847842 (W)
+     | 1683911847842 Writing back bytes
+     | 1683911847842 Wrote [9329] bytes to the client
+     | 1683911847842 (W)
+     | 1683911847842 Writing back bytes
+     | 1683911847842 Wrote [5] bytes to the client
+     | 1683911847842 (W)
+     | 1683911847842 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847842 (WKA)
+     | 1683911847842 Read [336] bytes from client
+     | 1683911847842 (R)
+     | 1683911847842 (RP)
+     | 1683911847842 Preamble successfully parsed
+     | 1683911847842 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847842 (RWo)
+     | 1683911847842 (RC)
+     | 1683911847843 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847843 Preamble is [198] bytes long
+     | 1683911847843 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847843 Still writing preamble
+     | 1683911847843 Wrote [198] bytes to the client
+     | 1683911847843 (W)
+     | 1683911847843 Writing back bytes
+     | 1683911847843 Wrote [9423] bytes to the client
+     | 1683911847843 (W)
+     | 1683911847843 Writing back bytes
+     | 1683911847843 Wrote [5] bytes to the client
+     | 1683911847843 (W)
+     | 1683911847843 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847843 (WKA)
+     | 1683911847844 Read [336] bytes from client
+     | 1683911847844 (R)
+     | 1683911847844 (RP)
+     | 1683911847844 Preamble successfully parsed
+     | 1683911847844 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847844 (RWo)
+     | 1683911847844 (RC)
+     | 1683911847845 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847845 Preamble is [198] bytes long
+     | 1683911847845 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847845 Still writing preamble
+     | 1683911847845 Wrote [198] bytes to the client
+     | 1683911847845 (W)
+     | 1683911847845 Writing back bytes
+     | 1683911847845 Wrote [9522] bytes to the client
+     | 1683911847845 (W)
+     | 1683911847845 Writing back bytes
+     | 1683911847845 Wrote [5] bytes to the client
+     | 1683911847845 (W)
+     | 1683911847845 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847845 (WKA)
+     | 1683911847846 Read [336] bytes from client
+     | 1683911847846 (R)
+     | 1683911847846 (RP)
+     | 1683911847846 Preamble successfully parsed
+     | 1683911847846 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847846 (RWo)
+     | 1683911847846 (RC)
+     | 1683911847847 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847847 Preamble is [198] bytes long
+     | 1683911847847 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847847 Still writing preamble
+     | 1683911847847 Wrote [198] bytes to the client
+     | 1683911847847 (W)
+     | 1683911847847 Writing back bytes
+     | 1683911847847 Wrote [9621] bytes to the client
+     | 1683911847847 (W)
+     | 1683911847847 Writing back bytes
+     | 1683911847847 Wrote [5] bytes to the client
+     | 1683911847847 (W)
+     | 1683911847847 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847847 (WKA)
+     | 1683911847847 Read [336] bytes from client
+     | 1683911847847 (R)
+     | 1683911847847 (RP)
+     | 1683911847847 Preamble successfully parsed
+     | 1683911847847 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847847 (RWo)
+     | 1683911847847 (RC)
+     | 1683911847849 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847849 Preamble is [198] bytes long
+     | 1683911847849 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847849 Still writing preamble
+     | 1683911847849 Wrote [198] bytes to the client
+     | 1683911847849 (W)
+     | 1683911847849 Writing back bytes
+     | 1683911847849 Wrote [9720] bytes to the client
+     | 1683911847849 (W)
+     | 1683911847849 Writing back bytes
+     | 1683911847849 Wrote [5] bytes to the client
+     | 1683911847849 (W)
+     | 1683911847849 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847849 (WKA)
+     | 1683911847849 Read [336] bytes from client
+     | 1683911847849 (R)
+     | 1683911847849 (RP)
+     | 1683911847849 Preamble successfully parsed
+     | 1683911847849 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847849 (RWo)
+     | 1683911847849 (RC)
+     | 1683911847851 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847851 Preamble is [198] bytes long
+     | 1683911847851 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847851 Still writing preamble
+     | 1683911847851 Wrote [198] bytes to the client
+     | 1683911847851 (W)
+     | 1683911847851 Writing back bytes
+     | 1683911847851 Wrote [9819] bytes to the client
+     | 1683911847851 (W)
+     | 1683911847851 Writing back bytes
+     | 1683911847851 Wrote [5] bytes to the client
+     | 1683911847851 (W)
+     | 1683911847851 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847851 (WKA)
+     | 1683911847851 Read [336] bytes from client
+     | 1683911847851 (R)
+     | 1683911847851 (RP)
+     | 1683911847851 Preamble successfully parsed
+     | 1683911847851 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847851 (RWo)
+     | 1683911847851 (RC)
+     | 1683911847852 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847852 Preamble is [198] bytes long
+     | 1683911847852 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847852 Still writing preamble
+     | 1683911847852 Wrote [198] bytes to the client
+     | 1683911847852 (W)
+     | 1683911847852 Writing back bytes
+     | 1683911847852 Wrote [9918] bytes to the client
+     | 1683911847852 (W)
+     | 1683911847852 Writing back bytes
+     | 1683911847852 Wrote [5] bytes to the client
+     | 1683911847852 (W)
+     | 1683911847852 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847852 (WKA)
+     | 1683911847853 Read [336] bytes from client
+     | 1683911847853 (R)
+     | 1683911847853 (RP)
+     | 1683911847853 Preamble successfully parsed
+     | 1683911847853 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847853 (RWo)
+     | 1683911847853 (RC)
+     | 1683911847854 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847854 Preamble is [198] bytes long
+     | 1683911847854 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847854 Still writing preamble
+     | 1683911847854 Wrote [198] bytes to the client
+     | 1683911847854 (W)
+     | 1683911847854 Writing back bytes
+     | 1683911847854 Wrote [10017] bytes to the client
+     | 1683911847854 (W)
+     | 1683911847854 Writing back bytes
+     | 1683911847854 Wrote [5] bytes to the client
+     | 1683911847854 (W)
+     | 1683911847854 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847854 (WKA)
+     | 1683911847854 Read [336] bytes from client
+     | 1683911847854 (R)
+     | 1683911847854 (RP)
+     | 1683911847854 Preamble successfully parsed
+     | 1683911847854 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847854 (RWo)
+     | 1683911847854 (RC)
+     | 1683911847855 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847856 Preamble is [198] bytes long
+     | 1683911847856 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847856 Still writing preamble
+     | 1683911847856 Wrote [198] bytes to the client
+     | 1683911847856 (W)
+     | 1683911847856 Writing back bytes
+     | 1683911847856 Wrote [10116] bytes to the client
+     | 1683911847856 (W)
+     | 1683911847856 Writing back bytes
+     | 1683911847856 Wrote [5] bytes to the client
+     | 1683911847856 (W)
+     | 1683911847856 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847856 (WKA)
+     | 1683911847856 Read [336] bytes from client
+     | 1683911847856 (R)
+     | 1683911847856 (RP)
+     | 1683911847856 Preamble successfully parsed
+     | 1683911847856 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847856 (RWo)
+     | 1683911847856 (RC)
+     | 1683911847857 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847857 Preamble is [198] bytes long
+     | 1683911847857 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847857 Still writing preamble
+     | 1683911847857 Wrote [198] bytes to the client
+     | 1683911847857 (W)
+     | 1683911847857 Writing back bytes
+     | 1683911847857 Wrote [10215] bytes to the client
+     | 1683911847857 (W)
+     | 1683911847857 Writing back bytes
+     | 1683911847857 Wrote [5] bytes to the client
+     | 1683911847857 (W)
+     | 1683911847857 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847857 (WKA)
+     | 1683911847858 Read [336] bytes from client
+     | 1683911847858 (R)
+     | 1683911847858 (RP)
+     | 1683911847858 Preamble successfully parsed
+     | 1683911847858 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847858 (RWo)
+     | 1683911847858 (RC)
+     | 1683911847859 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847859 Preamble is [198] bytes long
+     | 1683911847859 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847859 Still writing preamble
+     | 1683911847859 Wrote [198] bytes to the client
+     | 1683911847859 (W)
+     | 1683911847859 Writing back bytes
+     | 1683911847859 Wrote [10314] bytes to the client
+     | 1683911847859 (W)
+     | 1683911847859 Writing back bytes
+     | 1683911847859 Wrote [5] bytes to the client
+     | 1683911847859 (W)
+     | 1683911847859 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847859 (WKA)
+     | 1683911847859 Read [336] bytes from client
+     | 1683911847859 (R)
+     | 1683911847859 (RP)
+     | 1683911847859 Preamble successfully parsed
+     | 1683911847859 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847859 (RWo)
+     | 1683911847859 (RC)
+     | 1683911847860 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847860 Preamble is [198] bytes long
+     | 1683911847860 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847860 Still writing preamble
+     | 1683911847861 Wrote [198] bytes to the client
+     | 1683911847861 (W)
+     | 1683911847861 Writing back bytes
+     | 1683911847861 Wrote [10413] bytes to the client
+     | 1683911847861 (W)
+     | 1683911847861 Writing back bytes
+     | 1683911847861 Wrote [5] bytes to the client
+     | 1683911847861 (W)
+     | 1683911847861 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847861 (WKA)
+     | 1683911847861 Read [336] bytes from client
+     | 1683911847861 (R)
+     | 1683911847861 (RP)
+     | 1683911847861 Preamble successfully parsed
+     | 1683911847861 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847861 (RWo)
+     | 1683911847861 (RC)
+     | 1683911847862 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847862 Preamble is [198] bytes long
+     | 1683911847862 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847862 Still writing preamble
+     | 1683911847862 Wrote [198] bytes to the client
+     | 1683911847862 (W)
+     | 1683911847862 Writing back bytes
+     | 1683911847862 Wrote [10512] bytes to the client
+     | 1683911847862 (W)
+     | 1683911847862 Writing back bytes
+     | 1683911847862 Wrote [5] bytes to the client
+     | 1683911847862 (W)
+     | 1683911847862 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847862 (WKA)
+     | 1683911847862 Read [336] bytes from client
+     | 1683911847862 (R)
+     | 1683911847862 (RP)
+     | 1683911847862 Preamble successfully parsed
+     | 1683911847862 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847862 (RWo)
+     | 1683911847862 (RC)
+     | 1683911847864 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847864 Preamble is [198] bytes long
+     | 1683911847864 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847864 Still writing preamble
+     | 1683911847864 Wrote [198] bytes to the client
+     | 1683911847864 (W)
+     | 1683911847864 Writing back bytes
+     | 1683911847864 Wrote [10611] bytes to the client
+     | 1683911847864 (W)
+     | 1683911847864 Writing back bytes
+     | 1683911847864 Wrote [5] bytes to the client
+     | 1683911847864 (W)
+     | 1683911847864 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847864 (WKA)
+     | 1683911847864 Read [336] bytes from client
+     | 1683911847864 (R)
+     | 1683911847864 (RP)
+     | 1683911847864 Preamble successfully parsed
+     | 1683911847864 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847864 (RWo)
+     | 1683911847864 (RC)
+     | 1683911847865 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847865 Preamble is [198] bytes long
+     | 1683911847865 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847865 Still writing preamble
+     | 1683911847865 Wrote [198] bytes to the client
+     | 1683911847865 (W)
+     | 1683911847865 Writing back bytes
+     | 1683911847865 Wrote [10710] bytes to the client
+     | 1683911847865 (W)
+     | 1683911847865 Writing back bytes
+     | 1683911847865 Wrote [5] bytes to the client
+     | 1683911847865 (W)
+     | 1683911847865 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847865 (WKA)
+     | 1683911847865 Read [336] bytes from client
+     | 1683911847865 (R)
+     | 1683911847865 (RP)
+     | 1683911847865 Preamble successfully parsed
+     | 1683911847865 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847865 (RWo)
+     | 1683911847865 (RC)
+     | 1683911847866 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847866 Preamble is [198] bytes long
+     | 1683911847866 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847866 Still writing preamble
+     | 1683911847866 Wrote [198] bytes to the client
+     | 1683911847866 (W)
+     | 1683911847866 Writing back bytes
+     | 1683911847866 Wrote [10809] bytes to the client
+     | 1683911847866 (W)
+     | 1683911847866 Writing back bytes
+     | 1683911847866 Wrote [5] bytes to the client
+     | 1683911847866 (W)
+     | 1683911847866 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847866 (WKA)
+     | 1683911847867 Read [336] bytes from client
+     | 1683911847867 (R)
+     | 1683911847867 (RP)
+     | 1683911847867 Preamble successfully parsed
+     | 1683911847867 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847867 (RWo)
+     | 1683911847867 (RC)
+     | 1683911847868 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847868 Preamble is [198] bytes long
+     | 1683911847868 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847868 Still writing preamble
+     | 1683911847868 Wrote [198] bytes to the client
+     | 1683911847868 (W)
+     | 1683911847868 Writing back bytes
+     | 1683911847868 Wrote [10908] bytes to the client
+     | 1683911847868 (W)
+     | 1683911847868 Writing back bytes
+     | 1683911847868 Wrote [5] bytes to the client
+     | 1683911847868 (W)
+     | 1683911847868 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847868 (WKA)
+     | 1683911847868 Read [336] bytes from client
+     | 1683911847868 (R)
+     | 1683911847868 (RP)
+     | 1683911847868 Preamble successfully parsed
+     | 1683911847868 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847868 (RWo)
+     | 1683911847868 (RC)
+     | 1683911847869 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847869 Preamble is [198] bytes long
+     | 1683911847869 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847869 Still writing preamble
+     | 1683911847869 Wrote [198] bytes to the client
+     | 1683911847869 (W)
+     | 1683911847869 Writing back bytes
+     | 1683911847869 Wrote [11007] bytes to the client
+     | 1683911847869 (W)
+     | 1683911847869 Writing back bytes
+     | 1683911847869 Wrote [5] bytes to the client
+     | 1683911847869 (W)
+     | 1683911847869 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847869 (WKA)
+     | 1683911847870 Read [336] bytes from client
+     | 1683911847870 (R)
+     | 1683911847870 (RP)
+     | 1683911847870 Preamble successfully parsed
+     | 1683911847870 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847870 (RWo)
+     | 1683911847870 (RC)
+     | 1683911847871 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847871 Preamble is [198] bytes long
+     | 1683911847871 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847871 Still writing preamble
+     | 1683911847871 Wrote [198] bytes to the client
+     | 1683911847871 (W)
+     | 1683911847871 Writing back bytes
+     | 1683911847871 Wrote [11106] bytes to the client
+     | 1683911847871 (W)
+     | 1683911847871 Writing back bytes
+     | 1683911847871 Wrote [5] bytes to the client
+     | 1683911847871 (W)
+     | 1683911847871 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847871 (WKA)
+     | 1683911847871 Read [336] bytes from client
+     | 1683911847871 (R)
+     | 1683911847871 (RP)
+     | 1683911847871 Preamble successfully parsed
+     | 1683911847871 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847871 (RWo)
+     | 1683911847871 (RC)
+     | 1683911847872 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847872 Preamble is [198] bytes long
+     | 1683911847872 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847872 Still writing preamble
+     | 1683911847872 Wrote [198] bytes to the client
+     | 1683911847872 (W)
+     | 1683911847872 Writing back bytes
+     | 1683911847872 Wrote [11205] bytes to the client
+     | 1683911847872 (W)
+     | 1683911847872 Writing back bytes
+     | 1683911847872 Wrote [5] bytes to the client
+     | 1683911847872 (W)
+     | 1683911847872 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847872 (WKA)
+     | 1683911847873 Read [336] bytes from client
+     | 1683911847873 (R)
+     | 1683911847873 (RP)
+     | 1683911847873 Preamble successfully parsed
+     | 1683911847873 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847873 (RWo)
+     | 1683911847873 (RC)
+     | 1683911847874 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847874 Preamble is [198] bytes long
+     | 1683911847874 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847874 Still writing preamble
+     | 1683911847874 Wrote [198] bytes to the client
+     | 1683911847874 (W)
+     | 1683911847874 Writing back bytes
+     | 1683911847874 Wrote [11304] bytes to the client
+     | 1683911847874 (W)
+     | 1683911847874 Writing back bytes
+     | 1683911847874 Wrote [5] bytes to the client
+     | 1683911847874 (W)
+     | 1683911847874 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847874 (WKA)
+     | 1683911847874 Read [336] bytes from client
+     | 1683911847874 (R)
+     | 1683911847874 (RP)
+     | 1683911847874 Preamble successfully parsed
+     | 1683911847874 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847874 (RWo)
+     | 1683911847874 (RC)
+     | 1683911847876 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847876 Preamble is [198] bytes long
+     | 1683911847876 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847876 Still writing preamble
+     | 1683911847876 Wrote [198] bytes to the client
+     | 1683911847876 (W)
+     | 1683911847876 Writing back bytes
+     | 1683911847876 Wrote [11403] bytes to the client
+     | 1683911847876 (W)
+     | 1683911847876 Writing back bytes
+     | 1683911847876 Wrote [5] bytes to the client
+     | 1683911847876 (W)
+     | 1683911847876 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847876 (WKA)
+     | 1683911847876 Read [336] bytes from client
+     | 1683911847876 (R)
+     | 1683911847876 (RP)
+     | 1683911847876 Preamble successfully parsed
+     | 1683911847876 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847876 (RWo)
+     | 1683911847876 (RC)
+     | 1683911847877 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847877 Preamble is [198] bytes long
+     | 1683911847877 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847877 Still writing preamble
+     | 1683911847877 Wrote [198] bytes to the client
+     | 1683911847877 (W)
+     | 1683911847877 Writing back bytes
+     | 1683911847877 Wrote [11502] bytes to the client
+     | 1683911847877 (W)
+     | 1683911847877 Writing back bytes
+     | 1683911847877 Wrote [5] bytes to the client
+     | 1683911847877 (W)
+     | 1683911847877 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847877 (WKA)
+     | 1683911847878 Read [336] bytes from client
+     | 1683911847878 (R)
+     | 1683911847878 (RP)
+     | 1683911847878 Preamble successfully parsed
+     | 1683911847878 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847878 (RWo)
+     | 1683911847878 (RC)
+     | 1683911847879 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847879 Preamble is [198] bytes long
+     | 1683911847879 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847879 Still writing preamble
+     | 1683911847879 Wrote [198] bytes to the client
+     | 1683911847879 (W)
+     | 1683911847879 Writing back bytes
+     | 1683911847879 Wrote [11601] bytes to the client
+     | 1683911847879 (W)
+     | 1683911847879 Writing back bytes
+     | 1683911847879 Wrote [5] bytes to the client
+     | 1683911847879 (W)
+     | 1683911847879 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847879 (WKA)
+     | 1683911847879 Read [336] bytes from client
+     | 1683911847879 (R)
+     | 1683911847879 (RP)
+     | 1683911847879 Preamble successfully parsed
+     | 1683911847879 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847879 (RWo)
+     | 1683911847879 (RC)
+     | 1683911847881 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847881 Preamble is [198] bytes long
+     | 1683911847881 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847881 Still writing preamble
+     | 1683911847881 Wrote [198] bytes to the client
+     | 1683911847881 (W)
+     | 1683911847881 Writing back bytes
+     | 1683911847881 Wrote [11700] bytes to the client
+     | 1683911847881 (W)
+     | 1683911847881 Writing back bytes
+     | 1683911847881 Wrote [5] bytes to the client
+     | 1683911847881 (W)
+     | 1683911847881 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847881 (WKA)
+     | 1683911847881 Read [336] bytes from client
+     | 1683911847881 (R)
+     | 1683911847881 (RP)
+     | 1683911847881 Preamble successfully parsed
+     | 1683911847881 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847881 (RWo)
+     | 1683911847881 (RC)
+     | 1683911847882 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847882 Preamble is [198] bytes long
+     | 1683911847882 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847882 Still writing preamble
+     | 1683911847882 Wrote [198] bytes to the client
+     | 1683911847882 (W)
+     | 1683911847882 Writing back bytes
+     | 1683911847882 Wrote [11799] bytes to the client
+     | 1683911847882 (W)
+     | 1683911847882 Writing back bytes
+     | 1683911847882 Wrote [5] bytes to the client
+     | 1683911847882 (W)
+     | 1683911847882 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847882 (WKA)
+     | 1683911847882 Read [336] bytes from client
+     | 1683911847882 (R)
+     | 1683911847882 (RP)
+     | 1683911847882 Preamble successfully parsed
+     | 1683911847882 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847882 (RWo)
+     | 1683911847882 (RC)
+     | 1683911847883 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847883 Preamble is [198] bytes long
+     | 1683911847883 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847883 Still writing preamble
+     | 1683911847883 Wrote [198] bytes to the client
+     | 1683911847883 (W)
+     | 1683911847883 Writing back bytes
+     | 1683911847883 Wrote [11898] bytes to the client
+     | 1683911847883 (W)
+     | 1683911847883 Writing back bytes
+     | 1683911847883 Wrote [5] bytes to the client
+     | 1683911847883 (W)
+     | 1683911847883 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847883 (WKA)
+     | 1683911847884 Read [336] bytes from client
+     | 1683911847884 (R)
+     | 1683911847884 (RP)
+     | 1683911847884 Preamble successfully parsed
+     | 1683911847884 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847884 (RWo)
+     | 1683911847884 (RC)
+     | 1683911847885 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847885 Preamble is [198] bytes long
+     | 1683911847885 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847885 Still writing preamble
+     | 1683911847885 Wrote [198] bytes to the client
+     | 1683911847885 (W)
+     | 1683911847885 Writing back bytes
+     | 1683911847885 Wrote [11997] bytes to the client
+     | 1683911847885 (W)
+     | 1683911847885 Writing back bytes
+     | 1683911847885 Wrote [5] bytes to the client
+     | 1683911847885 (W)
+     | 1683911847885 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847885 (WKA)
+     | 1683911847885 Read [336] bytes from client
+     | 1683911847885 (R)
+     | 1683911847885 (RP)
+     | 1683911847885 Preamble successfully parsed
+     | 1683911847885 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847885 (RWo)
+     | 1683911847885 (RC)
+     | 1683911847886 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847886 Preamble is [198] bytes long
+     | 1683911847886 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847886 Still writing preamble
+     | 1683911847886 Wrote [198] bytes to the client
+     | 1683911847886 (W)
+     | 1683911847886 Writing back bytes
+     | 1683911847886 Wrote [12096] bytes to the client
+     | 1683911847886 (W)
+     | 1683911847886 Writing back bytes
+     | 1683911847886 Wrote [5] bytes to the client
+     | 1683911847886 (W)
+     | 1683911847886 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847886 (WKA)
+     | 1683911847887 Read [336] bytes from client
+     | 1683911847887 (R)
+     | 1683911847887 (RP)
+     | 1683911847887 Preamble successfully parsed
+     | 1683911847887 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847887 (RWo)
+     | 1683911847887 (RC)
+     | 1683911847888 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847888 Preamble is [198] bytes long
+     | 1683911847888 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847888 Still writing preamble
+     | 1683911847888 Wrote [198] bytes to the client
+     | 1683911847888 (W)
+     | 1683911847888 Writing back bytes
+     | 1683911847888 Wrote [12195] bytes to the client
+     | 1683911847888 (W)
+     | 1683911847888 Writing back bytes
+     | 1683911847888 Wrote [5] bytes to the client
+     | 1683911847888 (W)
+     | 1683911847888 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847888 (WKA)
+     | 1683911847888 Read [336] bytes from client
+     | 1683911847888 (R)
+     | 1683911847888 (RP)
+     | 1683911847888 Preamble successfully parsed
+     | 1683911847888 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847888 (RWo)
+     | 1683911847888 (RC)
+     | 1683911847889 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847889 Preamble is [198] bytes long
+     | 1683911847889 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847889 Still writing preamble
+     | 1683911847889 Wrote [198] bytes to the client
+     | 1683911847889 (W)
+     | 1683911847889 Writing back bytes
+     | 1683911847889 Wrote [12294] bytes to the client
+     | 1683911847889 (W)
+     | 1683911847889 Writing back bytes
+     | 1683911847889 Wrote [5] bytes to the client
+     | 1683911847889 (W)
+     | 1683911847889 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847889 (WKA)
+     | 1683911847890 Read [336] bytes from client
+     | 1683911847890 (R)
+     | 1683911847890 (RP)
+     | 1683911847890 Preamble successfully parsed
+     | 1683911847890 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847890 (RWo)
+     | 1683911847890 (RC)
+     | 1683911847891 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847891 Preamble is [198] bytes long
+     | 1683911847891 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847891 Still writing preamble
+     | 1683911847891 Wrote [198] bytes to the client
+     | 1683911847891 (W)
+     | 1683911847891 Writing back bytes
+     | 1683911847891 Wrote [12393] bytes to the client
+     | 1683911847891 (W)
+     | 1683911847891 Writing back bytes
+     | 1683911847891 Wrote [5] bytes to the client
+     | 1683911847891 (W)
+     | 1683911847891 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847891 (WKA)
+     | 1683911847891 Read [336] bytes from client
+     | 1683911847891 (R)
+     | 1683911847891 (RP)
+     | 1683911847891 Preamble successfully parsed
+     | 1683911847891 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847891 (RWo)
+     | 1683911847891 (RC)
+     | 1683911847892 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847892 Preamble is [198] bytes long
+     | 1683911847892 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847892 Still writing preamble
+     | 1683911847892 Wrote [198] bytes to the client
+     | 1683911847892 (W)
+     | 1683911847892 Writing back bytes
+     | 1683911847892 Wrote [12492] bytes to the client
+     | 1683911847892 (W)
+     | 1683911847892 Writing back bytes
+     | 1683911847892 Wrote [5] bytes to the client
+     | 1683911847892 (W)
+     | 1683911847892 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847892 (WKA)
+     | 1683911847892 Read [336] bytes from client
+     | 1683911847892 (R)
+     | 1683911847892 (RP)
+     | 1683911847893 Preamble successfully parsed
+     | 1683911847893 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847893 (RWo)
+     | 1683911847893 (RC)
+     | 1683911847895 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847895 Preamble is [198] bytes long
+     | 1683911847895 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847895 Still writing preamble
+     | 1683911847895 Wrote [198] bytes to the client
+     | 1683911847895 (W)
+     | 1683911847895 Writing back bytes
+     | 1683911847895 Wrote [12591] bytes to the client
+     | 1683911847895 (W)
+     | 1683911847895 Writing back bytes
+     | 1683911847895 Wrote [5] bytes to the client
+     | 1683911847895 (W)
+     | 1683911847895 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847895 (WKA)
+     | 1683911847895 Read [336] bytes from client
+     | 1683911847895 (R)
+     | 1683911847895 (RP)
+     | 1683911847895 Preamble successfully parsed
+     | 1683911847895 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847895 (RWo)
+     | 1683911847895 (RC)
+     | 1683911847896 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847896 Preamble is [198] bytes long
+     | 1683911847896 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847896 Still writing preamble
+     | 1683911847896 Wrote [198] bytes to the client
+     | 1683911847896 (W)
+     | 1683911847896 Writing back bytes
+     | 1683911847896 Wrote [12690] bytes to the client
+     | 1683911847896 (W)
+     | 1683911847896 Writing back bytes
+     | 1683911847896 Wrote [5] bytes to the client
+     | 1683911847896 (W)
+     | 1683911847896 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847896 (WKA)
+     | 1683911847897 Read [336] bytes from client
+     | 1683911847897 (R)
+     | 1683911847897 (RP)
+     | 1683911847897 Preamble successfully parsed
+     | 1683911847897 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847897 (RWo)
+     | 1683911847897 (RC)
+     | 1683911847898 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847898 Preamble is [198] bytes long
+     | 1683911847898 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847898 Still writing preamble
+     | 1683911847898 Wrote [198] bytes to the client
+     | 1683911847898 (W)
+     | 1683911847898 Writing back bytes
+     | 1683911847898 Wrote [12789] bytes to the client
+     | 1683911847898 (W)
+     | 1683911847898 Writing back bytes
+     | 1683911847898 Wrote [5] bytes to the client
+     | 1683911847898 (W)
+     | 1683911847898 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847898 (WKA)
+     | 1683911847898 Read [336] bytes from client
+     | 1683911847898 (R)
+     | 1683911847898 (RP)
+     | 1683911847898 Preamble successfully parsed
+     | 1683911847898 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847898 (RWo)
+     | 1683911847898 (RC)
+     | 1683911847899 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847899 Preamble is [198] bytes long
+     | 1683911847899 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847899 Still writing preamble
+     | 1683911847899 Wrote [198] bytes to the client
+     | 1683911847899 (W)
+     | 1683911847899 Writing back bytes
+     | 1683911847899 Wrote [12888] bytes to the client
+     | 1683911847899 (W)
+     | 1683911847899 Writing back bytes
+     | 1683911847899 Wrote [5] bytes to the client
+     | 1683911847899 (W)
+     | 1683911847899 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847899 (WKA)
+     | 1683911847899 Read [336] bytes from client
+     | 1683911847899 (R)
+     | 1683911847899 (RP)
+     | 1683911847899 Preamble successfully parsed
+     | 1683911847899 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847899 (RWo)
+     | 1683911847899 (RC)
+     | 1683911847900 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847900 Preamble is [198] bytes long
+     | 1683911847900 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847900 Still writing preamble
+     | 1683911847900 Wrote [198] bytes to the client
+     | 1683911847900 (W)
+     | 1683911847900 Writing back bytes
+     | 1683911847900 Wrote [12987] bytes to the client
+     | 1683911847900 (W)
+     | 1683911847900 Writing back bytes
+     | 1683911847900 Wrote [5] bytes to the client
+     | 1683911847900 (W)
+     | 1683911847900 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847900 (WKA)
+     | 1683911847901 Read [336] bytes from client
+     | 1683911847901 (R)
+     | 1683911847901 (RP)
+     | 1683911847901 Preamble successfully parsed
+     | 1683911847901 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847901 (RWo)
+     | 1683911847901 (RC)
+     | 1683911847902 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847902 Preamble is [198] bytes long
+     | 1683911847902 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847902 Still writing preamble
+     | 1683911847902 Wrote [198] bytes to the client
+     | 1683911847902 (W)
+     | 1683911847902 Writing back bytes
+     | 1683911847902 Wrote [13086] bytes to the client
+     | 1683911847902 (W)
+     | 1683911847902 Writing back bytes
+     | 1683911847902 Wrote [5] bytes to the client
+     | 1683911847902 (W)
+     | 1683911847902 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847902 (WKA)
+     | 1683911847902 Read [336] bytes from client
+     | 1683911847902 (R)
+     | 1683911847902 (RP)
+     | 1683911847902 Preamble successfully parsed
+     | 1683911847902 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847902 (RWo)
+     | 1683911847902 (RC)
+     | 1683911847903 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847903 Preamble is [198] bytes long
+     | 1683911847903 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847903 Still writing preamble
+     | 1683911847903 Wrote [198] bytes to the client
+     | 1683911847903 (W)
+     | 1683911847903 Writing back bytes
+     | 1683911847903 Wrote [13185] bytes to the client
+     | 1683911847903 (W)
+     | 1683911847903 Writing back bytes
+     | 1683911847903 Wrote [5] bytes to the client
+     | 1683911847903 (W)
+     | 1683911847903 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847903 (WKA)
+     | 1683911847903 Read [336] bytes from client
+     | 1683911847903 (R)
+     | 1683911847903 (RP)
+     | 1683911847903 Preamble successfully parsed
+     | 1683911847903 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847903 (RWo)
+     | 1683911847903 (RC)
+     | 1683911847904 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847904 Preamble is [198] bytes long
+     | 1683911847904 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847904 Still writing preamble
+     | 1683911847904 Wrote [198] bytes to the client
+     | 1683911847904 (W)
+     | 1683911847905 Writing back bytes
+     | 1683911847905 Wrote [13284] bytes to the client
+     | 1683911847905 (W)
+     | 1683911847905 Writing back bytes
+     | 1683911847905 Wrote [5] bytes to the client
+     | 1683911847905 (W)
+     | 1683911847905 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847905 (WKA)
+     | 1683911847905 Read [336] bytes from client
+     | 1683911847905 (R)
+     | 1683911847905 (RP)
+     | 1683911847905 Preamble successfully parsed
+     | 1683911847905 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847905 (RWo)
+     | 1683911847905 (RC)
+     | 1683911847906 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847906 Preamble is [198] bytes long
+     | 1683911847906 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847906 Still writing preamble
+     | 1683911847906 Wrote [198] bytes to the client
+     | 1683911847906 (W)
+     | 1683911847906 Writing back bytes
+     | 1683911847906 Wrote [13383] bytes to the client
+     | 1683911847906 (W)
+     | 1683911847906 Writing back bytes
+     | 1683911847906 Wrote [5] bytes to the client
+     | 1683911847906 (W)
+     | 1683911847906 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847906 (WKA)
+     | 1683911847906 Read [336] bytes from client
+     | 1683911847906 (R)
+     | 1683911847906 (RP)
+     | 1683911847906 Preamble successfully parsed
+     | 1683911847906 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847906 (RWo)
+     | 1683911847906 (RC)
+     | 1683911847907 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847907 Preamble is [198] bytes long
+     | 1683911847907 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847907 Still writing preamble
+     | 1683911847907 Wrote [198] bytes to the client
+     | 1683911847907 (W)
+     | 1683911847907 Writing back bytes
+     | 1683911847907 Wrote [13482] bytes to the client
+     | 1683911847907 (W)
+     | 1683911847907 Writing back bytes
+     | 1683911847907 Wrote [5] bytes to the client
+     | 1683911847907 (W)
+     | 1683911847907 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847907 (WKA)
+     | 1683911847907 Read [336] bytes from client
+     | 1683911847907 (R)
+     | 1683911847907 (RP)
+     | 1683911847907 Preamble successfully parsed
+     | 1683911847907 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847907 (RWo)
+     | 1683911847907 (RC)
+     | 1683911847908 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847908 Preamble is [198] bytes long
+     | 1683911847908 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847908 Still writing preamble
+     | 1683911847908 Wrote [198] bytes to the client
+     | 1683911847908 (W)
+     | 1683911847908 Writing back bytes
+     | 1683911847908 Wrote [13581] bytes to the client
+     | 1683911847908 (W)
+     | 1683911847908 Writing back bytes
+     | 1683911847908 Wrote [5] bytes to the client
+     | 1683911847908 (W)
+     | 1683911847908 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847908 (WKA)
+     | 1683911847909 Read [336] bytes from client
+     | 1683911847909 (R)
+     | 1683911847909 (RP)
+     | 1683911847909 Preamble successfully parsed
+     | 1683911847909 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847909 (RWo)
+     | 1683911847909 (RC)
+     | 1683911847909 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847909 Preamble is [198] bytes long
+     | 1683911847909 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847909 Still writing preamble
+     | 1683911847910 Wrote [198] bytes to the client
+     | 1683911847910 (W)
+     | 1683911847910 Writing back bytes
+     | 1683911847910 Wrote [13680] bytes to the client
+     | 1683911847910 (W)
+     | 1683911847910 Writing back bytes
+     | 1683911847910 Wrote [5] bytes to the client
+     | 1683911847910 (W)
+     | 1683911847910 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847910 (WKA)
+     | 1683911847910 Read [336] bytes from client
+     | 1683911847910 (R)
+     | 1683911847910 (RP)
+     | 1683911847910 Preamble successfully parsed
+     | 1683911847910 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847910 (RWo)
+     | 1683911847910 (RC)
+     | 1683911847911 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847911 Preamble is [198] bytes long
+     | 1683911847911 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847911 Still writing preamble
+     | 1683911847911 Wrote [198] bytes to the client
+     | 1683911847911 (W)
+     | 1683911847911 Writing back bytes
+     | 1683911847911 Wrote [13779] bytes to the client
+     | 1683911847911 (W)
+     | 1683911847911 Writing back bytes
+     | 1683911847911 Wrote [5] bytes to the client
+     | 1683911847911 (W)
+     | 1683911847911 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847911 (WKA)
+     | 1683911847911 Read [336] bytes from client
+     | 1683911847911 (R)
+     | 1683911847911 (RP)
+     | 1683911847911 Preamble successfully parsed
+     | 1683911847911 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847911 (RWo)
+     | 1683911847911 (RC)
+     | 1683911847912 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847912 Preamble is [198] bytes long
+     | 1683911847912 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847912 Still writing preamble
+     | 1683911847912 Wrote [198] bytes to the client
+     | 1683911847912 (W)
+     | 1683911847912 Writing back bytes
+     | 1683911847912 Wrote [13878] bytes to the client
+     | 1683911847912 (W)
+     | 1683911847912 Writing back bytes
+     | 1683911847912 Wrote [5] bytes to the client
+     | 1683911847912 (W)
+     | 1683911847912 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847912 (WKA)
+     | 1683911847912 Read [336] bytes from client
+     | 1683911847912 (R)
+     | 1683911847912 (RP)
+     | 1683911847913 Preamble successfully parsed
+     | 1683911847913 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847913 (RWo)
+     | 1683911847913 (RC)
+     | 1683911847914 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847914 Preamble is [198] bytes long
+     | 1683911847914 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847914 Still writing preamble
+     | 1683911847914 Wrote [198] bytes to the client
+     | 1683911847914 (W)
+     | 1683911847914 Writing back bytes
+     | 1683911847914 Wrote [13977] bytes to the client
+     | 1683911847914 (W)
+     | 1683911847914 Writing back bytes
+     | 1683911847914 Wrote [5] bytes to the client
+     | 1683911847914 (W)
+     | 1683911847914 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847914 (WKA)
+     | 1683911847914 Read [336] bytes from client
+     | 1683911847914 (R)
+     | 1683911847914 (RP)
+     | 1683911847914 Preamble successfully parsed
+     | 1683911847914 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847914 (RWo)
+     | 1683911847914 (RC)
+     | 1683911847915 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847915 Preamble is [198] bytes long
+     | 1683911847915 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847915 Still writing preamble
+     | 1683911847915 Wrote [198] bytes to the client
+     | 1683911847915 (W)
+     | 1683911847915 Writing back bytes
+     | 1683911847915 Wrote [14076] bytes to the client
+     | 1683911847915 (W)
+     | 1683911847915 Writing back bytes
+     | 1683911847915 Wrote [5] bytes to the client
+     | 1683911847915 (W)
+     | 1683911847915 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847915 (WKA)
+     | 1683911847915 Read [336] bytes from client
+     | 1683911847915 (R)
+     | 1683911847915 (RP)
+     | 1683911847915 Preamble successfully parsed
+     | 1683911847915 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847915 (RWo)
+     | 1683911847915 (RC)
+     | 1683911847916 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847916 Preamble is [198] bytes long
+     | 1683911847916 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847916 Still writing preamble
+     | 1683911847916 Wrote [198] bytes to the client
+     | 1683911847916 (W)
+     | 1683911847916 Writing back bytes
+     | 1683911847916 Wrote [14175] bytes to the client
+     | 1683911847916 (W)
+     | 1683911847916 Writing back bytes
+     | 1683911847916 Wrote [5] bytes to the client
+     | 1683911847916 (W)
+     | 1683911847916 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847916 (WKA)
+     | 1683911847916 Read [336] bytes from client
+     | 1683911847916 (R)
+     | 1683911847916 (RP)
+     | 1683911847917 Preamble successfully parsed
+     | 1683911847917 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847917 (RWo)
+     | 1683911847917 (RC)
+     | 1683911847917 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847917 Preamble is [198] bytes long
+     | 1683911847917 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847917 Still writing preamble
+     | 1683911847917 Wrote [198] bytes to the client
+     | 1683911847917 (W)
+     | 1683911847917 Writing back bytes
+     | 1683911847918 Wrote [14274] bytes to the client
+     | 1683911847918 (W)
+     | 1683911847918 Writing back bytes
+     | 1683911847918 Wrote [5] bytes to the client
+     | 1683911847918 (W)
+     | 1683911847918 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847918 (WKA)
+     | 1683911847918 Read [336] bytes from client
+     | 1683911847918 (R)
+     | 1683911847918 (RP)
+     | 1683911847918 Preamble successfully parsed
+     | 1683911847918 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847918 (RWo)
+     | 1683911847918 (RC)
+     | 1683911847919 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847919 Preamble is [198] bytes long
+     | 1683911847919 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847919 Still writing preamble
+     | 1683911847919 Wrote [198] bytes to the client
+     | 1683911847919 (W)
+     | 1683911847919 Writing back bytes
+     | 1683911847919 Wrote [14373] bytes to the client
+     | 1683911847919 (W)
+     | 1683911847919 Writing back bytes
+     | 1683911847919 Wrote [5] bytes to the client
+     | 1683911847919 (W)
+     | 1683911847919 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847919 (WKA)
+     | 1683911847919 Read [336] bytes from client
+     | 1683911847919 (R)
+     | 1683911847919 (RP)
+     | 1683911847919 Preamble successfully parsed
+     | 1683911847919 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847919 (RWo)
+     | 1683911847919 (RC)
+     | 1683911847920 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847920 Preamble is [198] bytes long
+     | 1683911847920 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847920 Still writing preamble
+     | 1683911847920 Wrote [198] bytes to the client
+     | 1683911847920 (W)
+     | 1683911847920 Writing back bytes
+     | 1683911847920 Wrote [14472] bytes to the client
+     | 1683911847920 (W)
+     | 1683911847920 Writing back bytes
+     | 1683911847920 Wrote [5] bytes to the client
+     | 1683911847920 (W)
+     | 1683911847920 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847920 (WKA)
+     | 1683911847920 Read [336] bytes from client
+     | 1683911847920 (R)
+     | 1683911847920 (RP)
+     | 1683911847921 Preamble successfully parsed
+     | 1683911847921 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847921 (RWo)
+     | 1683911847921 (RC)
+     | 1683911847921 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847921 Preamble is [198] bytes long
+     | 1683911847921 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847921 Still writing preamble
+     | 1683911847921 Wrote [198] bytes to the client
+     | 1683911847921 (W)
+     | 1683911847921 Writing back bytes
+     | 1683911847921 Wrote [14571] bytes to the client
+     | 1683911847921 (W)
+     | 1683911847921 Writing back bytes
+     | 1683911847921 Wrote [5] bytes to the client
+     | 1683911847921 (W)
+     | 1683911847921 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847921 (WKA)
+     | 1683911847922 Read [336] bytes from client
+     | 1683911847922 (R)
+     | 1683911847922 (RP)
+     | 1683911847922 Preamble successfully parsed
+     | 1683911847922 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847922 (RWo)
+     | 1683911847922 (RC)
+     | 1683911847923 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847923 Preamble is [198] bytes long
+     | 1683911847923 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847923 Still writing preamble
+     | 1683911847923 Wrote [198] bytes to the client
+     | 1683911847923 (W)
+     | 1683911847923 Writing back bytes
+     | 1683911847923 Wrote [14670] bytes to the client
+     | 1683911847923 (W)
+     | 1683911847923 Writing back bytes
+     | 1683911847923 Wrote [5] bytes to the client
+     | 1683911847923 (W)
+     | 1683911847923 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847923 (WKA)
+     | 1683911847923 Read [336] bytes from client
+     | 1683911847923 (R)
+     | 1683911847923 (RP)
+     | 1683911847923 Preamble successfully parsed
+     | 1683911847923 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847923 (RWo)
+     | 1683911847923 (RC)
+     | 1683911847924 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847924 Preamble is [198] bytes long
+     | 1683911847924 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847924 Still writing preamble
+     | 1683911847924 Wrote [198] bytes to the client
+     | 1683911847924 (W)
+     | 1683911847924 Writing back bytes
+     | 1683911847924 Wrote [14769] bytes to the client
+     | 1683911847924 (W)
+     | 1683911847924 Writing back bytes
+     | 1683911847924 Wrote [5] bytes to the client
+     | 1683911847924 (W)
+     | 1683911847924 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847924 (WKA)
+     | 1683911847924 Read [336] bytes from client
+     | 1683911847924 (R)
+     | 1683911847924 (RP)
+     | 1683911847924 Preamble successfully parsed
+     | 1683911847924 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847924 (RWo)
+     | 1683911847924 (RC)
+     | 1683911847925 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847925 Preamble is [198] bytes long
+     | 1683911847925 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847925 Still writing preamble
+     | 1683911847925 Wrote [198] bytes to the client
+     | 1683911847925 (W)
+     | 1683911847925 Writing back bytes
+     | 1683911847925 Wrote [14868] bytes to the client
+     | 1683911847925 (W)
+     | 1683911847925 Writing back bytes
+     | 1683911847925 Wrote [5] bytes to the client
+     | 1683911847925 (W)
+     | 1683911847925 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847925 (WKA)
+     | 1683911847926 Read [336] bytes from client
+     | 1683911847926 (R)
+     | 1683911847926 (RP)
+     | 1683911847926 Preamble successfully parsed
+     | 1683911847926 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847926 (RWo)
+     | 1683911847926 (RC)
+     | 1683911847927 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847927 Preamble is [198] bytes long
+     | 1683911847927 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847927 Still writing preamble
+     | 1683911847927 Wrote [198] bytes to the client
+     | 1683911847927 (W)
+     | 1683911847927 Writing back bytes
+     | 1683911847927 Wrote [14967] bytes to the client
+     | 1683911847927 (W)
+     | 1683911847927 Writing back bytes
+     | 1683911847927 Wrote [5] bytes to the client
+     | 1683911847927 (W)
+     | 1683911847927 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847927 (WKA)
+     | 1683911847927 Read [336] bytes from client
+     | 1683911847927 (R)
+     | 1683911847927 (RP)
+     | 1683911847927 Preamble successfully parsed
+     | 1683911847927 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847927 (RWo)
+     | 1683911847927 (RC)
+     | 1683911847928 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847928 Preamble is [198] bytes long
+     | 1683911847928 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847928 Still writing preamble
+     | 1683911847928 Wrote [198] bytes to the client
+     | 1683911847928 (W)
+     | 1683911847928 Writing back bytes
+     | 1683911847928 Wrote [15066] bytes to the client
+     | 1683911847928 (W)
+     | 1683911847928 Writing back bytes
+     | 1683911847928 Wrote [5] bytes to the client
+     | 1683911847928 (W)
+     | 1683911847928 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847928 (WKA)
+     | 1683911847928 Read [336] bytes from client
+     | 1683911847928 (R)
+     | 1683911847928 (RP)
+     | 1683911847928 Preamble successfully parsed
+     | 1683911847928 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847928 (RWo)
+     | 1683911847928 (RC)
+     | 1683911847929 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847929 Preamble is [198] bytes long
+     | 1683911847929 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847929 Still writing preamble
+     | 1683911847929 Wrote [198] bytes to the client
+     | 1683911847929 (W)
+     | 1683911847929 Writing back bytes
+     | 1683911847929 Wrote [15165] bytes to the client
+     | 1683911847929 (W)
+     | 1683911847929 Writing back bytes
+     | 1683911847929 Wrote [5] bytes to the client
+     | 1683911847929 (W)
+     | 1683911847929 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847929 (WKA)
+     | 1683911847929 Read [336] bytes from client
+     | 1683911847929 (R)
+     | 1683911847929 (RP)
+     | 1683911847929 Preamble successfully parsed
+     | 1683911847929 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847929 (RWo)
+     | 1683911847929 (RC)
+     | 1683911847930 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847930 Preamble is [198] bytes long
+     | 1683911847930 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847930 Still writing preamble
+     | 1683911847930 Wrote [198] bytes to the client
+     | 1683911847930 (W)
+     | 1683911847930 Writing back bytes
+     | 1683911847930 Wrote [15264] bytes to the client
+     | 1683911847930 (W)
+     | 1683911847930 Writing back bytes
+     | 1683911847930 Wrote [5] bytes to the client
+     | 1683911847930 (W)
+     | 1683911847930 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847930 (WKA)
+     | 1683911847930 Read [336] bytes from client
+     | 1683911847930 (R)
+     | 1683911847930 (RP)
+     | 1683911847931 Preamble successfully parsed
+     | 1683911847931 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847931 (RWo)
+     | 1683911847931 (RC)
+     | 1683911847931 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847931 Preamble is [198] bytes long
+     | 1683911847931 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847931 Still writing preamble
+     | 1683911847931 Wrote [198] bytes to the client
+     | 1683911847931 (W)
+     | 1683911847931 Writing back bytes
+     | 1683911847931 Wrote [15363] bytes to the client
+     | 1683911847931 (W)
+     | 1683911847931 Writing back bytes
+     | 1683911847931 Wrote [5] bytes to the client
+     | 1683911847931 (W)
+     | 1683911847931 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847931 (WKA)
+     | 1683911847932 Read [336] bytes from client
+     | 1683911847932 (R)
+     | 1683911847932 (RP)
+     | 1683911847932 Preamble successfully parsed
+     | 1683911847932 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847932 (RWo)
+     | 1683911847932 (RC)
+     | 1683911847933 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847933 Preamble is [198] bytes long
+     | 1683911847933 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847933 Still writing preamble
+     | 1683911847933 Wrote [198] bytes to the client
+     | 1683911847933 (W)
+     | 1683911847933 Writing back bytes
+     | 1683911847933 Wrote [15462] bytes to the client
+     | 1683911847933 (W)
+     | 1683911847933 Writing back bytes
+     | 1683911847933 Wrote [5] bytes to the client
+     | 1683911847933 (W)
+     | 1683911847933 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847933 (WKA)
+     | 1683911847933 Read [336] bytes from client
+     | 1683911847933 (R)
+     | 1683911847933 (RP)
+     | 1683911847933 Preamble successfully parsed
+     | 1683911847933 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847933 (RWo)
+     | 1683911847933 (RC)
+     | 1683911847934 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847934 Preamble is [198] bytes long
+     | 1683911847934 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847934 Still writing preamble
+     | 1683911847934 Wrote [198] bytes to the client
+     | 1683911847934 (W)
+     | 1683911847934 Writing back bytes
+     | 1683911847934 Wrote [15561] bytes to the client
+     | 1683911847934 (W)
+     | 1683911847934 Writing back bytes
+     | 1683911847934 Wrote [5] bytes to the client
+     | 1683911847934 (W)
+     | 1683911847934 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847934 (WKA)
+     | 1683911847934 Read [336] bytes from client
+     | 1683911847934 (R)
+     | 1683911847934 (RP)
+     | 1683911847934 Preamble successfully parsed
+     | 1683911847934 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847934 (RWo)
+     | 1683911847934 (RC)
+     | 1683911847935 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847935 Preamble is [198] bytes long
+     | 1683911847935 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847935 Still writing preamble
+     | 1683911847935 Wrote [198] bytes to the client
+     | 1683911847935 (W)
+     | 1683911847935 Writing back bytes
+     | 1683911847935 Wrote [15660] bytes to the client
+     | 1683911847935 (W)
+     | 1683911847935 Writing back bytes
+     | 1683911847935 Wrote [5] bytes to the client
+     | 1683911847935 (W)
+     | 1683911847935 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847935 (WKA)
+     | 1683911847935 Read [336] bytes from client
+     | 1683911847935 (R)
+     | 1683911847935 (RP)
+     | 1683911847935 Preamble successfully parsed
+     | 1683911847935 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847935 (RWo)
+     | 1683911847935 (RC)
+     | 1683911847936 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847936 Preamble is [198] bytes long
+     | 1683911847936 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847936 Still writing preamble
+     | 1683911847936 Wrote [198] bytes to the client
+     | 1683911847936 (W)
+     | 1683911847936 Writing back bytes
+     | 1683911847936 Wrote [15759] bytes to the client
+     | 1683911847936 (W)
+     | 1683911847936 Writing back bytes
+     | 1683911847936 Wrote [5] bytes to the client
+     | 1683911847936 (W)
+     | 1683911847936 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847936 (WKA)
+     | 1683911847936 Read [336] bytes from client
+     | 1683911847936 (R)
+     | 1683911847936 (RP)
+     | 1683911847936 Preamble successfully parsed
+     | 1683911847936 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847936 (RWo)
+     | 1683911847936 (RC)
+     | 1683911847937 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847937 Preamble is [198] bytes long
+     | 1683911847937 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847937 Still writing preamble
+     | 1683911847937 Wrote [198] bytes to the client
+     | 1683911847937 (W)
+     | 1683911847937 Writing back bytes
+     | 1683911847937 Wrote [15858] bytes to the client
+     | 1683911847937 (W)
+     | 1683911847937 Writing back bytes
+     | 1683911847937 Wrote [5] bytes to the client
+     | 1683911847937 (W)
+     | 1683911847937 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847937 (WKA)
+     | 1683911847938 Read [336] bytes from client
+     | 1683911847938 (R)
+     | 1683911847938 (RP)
+     | 1683911847938 Preamble successfully parsed
+     | 1683911847938 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847938 (RWo)
+     | 1683911847938 (RC)
+     | 1683911847938 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847938 Preamble is [198] bytes long
+     | 1683911847938 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847938 Still writing preamble
+     | 1683911847938 Wrote [198] bytes to the client
+     | 1683911847938 (W)
+     | 1683911847938 Writing back bytes
+     | 1683911847938 Wrote [15957] bytes to the client
+     | 1683911847938 (W)
+     | 1683911847938 Writing back bytes
+     | 1683911847938 Wrote [5] bytes to the client
+     | 1683911847938 (W)
+     | 1683911847938 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847938 (WKA)
+     | 1683911847939 Read [336] bytes from client
+     | 1683911847939 (R)
+     | 1683911847939 (RP)
+     | 1683911847939 Preamble successfully parsed
+     | 1683911847939 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847939 (RWo)
+     | 1683911847939 (RC)
+     | 1683911847939 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847940 Preamble is [198] bytes long
+     | 1683911847940 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847940 Still writing preamble
+     | 1683911847940 Wrote [198] bytes to the client
+     | 1683911847940 (W)
+     | 1683911847940 Writing back bytes
+     | 1683911847940 Wrote [16056] bytes to the client
+     | 1683911847940 (W)
+     | 1683911847940 Writing back bytes
+     | 1683911847940 Wrote [5] bytes to the client
+     | 1683911847940 (W)
+     | 1683911847940 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847940 (WKA)
+     | 1683911847940 Read [336] bytes from client
+     | 1683911847940 (R)
+     | 1683911847940 (RP)
+     | 1683911847940 Preamble successfully parsed
+     | 1683911847940 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847940 (RWo)
+     | 1683911847940 (RC)
+     | 1683911847941 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847941 Preamble is [198] bytes long
+     | 1683911847941 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847941 Still writing preamble
+     | 1683911847941 Wrote [198] bytes to the client
+     | 1683911847941 (W)
+     | 1683911847941 Writing back bytes
+     | 1683911847941 Wrote [16155] bytes to the client
+     | 1683911847941 (W)
+     | 1683911847941 Writing back bytes
+     | 1683911847941 Wrote [5] bytes to the client
+     | 1683911847941 (W)
+     | 1683911847941 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847941 (WKA)
+     | 1683911847941 Read [336] bytes from client
+     | 1683911847941 (R)
+     | 1683911847941 (RP)
+     | 1683911847941 Preamble successfully parsed
+     | 1683911847941 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847941 (RWo)
+     | 1683911847941 (RC)
+     | 1683911847942 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847942 Preamble is [198] bytes long
+     | 1683911847942 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847942 Still writing preamble
+     | 1683911847942 Wrote [198] bytes to the client
+     | 1683911847942 (W)
+     | 1683911847942 Writing back bytes
+     | 1683911847942 Wrote [16254] bytes to the client
+     | 1683911847942 (W)
+     | 1683911847942 Writing back bytes
+     | 1683911847942 Wrote [5] bytes to the client
+     | 1683911847942 (W)
+     | 1683911847942 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847942 (WKA)
+     | 1683911847942 Read [336] bytes from client
+     | 1683911847942 (R)
+     | 1683911847942 (RP)
+     | 1683911847942 Preamble successfully parsed
+     | 1683911847942 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847942 (RWo)
+     | 1683911847942 (RC)
+     | 1683911847943 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847943 Preamble is [198] bytes long
+     | 1683911847943 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847943 Still writing preamble
+     | 1683911847943 Wrote [198] bytes to the client
+     | 1683911847943 (W)
+     | 1683911847943 Writing back bytes
+     | 1683911847943 Wrote [16353] bytes to the client
+     | 1683911847943 (W)
+     | 1683911847943 Writing back bytes
+     | 1683911847943 Wrote [5] bytes to the client
+     | 1683911847943 (W)
+     | 1683911847943 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847943 (WKA)
+     | 1683911847944 Read [336] bytes from client
+     | 1683911847944 (R)
+     | 1683911847944 (RP)
+     | 1683911847944 Preamble successfully parsed
+     | 1683911847944 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847944 (RWo)
+     | 1683911847944 (RC)
+     | 1683911847945 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847945 Preamble is [198] bytes long
+     | 1683911847945 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847945 Still writing preamble
+     | 1683911847945 Wrote [198] bytes to the client
+     | 1683911847945 (W)
+     | 1683911847945 Writing back bytes
+     | 1683911847945 Wrote [16392] bytes to the client
+     | 1683911847945 (W)
+     | 1683911847945 Writing back bytes
+     | 1683911847945 Wrote [66] bytes to the client
+     | 1683911847945 (W)
+     | 1683911847945 Writing back bytes
+     | 1683911847945 Wrote [5] bytes to the client
+     | 1683911847945 (W)
+     | 1683911847945 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847945 (WKA)
+     | 1683911847945 Read [336] bytes from client
+     | 1683911847945 (R)
+     | 1683911847945 (RP)
+     | 1683911847945 Preamble successfully parsed
+     | 1683911847945 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847945 (RWo)
+     | 1683911847945 (RC)
+     | 1683911847946 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847946 Preamble is [198] bytes long
+     | 1683911847946 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847946 Still writing preamble
+     | 1683911847946 Wrote [198] bytes to the client
+     | 1683911847946 (W)
+     | 1683911847946 Writing back bytes
+     | 1683911847946 Wrote [16392] bytes to the client
+     | 1683911847946 (W)
+     | 1683911847946 Writing back bytes
+     | 1683911847946 Wrote [165] bytes to the client
+     | 1683911847946 (W)
+     | 1683911847946 Writing back bytes
+     | 1683911847946 Wrote [5] bytes to the client
+     | 1683911847946 (W)
+     | 1683911847946 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847946 (WKA)
+     | 1683911847947 Read [336] bytes from client
+     | 1683911847947 (R)
+     | 1683911847947 (RP)
+     | 1683911847947 Preamble successfully parsed
+     | 1683911847947 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847947 (RWo)
+     | 1683911847947 (RC)
+     | 1683911847947 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847947 Preamble is [198] bytes long
+     | 1683911847947 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847947 Still writing preamble
+     | 1683911847948 Wrote [198] bytes to the client
+     | 1683911847948 (W)
+     | 1683911847948 Writing back bytes
+     | 1683911847948 Wrote [16392] bytes to the client
+     | 1683911847948 (W)
+     | 1683911847948 Writing back bytes
+     | 1683911847948 Wrote [265] bytes to the client
+     | 1683911847948 (W)
+     | 1683911847948 Writing back bytes
+     | 1683911847948 Wrote [5] bytes to the client
+     | 1683911847948 (W)
+     | 1683911847948 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847948 (WKA)
+     | 1683911847948 Read [336] bytes from client
+     | 1683911847948 (R)
+     | 1683911847948 (RP)
+     | 1683911847948 Preamble successfully parsed
+     | 1683911847948 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847948 (RWo)
+     | 1683911847948 (RC)
+     | 1683911847949 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847949 Preamble is [198] bytes long
+     | 1683911847949 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847949 Still writing preamble
+     | 1683911847949 Wrote [198] bytes to the client
+     | 1683911847949 (W)
+     | 1683911847949 Writing back bytes
+     | 1683911847949 Wrote [16392] bytes to the client
+     | 1683911847949 (W)
+     | 1683911847949 Writing back bytes
+     | 1683911847949 Wrote [364] bytes to the client
+     | 1683911847949 (W)
+     | 1683911847949 Writing back bytes
+     | 1683911847949 Wrote [5] bytes to the client
+     | 1683911847949 (W)
+     | 1683911847949 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847949 (WKA)
+     | 1683911847949 Read [336] bytes from client
+     | 1683911847949 (R)
+     | 1683911847949 (RP)
+     | 1683911847949 Preamble successfully parsed
+     | 1683911847949 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847949 (RWo)
+     | 1683911847949 (RC)
+     | 1683911847950 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847950 Preamble is [198] bytes long
+     | 1683911847950 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847950 Still writing preamble
+     | 1683911847950 Wrote [198] bytes to the client
+     | 1683911847950 (W)
+     | 1683911847950 Writing back bytes
+     | 1683911847950 Wrote [16392] bytes to the client
+     | 1683911847950 (W)
+     | 1683911847950 Writing back bytes
+     | 1683911847950 Wrote [463] bytes to the client
+     | 1683911847950 (W)
+     | 1683911847950 Writing back bytes
+     | 1683911847950 Wrote [5] bytes to the client
+     | 1683911847950 (W)
+     | 1683911847950 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847950 (WKA)
+     | 1683911847950 Read [336] bytes from client
+     | 1683911847950 (R)
+     | 1683911847950 (RP)
+     | 1683911847951 Preamble successfully parsed
+     | 1683911847951 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847951 (RWo)
+     | 1683911847951 (RC)
+     | 1683911847952 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847952 Preamble is [198] bytes long
+     | 1683911847952 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847952 Still writing preamble
+     | 1683911847952 Wrote [198] bytes to the client
+     | 1683911847952 (W)
+     | 1683911847952 Writing back bytes
+     | 1683911847952 Wrote [16392] bytes to the client
+     | 1683911847952 (W)
+     | 1683911847952 Writing back bytes
+     | 1683911847952 Wrote [562] bytes to the client
+     | 1683911847952 (W)
+     | 1683911847952 Writing back bytes
+     | 1683911847952 Wrote [5] bytes to the client
+     | 1683911847952 (W)
+     | 1683911847952 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847952 (WKA)
+     | 1683911847952 Read [336] bytes from client
+     | 1683911847952 (R)
+     | 1683911847952 (RP)
+     | 1683911847952 Preamble successfully parsed
+     | 1683911847952 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847952 (RWo)
+     | 1683911847952 (RC)
+     | 1683911847953 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847953 Preamble is [198] bytes long
+     | 1683911847953 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847953 Still writing preamble
+     | 1683911847953 Wrote [198] bytes to the client
+     | 1683911847953 (W)
+     | 1683911847953 Writing back bytes
+     | 1683911847953 Wrote [16392] bytes to the client
+     | 1683911847953 (W)
+     | 1683911847953 Writing back bytes
+     | 1683911847953 Wrote [661] bytes to the client
+     | 1683911847953 (W)
+     | 1683911847953 Writing back bytes
+     | 1683911847953 Wrote [5] bytes to the client
+     | 1683911847953 (W)
+     | 1683911847953 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847953 (WKA)
+     | 1683911847953 Read [336] bytes from client
+     | 1683911847953 (R)
+     | 1683911847953 (RP)
+     | 1683911847954 Preamble successfully parsed
+     | 1683911847954 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847954 (RWo)
+     | 1683911847954 (RC)
+     | 1683911847954 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847954 Preamble is [198] bytes long
+     | 1683911847954 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847954 Still writing preamble
+     | 1683911847954 Wrote [198] bytes to the client
+     | 1683911847954 (W)
+     | 1683911847954 Writing back bytes
+     | 1683911847954 Wrote [16392] bytes to the client
+     | 1683911847954 (W)
+     | 1683911847954 Writing back bytes
+     | 1683911847954 Wrote [760] bytes to the client
+     | 1683911847954 (W)
+     | 1683911847954 Writing back bytes
+     | 1683911847955 Wrote [5] bytes to the client
+     | 1683911847955 (W)
+     | 1683911847955 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847955 (WKA)
+     | 1683911847955 Read [336] bytes from client
+     | 1683911847955 (R)
+     | 1683911847955 (RP)
+     | 1683911847955 Preamble successfully parsed
+     | 1683911847955 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847955 (RWo)
+     | 1683911847955 (RC)
+     | 1683911847956 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847956 Preamble is [198] bytes long
+     | 1683911847956 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847956 Still writing preamble
+     | 1683911847956 Wrote [198] bytes to the client
+     | 1683911847956 (W)
+     | 1683911847956 Writing back bytes
+     | 1683911847956 Wrote [16392] bytes to the client
+     | 1683911847956 (W)
+     | 1683911847956 Writing back bytes
+     | 1683911847956 Wrote [859] bytes to the client
+     | 1683911847956 (W)
+     | 1683911847956 Writing back bytes
+     | 1683911847956 Wrote [5] bytes to the client
+     | 1683911847956 (W)
+     | 1683911847956 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847956 (WKA)
+     | 1683911847956 Read [336] bytes from client
+     | 1683911847956 (R)
+     | 1683911847956 (RP)
+     | 1683911847956 Preamble successfully parsed
+     | 1683911847956 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847956 (RWo)
+     | 1683911847956 (RC)
+     | 1683911847957 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847957 Preamble is [198] bytes long
+     | 1683911847957 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847957 Still writing preamble
+     | 1683911847957 Wrote [198] bytes to the client
+     | 1683911847957 (W)
+     | 1683911847957 Writing back bytes
+     | 1683911847957 Wrote [16392] bytes to the client
+     | 1683911847957 (W)
+     | 1683911847957 Writing back bytes
+     | 1683911847957 Wrote [958] bytes to the client
+     | 1683911847957 (W)
+     | 1683911847957 Writing back bytes
+     | 1683911847957 Wrote [5] bytes to the client
+     | 1683911847957 (W)
+     | 1683911847957 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847957 (WKA)
+     | 1683911847958 Read [336] bytes from client
+     | 1683911847958 (R)
+     | 1683911847958 (RP)
+     | 1683911847958 Preamble successfully parsed
+     | 1683911847958 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847958 (RWo)
+     | 1683911847958 (RC)
+     | 1683911847959 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847959 Preamble is [198] bytes long
+     | 1683911847959 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847959 Still writing preamble
+     | 1683911847959 Wrote [198] bytes to the client
+     | 1683911847959 (W)
+     | 1683911847959 Writing back bytes
+     | 1683911847959 Wrote [16392] bytes to the client
+     | 1683911847959 (W)
+     | 1683911847959 Writing back bytes
+     | 1683911847959 Wrote [1057] bytes to the client
+     | 1683911847959 (W)
+     | 1683911847959 Writing back bytes
+     | 1683911847959 Wrote [5] bytes to the client
+     | 1683911847959 (W)
+     | 1683911847959 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847959 (WKA)
+     | 1683911847959 Read [336] bytes from client
+     | 1683911847959 (R)
+     | 1683911847959 (RP)
+     | 1683911847959 Preamble successfully parsed
+     | 1683911847959 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847959 (RWo)
+     | 1683911847959 (RC)
+     | 1683911847960 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847960 Preamble is [198] bytes long
+     | 1683911847960 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847960 Still writing preamble
+     | 1683911847960 Wrote [198] bytes to the client
+     | 1683911847960 (W)
+     | 1683911847960 Writing back bytes
+     | 1683911847960 Wrote [16392] bytes to the client
+     | 1683911847960 (W)
+     | 1683911847960 Writing back bytes
+     | 1683911847960 Wrote [1156] bytes to the client
+     | 1683911847960 (W)
+     | 1683911847960 Writing back bytes
+     | 1683911847960 Wrote [5] bytes to the client
+     | 1683911847960 (W)
+     | 1683911847960 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847960 (WKA)
+     | 1683911847960 Read [336] bytes from client
+     | 1683911847960 (R)
+     | 1683911847960 (RP)
+     | 1683911847961 Preamble successfully parsed
+     | 1683911847961 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847961 (RWo)
+     | 1683911847961 (RC)
+     | 1683911847961 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847961 Preamble is [198] bytes long
+     | 1683911847961 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847961 Still writing preamble
+     | 1683911847961 Wrote [198] bytes to the client
+     | 1683911847961 (W)
+     | 1683911847961 Writing back bytes
+     | 1683911847961 Wrote [16392] bytes to the client
+     | 1683911847961 (W)
+     | 1683911847961 Writing back bytes
+     | 1683911847961 Wrote [1255] bytes to the client
+     | 1683911847961 (W)
+     | 1683911847961 Writing back bytes
+     | 1683911847961 Wrote [5] bytes to the client
+     | 1683911847961 (W)
+     | 1683911847961 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847961 (WKA)
+     | 1683911847962 Read [336] bytes from client
+     | 1683911847962 (R)
+     | 1683911847962 (RP)
+     | 1683911847962 Preamble successfully parsed
+     | 1683911847962 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847962 (RWo)
+     | 1683911847962 (RC)
+     | 1683911847963 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847963 Preamble is [198] bytes long
+     | 1683911847963 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847963 Still writing preamble
+     | 1683911847963 Wrote [198] bytes to the client
+     | 1683911847963 (W)
+     | 1683911847963 Writing back bytes
+     | 1683911847963 Wrote [16392] bytes to the client
+     | 1683911847963 (W)
+     | 1683911847963 Writing back bytes
+     | 1683911847963 Wrote [1354] bytes to the client
+     | 1683911847963 (W)
+     | 1683911847963 Writing back bytes
+     | 1683911847963 Wrote [5] bytes to the client
+     | 1683911847963 (W)
+     | 1683911847963 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847963 (WKA)
+     | 1683911847963 Read [336] bytes from client
+     | 1683911847963 (R)
+     | 1683911847963 (RP)
+     | 1683911847963 Preamble successfully parsed
+     | 1683911847963 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847963 (RWo)
+     | 1683911847963 (RC)
+     | 1683911847964 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847964 Preamble is [198] bytes long
+     | 1683911847964 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847964 Still writing preamble
+     | 1683911847964 Wrote [198] bytes to the client
+     | 1683911847964 (W)
+     | 1683911847964 Writing back bytes
+     | 1683911847964 Wrote [16392] bytes to the client
+     | 1683911847964 (W)
+     | 1683911847964 Writing back bytes
+     | 1683911847964 Wrote [1453] bytes to the client
+     | 1683911847964 (W)
+     | 1683911847964 Writing back bytes
+     | 1683911847964 Wrote [5] bytes to the client
+     | 1683911847964 (W)
+     | 1683911847964 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847964 (WKA)
+     | 1683911847965 Read [336] bytes from client
+     | 1683911847965 (R)
+     | 1683911847965 (RP)
+     | 1683911847965 Preamble successfully parsed
+     | 1683911847965 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847965 (RWo)
+     | 1683911847965 (RC)
+     | 1683911847966 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847966 Preamble is [198] bytes long
+     | 1683911847966 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847966 Still writing preamble
+     | 1683911847966 Wrote [198] bytes to the client
+     | 1683911847966 (W)
+     | 1683911847966 Writing back bytes
+     | 1683911847966 Wrote [16392] bytes to the client
+     | 1683911847966 (W)
+     | 1683911847966 Writing back bytes
+     | 1683911847966 Wrote [1552] bytes to the client
+     | 1683911847966 (W)
+     | 1683911847966 Writing back bytes
+     | 1683911847966 Wrote [5] bytes to the client
+     | 1683911847966 (W)
+     | 1683911847966 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847966 (WKA)
+     | 1683911847966 Read [336] bytes from client
+     | 1683911847966 (R)
+     | 1683911847966 (RP)
+     | 1683911847966 Preamble successfully parsed
+     | 1683911847966 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847966 (RWo)
+     | 1683911847966 (RC)
+     | 1683911847967 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847967 Preamble is [198] bytes long
+     | 1683911847967 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847967 Still writing preamble
+     | 1683911847967 Wrote [198] bytes to the client
+     | 1683911847967 (W)
+     | 1683911847967 Writing back bytes
+     | 1683911847967 Wrote [16392] bytes to the client
+     | 1683911847967 (W)
+     | 1683911847967 Writing back bytes
+     | 1683911847967 Wrote [1651] bytes to the client
+     | 1683911847967 (W)
+     | 1683911847967 Writing back bytes
+     | 1683911847967 Wrote [5] bytes to the client
+     | 1683911847967 (W)
+     | 1683911847967 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847967 (WKA)
+     | 1683911847967 Read [336] bytes from client
+     | 1683911847967 (R)
+     | 1683911847967 (RP)
+     | 1683911847967 Preamble successfully parsed
+     | 1683911847967 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847967 (RWo)
+     | 1683911847967 (RC)
+     | 1683911847968 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847968 Preamble is [198] bytes long
+     | 1683911847968 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847968 Still writing preamble
+     | 1683911847968 Wrote [198] bytes to the client
+     | 1683911847968 (W)
+     | 1683911847968 Writing back bytes
+     | 1683911847968 Wrote [16392] bytes to the client
+     | 1683911847968 (W)
+     | 1683911847968 Writing back bytes
+     | 1683911847968 Wrote [1750] bytes to the client
+     | 1683911847968 (W)
+     | 1683911847968 Writing back bytes
+     | 1683911847968 Wrote [5] bytes to the client
+     | 1683911847968 (W)
+     | 1683911847968 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847968 (WKA)
+     | 1683911847969 Read [336] bytes from client
+     | 1683911847969 (R)
+     | 1683911847969 (RP)
+     | 1683911847969 Preamble successfully parsed
+     | 1683911847969 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847969 (RWo)
+     | 1683911847969 (RC)
+     | 1683911847969 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847970 Preamble is [198] bytes long
+     | 1683911847970 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847970 Still writing preamble
+     | 1683911847970 Wrote [198] bytes to the client
+     | 1683911847970 (W)
+     | 1683911847970 Writing back bytes
+     | 1683911847970 Wrote [16392] bytes to the client
+     | 1683911847970 (W)
+     | 1683911847970 Writing back bytes
+     | 1683911847970 Wrote [1849] bytes to the client
+     | 1683911847970 (W)
+     | 1683911847970 Writing back bytes
+     | 1683911847970 Wrote [5] bytes to the client
+     | 1683911847970 (W)
+     | 1683911847970 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847970 (WKA)
+     | 1683911847970 Read [336] bytes from client
+     | 1683911847970 (R)
+     | 1683911847970 (RP)
+     | 1683911847970 Preamble successfully parsed
+     | 1683911847970 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847970 (RWo)
+     | 1683911847970 (RC)
+     | 1683911847971 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847971 Preamble is [198] bytes long
+     | 1683911847971 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847971 Still writing preamble
+     | 1683911847971 Wrote [198] bytes to the client
+     | 1683911847971 (W)
+     | 1683911847971 Writing back bytes
+     | 1683911847971 Wrote [16392] bytes to the client
+     | 1683911847971 (W)
+     | 1683911847971 Writing back bytes
+     | 1683911847971 Wrote [1948] bytes to the client
+     | 1683911847971 (W)
+     | 1683911847971 Writing back bytes
+     | 1683911847971 Wrote [5] bytes to the client
+     | 1683911847971 (W)
+     | 1683911847971 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847971 (WKA)
+     | 1683911847971 Read [336] bytes from client
+     | 1683911847971 (R)
+     | 1683911847971 (RP)
+     | 1683911847971 Preamble successfully parsed
+     | 1683911847971 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847971 (RWo)
+     | 1683911847971 (RC)
+     | 1683911847972 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847972 Preamble is [198] bytes long
+     | 1683911847972 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847972 Still writing preamble
+     | 1683911847972 Wrote [198] bytes to the client
+     | 1683911847972 (W)
+     | 1683911847972 Writing back bytes
+     | 1683911847972 Wrote [16392] bytes to the client
+     | 1683911847972 (W)
+     | 1683911847972 Writing back bytes
+     | 1683911847972 Wrote [2047] bytes to the client
+     | 1683911847972 (W)
+     | 1683911847972 Writing back bytes
+     | 1683911847972 Wrote [5] bytes to the client
+     | 1683911847972 (W)
+     | 1683911847972 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847972 (WKA)
+     | 1683911847973 Read [336] bytes from client
+     | 1683911847973 (R)
+     | 1683911847973 (RP)
+     | 1683911847973 Preamble successfully parsed
+     | 1683911847973 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847973 (RWo)
+     | 1683911847973 (RC)
+     | 1683911847974 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847974 Preamble is [198] bytes long
+     | 1683911847974 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847974 Still writing preamble
+     | 1683911847974 Wrote [198] bytes to the client
+     | 1683911847974 (W)
+     | 1683911847974 Writing back bytes
+     | 1683911847974 Wrote [16392] bytes to the client
+     | 1683911847974 (W)
+     | 1683911847974 Writing back bytes
+     | 1683911847974 Wrote [2146] bytes to the client
+     | 1683911847974 (W)
+     | 1683911847974 Writing back bytes
+     | 1683911847974 Wrote [5] bytes to the client
+     | 1683911847974 (W)
+     | 1683911847974 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847974 (WKA)
+     | 1683911847974 Read [336] bytes from client
+     | 1683911847974 (R)
+     | 1683911847974 (RP)
+     | 1683911847974 Preamble successfully parsed
+     | 1683911847974 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847974 (RWo)
+     | 1683911847974 (RC)
+     | 1683911847975 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847975 Preamble is [198] bytes long
+     | 1683911847975 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847975 Still writing preamble
+     | 1683911847975 Wrote [198] bytes to the client
+     | 1683911847975 (W)
+     | 1683911847975 Writing back bytes
+     | 1683911847975 Wrote [16392] bytes to the client
+     | 1683911847975 (W)
+     | 1683911847975 Writing back bytes
+     | 1683911847975 Wrote [2245] bytes to the client
+     | 1683911847975 (W)
+     | 1683911847975 Writing back bytes
+     | 1683911847975 Wrote [5] bytes to the client
+     | 1683911847975 (W)
+     | 1683911847975 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847975 (WKA)
+     | 1683911847975 Read [336] bytes from client
+     | 1683911847975 (R)
+     | 1683911847975 (RP)
+     | 1683911847976 Preamble successfully parsed
+     | 1683911847976 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847976 (RWo)
+     | 1683911847976 (RC)
+     | 1683911847976 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847976 Preamble is [198] bytes long
+     | 1683911847976 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847976 Still writing preamble
+     | 1683911847976 Wrote [198] bytes to the client
+     | 1683911847976 (W)
+     | 1683911847976 Writing back bytes
+     | 1683911847976 Wrote [16392] bytes to the client
+     | 1683911847976 (W)
+     | 1683911847976 Writing back bytes
+     | 1683911847976 Wrote [2344] bytes to the client
+     | 1683911847976 (W)
+     | 1683911847976 Writing back bytes
+     | 1683911847976 Wrote [5] bytes to the client
+     | 1683911847976 (W)
+     | 1683911847976 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847976 (WKA)
+     | 1683911847977 Read [336] bytes from client
+     | 1683911847977 (R)
+     | 1683911847977 (RP)
+     | 1683911847977 Preamble successfully parsed
+     | 1683911847977 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847977 (RWo)
+     | 1683911847977 (RC)
+     | 1683911847978 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847978 Preamble is [198] bytes long
+     | 1683911847978 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847978 Still writing preamble
+     | 1683911847978 Wrote [198] bytes to the client
+     | 1683911847978 (W)
+     | 1683911847978 Writing back bytes
+     | 1683911847978 Wrote [16392] bytes to the client
+     | 1683911847978 (W)
+     | 1683911847978 Writing back bytes
+     | 1683911847978 Wrote [2443] bytes to the client
+     | 1683911847978 (W)
+     | 1683911847978 Writing back bytes
+     | 1683911847978 Wrote [5] bytes to the client
+     | 1683911847978 (W)
+     | 1683911847978 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847978 (WKA)
+     | 1683911847978 Read [336] bytes from client
+     | 1683911847978 (R)
+     | 1683911847978 (RP)
+     | 1683911847978 Preamble successfully parsed
+     | 1683911847978 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847978 (RWo)
+     | 1683911847978 (RC)
+     | 1683911847979 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847979 Preamble is [198] bytes long
+     | 1683911847979 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847979 Still writing preamble
+     | 1683911847979 Wrote [198] bytes to the client
+     | 1683911847979 (W)
+     | 1683911847979 Writing back bytes
+     | 1683911847979 Wrote [16392] bytes to the client
+     | 1683911847979 (W)
+     | 1683911847979 Writing back bytes
+     | 1683911847979 Wrote [2542] bytes to the client
+     | 1683911847979 (W)
+     | 1683911847979 Writing back bytes
+     | 1683911847979 Wrote [5] bytes to the client
+     | 1683911847979 (W)
+     | 1683911847979 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847979 (WKA)
+     | 1683911847979 Read [336] bytes from client
+     | 1683911847979 (R)
+     | 1683911847979 (RP)
+     | 1683911847979 Preamble successfully parsed
+     | 1683911847979 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847979 (RWo)
+     | 1683911847979 (RC)
+     | 1683911847980 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847980 Preamble is [198] bytes long
+     | 1683911847980 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847980 Still writing preamble
+     | 1683911847980 Wrote [198] bytes to the client
+     | 1683911847980 (W)
+     | 1683911847980 Writing back bytes
+     | 1683911847980 Wrote [16392] bytes to the client
+     | 1683911847980 (W)
+     | 1683911847980 Writing back bytes
+     | 1683911847980 Wrote [2641] bytes to the client
+     | 1683911847980 (W)
+     | 1683911847980 Writing back bytes
+     | 1683911847980 Wrote [5] bytes to the client
+     | 1683911847980 (W)
+     | 1683911847980 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847980 (WKA)
+     | 1683911847981 Read [336] bytes from client
+     | 1683911847981 (R)
+     | 1683911847981 (RP)
+     | 1683911847981 Preamble successfully parsed
+     | 1683911847981 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847981 (RWo)
+     | 1683911847981 (RC)
+     | 1683911847982 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847982 Preamble is [198] bytes long
+     | 1683911847982 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847982 Still writing preamble
+     | 1683911847982 Wrote [198] bytes to the client
+     | 1683911847982 (W)
+     | 1683911847982 Writing back bytes
+     | 1683911847982 Wrote [16392] bytes to the client
+     | 1683911847982 (W)
+     | 1683911847982 Writing back bytes
+     | 1683911847982 Wrote [2740] bytes to the client
+     | 1683911847982 (W)
+     | 1683911847982 Writing back bytes
+     | 1683911847982 Wrote [5] bytes to the client
+     | 1683911847982 (W)
+     | 1683911847982 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847982 (WKA)
+     | 1683911847982 Read [336] bytes from client
+     | 1683911847982 (R)
+     | 1683911847982 (RP)
+     | 1683911847982 Preamble successfully parsed
+     | 1683911847982 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847982 (RWo)
+     | 1683911847982 (RC)
+     | 1683911847983 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847983 Preamble is [198] bytes long
+     | 1683911847983 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847983 Still writing preamble
+     | 1683911847983 Wrote [198] bytes to the client
+     | 1683911847983 (W)
+     | 1683911847983 Writing back bytes
+     | 1683911847983 Wrote [16392] bytes to the client
+     | 1683911847983 (W)
+     | 1683911847983 Writing back bytes
+     | 1683911847983 Wrote [2839] bytes to the client
+     | 1683911847983 (W)
+     | 1683911847983 Writing back bytes
+     | 1683911847983 Wrote [5] bytes to the client
+     | 1683911847983 (W)
+     | 1683911847983 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847983 (WKA)
+     | 1683911847983 Read [336] bytes from client
+     | 1683911847983 (R)
+     | 1683911847983 (RP)
+     | 1683911847983 Preamble successfully parsed
+     | 1683911847983 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847983 (RWo)
+     | 1683911847983 (RC)
+     | 1683911847984 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847984 Preamble is [198] bytes long
+     | 1683911847984 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847984 Still writing preamble
+     | 1683911847984 Wrote [198] bytes to the client
+     | 1683911847984 (W)
+     | 1683911847984 Writing back bytes
+     | 1683911847984 Wrote [16392] bytes to the client
+     | 1683911847984 (W)
+     | 1683911847984 Writing back bytes
+     | 1683911847984 Wrote [2938] bytes to the client
+     | 1683911847984 (W)
+     | 1683911847984 Writing back bytes
+     | 1683911847984 Wrote [5] bytes to the client
+     | 1683911847984 (W)
+     | 1683911847984 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847984 (WKA)
+     | 1683911847985 Read [336] bytes from client
+     | 1683911847985 (R)
+     | 1683911847985 (RP)
+     | 1683911847985 Preamble successfully parsed
+     | 1683911847985 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847985 (RWo)
+     | 1683911847985 (RC)
+     | 1683911847985 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847985 Preamble is [198] bytes long
+     | 1683911847985 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847985 Still writing preamble
+     | 1683911847985 Wrote [198] bytes to the client
+     | 1683911847985 (W)
+     | 1683911847985 Writing back bytes
+     | 1683911847985 Wrote [16392] bytes to the client
+     | 1683911847985 (W)
+     | 1683911847985 Writing back bytes
+     | 1683911847985 Wrote [3037] bytes to the client
+     | 1683911847985 (W)
+     | 1683911847985 Writing back bytes
+     | 1683911847985 Wrote [5] bytes to the client
+     | 1683911847985 (W)
+     | 1683911847985 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847985 (WKA)
+     | 1683911847986 Read [336] bytes from client
+     | 1683911847986 (R)
+     | 1683911847986 (RP)
+     | 1683911847986 Preamble successfully parsed
+     | 1683911847986 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847986 (RWo)
+     | 1683911847986 (RC)
+     | 1683911847987 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847987 Preamble is [198] bytes long
+     | 1683911847987 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847987 Still writing preamble
+     | 1683911847987 Wrote [198] bytes to the client
+     | 1683911847987 (W)
+     | 1683911847987 Writing back bytes
+     | 1683911847987 Wrote [16392] bytes to the client
+     | 1683911847987 (W)
+     | 1683911847987 Writing back bytes
+     | 1683911847987 Wrote [3136] bytes to the client
+     | 1683911847987 (W)
+     | 1683911847987 Writing back bytes
+     | 1683911847987 Wrote [5] bytes to the client
+     | 1683911847987 (W)
+     | 1683911847987 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847987 (WKA)
+     | 1683911847987 Read [336] bytes from client
+     | 1683911847987 (R)
+     | 1683911847987 (RP)
+     | 1683911847987 Preamble successfully parsed
+     | 1683911847987 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847987 (RWo)
+     | 1683911847987 (RC)
+     | 1683911847988 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847988 Preamble is [198] bytes long
+     | 1683911847988 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847988 Still writing preamble
+     | 1683911847988 Wrote [198] bytes to the client
+     | 1683911847988 (W)
+     | 1683911847988 Writing back bytes
+     | 1683911847988 Wrote [16392] bytes to the client
+     | 1683911847988 (W)
+     | 1683911847988 Writing back bytes
+     | 1683911847988 Wrote [3235] bytes to the client
+     | 1683911847988 (W)
+     | 1683911847988 Writing back bytes
+     | 1683911847988 Wrote [5] bytes to the client
+     | 1683911847988 (W)
+     | 1683911847988 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847988 (WKA)
+     | 1683911847988 Read [336] bytes from client
+     | 1683911847988 (R)
+     | 1683911847988 (RP)
+     | 1683911847988 Preamble successfully parsed
+     | 1683911847988 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847988 (RWo)
+     | 1683911847988 (RC)
+     | 1683911847989 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847989 Preamble is [198] bytes long
+     | 1683911847989 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847989 Still writing preamble
+     | 1683911847989 Wrote [198] bytes to the client
+     | 1683911847989 (W)
+     | 1683911847989 Writing back bytes
+     | 1683911847989 Wrote [16392] bytes to the client
+     | 1683911847989 (W)
+     | 1683911847989 Writing back bytes
+     | 1683911847989 Wrote [3334] bytes to the client
+     | 1683911847989 (W)
+     | 1683911847989 Writing back bytes
+     | 1683911847989 Wrote [5] bytes to the client
+     | 1683911847989 (W)
+     | 1683911847989 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847989 (WKA)
+     | 1683911847990 Read [336] bytes from client
+     | 1683911847990 (R)
+     | 1683911847990 (RP)
+     | 1683911847990 Preamble successfully parsed
+     | 1683911847990 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847990 (RWo)
+     | 1683911847990 (RC)
+     | 1683911847991 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847991 Preamble is [198] bytes long
+     | 1683911847991 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847991 Still writing preamble
+     | 1683911847991 Wrote [198] bytes to the client
+     | 1683911847991 (W)
+     | 1683911847991 Writing back bytes
+     | 1683911847991 Wrote [16392] bytes to the client
+     | 1683911847991 (W)
+     | 1683911847991 Writing back bytes
+     | 1683911847991 Wrote [3433] bytes to the client
+     | 1683911847991 (W)
+     | 1683911847991 Writing back bytes
+     | 1683911847991 Wrote [5] bytes to the client
+     | 1683911847991 (W)
+     | 1683911847991 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847991 (WKA)
+     | 1683911847991 Read [336] bytes from client
+     | 1683911847991 (R)
+     | 1683911847991 (RP)
+     | 1683911847991 Preamble successfully parsed
+     | 1683911847991 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847991 (RWo)
+     | 1683911847991 (RC)
+     | 1683911847992 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847992 Preamble is [198] bytes long
+     | 1683911847992 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847992 Still writing preamble
+     | 1683911847992 Wrote [198] bytes to the client
+     | 1683911847992 (W)
+     | 1683911847992 Writing back bytes
+     | 1683911847992 Wrote [16392] bytes to the client
+     | 1683911847992 (W)
+     | 1683911847992 Writing back bytes
+     | 1683911847992 Wrote [3532] bytes to the client
+     | 1683911847992 (W)
+     | 1683911847992 Writing back bytes
+     | 1683911847992 Wrote [5] bytes to the client
+     | 1683911847992 (W)
+     | 1683911847992 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847992 (WKA)
+     | 1683911847992 Read [336] bytes from client
+     | 1683911847992 (R)
+     | 1683911847992 (RP)
+     | 1683911847992 Preamble successfully parsed
+     | 1683911847992 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847992 (RWo)
+     | 1683911847992 (RC)
+     | 1683911847993 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847993 Preamble is [198] bytes long
+     | 1683911847993 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847993 Still writing preamble
+     | 1683911847993 Wrote [198] bytes to the client
+     | 1683911847993 (W)
+     | 1683911847993 Writing back bytes
+     | 1683911847993 Wrote [16392] bytes to the client
+     | 1683911847993 (W)
+     | 1683911847993 Writing back bytes
+     | 1683911847993 Wrote [3631] bytes to the client
+     | 1683911847993 (W)
+     | 1683911847993 Writing back bytes
+     | 1683911847993 Wrote [5] bytes to the client
+     | 1683911847993 (W)
+     | 1683911847993 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847993 (WKA)
+     | 1683911847993 Read [336] bytes from client
+     | 1683911847993 (R)
+     | 1683911847993 (RP)
+     | 1683911847994 Preamble successfully parsed
+     | 1683911847994 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847994 (RWo)
+     | 1683911847994 (RC)
+     | 1683911847994 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847994 Preamble is [198] bytes long
+     | 1683911847994 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847994 Still writing preamble
+     | 1683911847994 Wrote [198] bytes to the client
+     | 1683911847994 (W)
+     | 1683911847994 Writing back bytes
+     | 1683911847994 Wrote [16392] bytes to the client
+     | 1683911847994 (W)
+     | 1683911847994 Writing back bytes
+     | 1683911847994 Wrote [3730] bytes to the client
+     | 1683911847994 (W)
+     | 1683911847994 Writing back bytes
+     | 1683911847994 Wrote [5] bytes to the client
+     | 1683911847994 (W)
+     | 1683911847994 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847994 (WKA)
+     | 1683911847995 Read [336] bytes from client
+     | 1683911847995 (R)
+     | 1683911847995 (RP)
+     | 1683911847995 Preamble successfully parsed
+     | 1683911847995 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847995 (RWo)
+     | 1683911847995 (RC)
+     | 1683911847996 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847996 Preamble is [198] bytes long
+     | 1683911847996 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847996 Still writing preamble
+     | 1683911847996 Wrote [198] bytes to the client
+     | 1683911847996 (W)
+     | 1683911847996 Writing back bytes
+     | 1683911847996 Wrote [16392] bytes to the client
+     | 1683911847996 (W)
+     | 1683911847996 Writing back bytes
+     | 1683911847996 Wrote [3829] bytes to the client
+     | 1683911847996 (W)
+     | 1683911847996 Writing back bytes
+     | 1683911847996 Wrote [5] bytes to the client
+     | 1683911847996 (W)
+     | 1683911847996 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847996 (WKA)
+     | 1683911847996 Read [336] bytes from client
+     | 1683911847996 (R)
+     | 1683911847996 (RP)
+     | 1683911847996 Preamble successfully parsed
+     | 1683911847996 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847996 (RWo)
+     | 1683911847996 (RC)
+     | 1683911847997 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847997 Preamble is [198] bytes long
+     | 1683911847997 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847997 Still writing preamble
+     | 1683911847997 Wrote [198] bytes to the client
+     | 1683911847997 (W)
+     | 1683911847997 Writing back bytes
+     | 1683911847997 Wrote [16392] bytes to the client
+     | 1683911847997 (W)
+     | 1683911847997 Writing back bytes
+     | 1683911847997 Wrote [3928] bytes to the client
+     | 1683911847997 (W)
+     | 1683911847997 Writing back bytes
+     | 1683911847997 Wrote [5] bytes to the client
+     | 1683911847997 (W)
+     | 1683911847997 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847997 (WKA)
+     | 1683911847998 Read [336] bytes from client
+     | 1683911847998 (R)
+     | 1683911847998 (RP)
+     | 1683911847998 Preamble successfully parsed
+     | 1683911847998 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847998 (RWo)
+     | 1683911847998 (RC)
+     | 1683911847998 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911847998 Preamble is [198] bytes long
+     | 1683911847998 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911847998 Still writing preamble
+     | 1683911847998 Wrote [198] bytes to the client
+     | 1683911847998 (W)
+     | 1683911847998 Writing back bytes
+     | 1683911847998 Wrote [16392] bytes to the client
+     | 1683911847998 (W)
+     | 1683911847998 Writing back bytes
+     | 1683911847999 Wrote [4027] bytes to the client
+     | 1683911847999 (W)
+     | 1683911847999 Writing back bytes
+     | 1683911847999 Wrote [5] bytes to the client
+     | 1683911847999 (W)
+     | 1683911847999 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911847999 (WKA)
+     | 1683911847999 Read [336] bytes from client
+     | 1683911847999 (R)
+     | 1683911847999 (RP)
+     | 1683911847999 Preamble successfully parsed
+     | 1683911847999 Client indicated it was NOT sending an entity-body in the request
+     | 1683911847999 (RWo)
+     | 1683911847999 (RC)
+     | 1683911848000 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848000 Preamble is [198] bytes long
+     | 1683911848000 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848000 Still writing preamble
+     | 1683911848000 Wrote [198] bytes to the client
+     | 1683911848000 (W)
+     | 1683911848000 Writing back bytes
+     | 1683911848000 Wrote [16392] bytes to the client
+     | 1683911848000 (W)
+     | 1683911848000 Writing back bytes
+     | 1683911848000 Wrote [4127] bytes to the client
+     | 1683911848000 (W)
+     | 1683911848000 Writing back bytes
+     | 1683911848000 Wrote [5] bytes to the client
+     | 1683911848000 (W)
+     | 1683911848000 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848000 (WKA)
+     | 1683911848000 Read [336] bytes from client
+     | 1683911848000 (R)
+     | 1683911848000 (RP)
+     | 1683911848000 Preamble successfully parsed
+     | 1683911848000 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848000 (RWo)
+     | 1683911848000 (RC)
+     | 1683911848001 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848001 Preamble is [198] bytes long
+     | 1683911848001 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848001 Still writing preamble
+     | 1683911848001 Wrote [198] bytes to the client
+     | 1683911848001 (W)
+     | 1683911848001 Writing back bytes
+     | 1683911848001 Wrote [16392] bytes to the client
+     | 1683911848001 (W)
+     | 1683911848001 Writing back bytes
+     | 1683911848001 Wrote [4226] bytes to the client
+     | 1683911848001 (W)
+     | 1683911848001 Writing back bytes
+     | 1683911848001 Wrote [5] bytes to the client
+     | 1683911848001 (W)
+     | 1683911848001 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848001 (WKA)
+     | 1683911848002 Read [336] bytes from client
+     | 1683911848002 (R)
+     | 1683911848002 (RP)
+     | 1683911848002 Preamble successfully parsed
+     | 1683911848002 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848002 (RWo)
+     | 1683911848002 (RC)
+     | 1683911848003 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848003 Preamble is [198] bytes long
+     | 1683911848003 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848003 Still writing preamble
+     | 1683911848003 Wrote [198] bytes to the client
+     | 1683911848003 (W)
+     | 1683911848003 Writing back bytes
+     | 1683911848003 Wrote [16392] bytes to the client
+     | 1683911848003 (W)
+     | 1683911848003 Writing back bytes
+     | 1683911848003 Wrote [4325] bytes to the client
+     | 1683911848003 (W)
+     | 1683911848003 Writing back bytes
+     | 1683911848003 Wrote [5] bytes to the client
+     | 1683911848003 (W)
+     | 1683911848003 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848003 (WKA)
+     | 1683911848003 Read [336] bytes from client
+     | 1683911848003 (R)
+     | 1683911848003 (RP)
+     | 1683911848003 Preamble successfully parsed
+     | 1683911848003 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848003 (RWo)
+     | 1683911848003 (RC)
+     | 1683911848004 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848004 Preamble is [198] bytes long
+     | 1683911848004 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848004 Still writing preamble
+     | 1683911848004 Wrote [198] bytes to the client
+     | 1683911848004 (W)
+     | 1683911848004 Writing back bytes
+     | 1683911848004 Wrote [16392] bytes to the client
+     | 1683911848004 (W)
+     | 1683911848004 Writing back bytes
+     | 1683911848004 Wrote [4424] bytes to the client
+     | 1683911848004 (W)
+     | 1683911848004 Writing back bytes
+     | 1683911848004 Wrote [5] bytes to the client
+     | 1683911848004 (W)
+     | 1683911848004 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848004 (WKA)
+     | 1683911848004 Read [336] bytes from client
+     | 1683911848004 (R)
+     | 1683911848004 (RP)
+     | 1683911848004 Preamble successfully parsed
+     | 1683911848004 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848004 (RWo)
+     | 1683911848004 (RC)
+     | 1683911848005 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848005 Preamble is [198] bytes long
+     | 1683911848005 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848005 Still writing preamble
+     | 1683911848005 Wrote [198] bytes to the client
+     | 1683911848005 (W)
+     | 1683911848005 Writing back bytes
+     | 1683911848005 Wrote [16392] bytes to the client
+     | 1683911848005 (W)
+     | 1683911848005 Writing back bytes
+     | 1683911848005 Wrote [4523] bytes to the client
+     | 1683911848005 (W)
+     | 1683911848005 Writing back bytes
+     | 1683911848005 Wrote [5] bytes to the client
+     | 1683911848005 (W)
+     | 1683911848005 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848005 (WKA)
+     | 1683911848006 Read [336] bytes from client
+     | 1683911848006 (R)
+     | 1683911848006 (RP)
+     | 1683911848006 Preamble successfully parsed
+     | 1683911848006 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848006 (RWo)
+     | 1683911848006 (RC)
+     | 1683911848007 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848007 Preamble is [198] bytes long
+     | 1683911848007 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848007 Still writing preamble
+     | 1683911848007 Wrote [198] bytes to the client
+     | 1683911848007 (W)
+     | 1683911848007 Writing back bytes
+     | 1683911848007 Wrote [16392] bytes to the client
+     | 1683911848007 (W)
+     | 1683911848007 Writing back bytes
+     | 1683911848007 Wrote [4622] bytes to the client
+     | 1683911848007 (W)
+     | 1683911848007 Writing back bytes
+     | 1683911848007 Wrote [5] bytes to the client
+     | 1683911848007 (W)
+     | 1683911848007 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848007 (WKA)
+     | 1683911848007 Read [336] bytes from client
+     | 1683911848007 (R)
+     | 1683911848007 (RP)
+     | 1683911848007 Preamble successfully parsed
+     | 1683911848007 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848007 (RWo)
+     | 1683911848007 (RC)
+     | 1683911848008 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848008 Preamble is [198] bytes long
+     | 1683911848008 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848008 Still writing preamble
+     | 1683911848008 Wrote [198] bytes to the client
+     | 1683911848008 (W)
+     | 1683911848008 Writing back bytes
+     | 1683911848008 Wrote [16392] bytes to the client
+     | 1683911848008 (W)
+     | 1683911848008 Writing back bytes
+     | 1683911848008 Wrote [4721] bytes to the client
+     | 1683911848008 (W)
+     | 1683911848008 Writing back bytes
+     | 1683911848008 Wrote [5] bytes to the client
+     | 1683911848008 (W)
+     | 1683911848008 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848008 (WKA)
+     | 1683911848008 Read [336] bytes from client
+     | 1683911848008 (R)
+     | 1683911848008 (RP)
+     | 1683911848008 Preamble successfully parsed
+     | 1683911848008 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848008 (RWo)
+     | 1683911848008 (RC)
+     | 1683911848009 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848009 Preamble is [198] bytes long
+     | 1683911848009 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848009 Still writing preamble
+     | 1683911848009 Wrote [198] bytes to the client
+     | 1683911848009 (W)
+     | 1683911848009 Writing back bytes
+     | 1683911848009 Wrote [16392] bytes to the client
+     | 1683911848009 (W)
+     | 1683911848009 Writing back bytes
+     | 1683911848009 Wrote [4820] bytes to the client
+     | 1683911848009 (W)
+     | 1683911848009 Writing back bytes
+     | 1683911848009 Wrote [5] bytes to the client
+     | 1683911848009 (W)
+     | 1683911848009 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848009 (WKA)
+     | 1683911848010 Read [336] bytes from client
+     | 1683911848010 (R)
+     | 1683911848010 (RP)
+     | 1683911848010 Preamble successfully parsed
+     | 1683911848010 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848010 (RWo)
+     | 1683911848010 (RC)
+     | 1683911848010 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848011 Preamble is [198] bytes long
+     | 1683911848011 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848011 Still writing preamble
+     | 1683911848011 Wrote [198] bytes to the client
+     | 1683911848011 (W)
+     | 1683911848011 Writing back bytes
+     | 1683911848011 Wrote [16392] bytes to the client
+     | 1683911848011 (W)
+     | 1683911848011 Writing back bytes
+     | 1683911848011 Wrote [4919] bytes to the client
+     | 1683911848011 (W)
+     | 1683911848011 Writing back bytes
+     | 1683911848011 Wrote [5] bytes to the client
+     | 1683911848011 (W)
+     | 1683911848011 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848011 (WKA)
+     | 1683911848011 Read [336] bytes from client
+     | 1683911848011 (R)
+     | 1683911848011 (RP)
+     | 1683911848011 Preamble successfully parsed
+     | 1683911848011 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848011 (RWo)
+     | 1683911848011 (RC)
+     | 1683911848012 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848012 Preamble is [198] bytes long
+     | 1683911848012 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848012 Still writing preamble
+     | 1683911848012 Wrote [198] bytes to the client
+     | 1683911848012 (W)
+     | 1683911848012 Writing back bytes
+     | 1683911848012 Wrote [16392] bytes to the client
+     | 1683911848012 (W)
+     | 1683911848012 Writing back bytes
+     | 1683911848012 Wrote [5018] bytes to the client
+     | 1683911848012 (W)
+     | 1683911848012 Writing back bytes
+     | 1683911848012 Wrote [5] bytes to the client
+     | 1683911848012 (W)
+     | 1683911848012 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848012 (WKA)
+     | 1683911848012 Read [336] bytes from client
+     | 1683911848012 (R)
+     | 1683911848012 (RP)
+     | 1683911848012 Preamble successfully parsed
+     | 1683911848012 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848012 (RWo)
+     | 1683911848012 (RC)
+     | 1683911848013 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848013 Preamble is [198] bytes long
+     | 1683911848013 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848013 Still writing preamble
+     | 1683911848013 Wrote [198] bytes to the client
+     | 1683911848013 (W)
+     | 1683911848013 Writing back bytes
+     | 1683911848013 Wrote [16392] bytes to the client
+     | 1683911848013 (W)
+     | 1683911848013 Writing back bytes
+     | 1683911848013 Wrote [5117] bytes to the client
+     | 1683911848013 (W)
+     | 1683911848013 Writing back bytes
+     | 1683911848013 Wrote [5] bytes to the client
+     | 1683911848013 (W)
+     | 1683911848013 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848013 (WKA)
+     | 1683911848014 Read [336] bytes from client
+     | 1683911848014 (R)
+     | 1683911848014 (RP)
+     | 1683911848014 Preamble successfully parsed
+     | 1683911848014 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848014 (RWo)
+     | 1683911848014 (RC)
+     | 1683911848015 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848015 Preamble is [198] bytes long
+     | 1683911848015 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848015 Still writing preamble
+     | 1683911848015 Wrote [198] bytes to the client
+     | 1683911848015 (W)
+     | 1683911848015 Writing back bytes
+     | 1683911848015 Wrote [16392] bytes to the client
+     | 1683911848015 (W)
+     | 1683911848015 Writing back bytes
+     | 1683911848015 Wrote [5216] bytes to the client
+     | 1683911848015 (W)
+     | 1683911848015 Writing back bytes
+     | 1683911848015 Wrote [5] bytes to the client
+     | 1683911848015 (W)
+     | 1683911848015 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848015 (WKA)
+     | 1683911848015 Read [336] bytes from client
+     | 1683911848015 (R)
+     | 1683911848015 (RP)
+     | 1683911848015 Preamble successfully parsed
+     | 1683911848015 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848015 (RWo)
+     | 1683911848015 (RC)
+     | 1683911848016 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848016 Preamble is [198] bytes long
+     | 1683911848016 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848016 Still writing preamble
+     | 1683911848016 Wrote [198] bytes to the client
+     | 1683911848016 (W)
+     | 1683911848016 Writing back bytes
+     | 1683911848016 Wrote [16392] bytes to the client
+     | 1683911848016 (W)
+     | 1683911848016 Writing back bytes
+     | 1683911848016 Wrote [5315] bytes to the client
+     | 1683911848016 (W)
+     | 1683911848016 Writing back bytes
+     | 1683911848016 Wrote [5] bytes to the client
+     | 1683911848016 (W)
+     | 1683911848016 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848016 (WKA)
+     | 1683911848017 Read [336] bytes from client
+     | 1683911848017 (R)
+     | 1683911848017 (RP)
+     | 1683911848017 Preamble successfully parsed
+     | 1683911848017 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848017 (RWo)
+     | 1683911848017 (RC)
+     | 1683911848018 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848018 Preamble is [198] bytes long
+     | 1683911848018 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848018 Still writing preamble
+     | 1683911848018 Wrote [198] bytes to the client
+     | 1683911848018 (W)
+     | 1683911848018 Writing back bytes
+     | 1683911848018 Wrote [16392] bytes to the client
+     | 1683911848018 (W)
+     | 1683911848018 Writing back bytes
+     | 1683911848018 Wrote [5414] bytes to the client
+     | 1683911848018 (W)
+     | 1683911848018 Writing back bytes
+     | 1683911848018 Wrote [5] bytes to the client
+     | 1683911848018 (W)
+     | 1683911848018 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848018 (WKA)
+     | 1683911848018 Read [336] bytes from client
+     | 1683911848018 (R)
+     | 1683911848018 (RP)
+     | 1683911848018 Preamble successfully parsed
+     | 1683911848018 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848018 (RWo)
+     | 1683911848018 (RC)
+     | 1683911848019 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848019 Preamble is [198] bytes long
+     | 1683911848019 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848019 Still writing preamble
+     | 1683911848019 Wrote [198] bytes to the client
+     | 1683911848019 (W)
+     | 1683911848019 Writing back bytes
+     | 1683911848019 Wrote [16392] bytes to the client
+     | 1683911848019 (W)
+     | 1683911848019 Writing back bytes
+     | 1683911848019 Wrote [5513] bytes to the client
+     | 1683911848019 (W)
+     | 1683911848019 Writing back bytes
+     | 1683911848019 Wrote [5] bytes to the client
+     | 1683911848019 (W)
+     | 1683911848019 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848019 (WKA)
+     | 1683911848019 Read [336] bytes from client
+     | 1683911848019 (R)
+     | 1683911848019 (RP)
+     | 1683911848019 Preamble successfully parsed
+     | 1683911848019 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848019 (RWo)
+     | 1683911848019 (RC)
+     | 1683911848020 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848020 Preamble is [198] bytes long
+     | 1683911848020 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848020 Still writing preamble
+     | 1683911848020 Wrote [198] bytes to the client
+     | 1683911848020 (W)
+     | 1683911848020 Writing back bytes
+     | 1683911848020 Wrote [16392] bytes to the client
+     | 1683911848020 (W)
+     | 1683911848020 Writing back bytes
+     | 1683911848020 Wrote [5612] bytes to the client
+     | 1683911848020 (W)
+     | 1683911848020 Writing back bytes
+     | 1683911848020 Wrote [5] bytes to the client
+     | 1683911848020 (W)
+     | 1683911848020 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848020 (WKA)
+     | 1683911848021 Read [336] bytes from client
+     | 1683911848021 (R)
+     | 1683911848021 (RP)
+     | 1683911848021 Preamble successfully parsed
+     | 1683911848021 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848021 (RWo)
+     | 1683911848021 (RC)
+     | 1683911848022 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848022 Preamble is [198] bytes long
+     | 1683911848022 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848022 Still writing preamble
+     | 1683911848022 Wrote [198] bytes to the client
+     | 1683911848022 (W)
+     | 1683911848022 Writing back bytes
+     | 1683911848022 Wrote [16392] bytes to the client
+     | 1683911848022 (W)
+     | 1683911848022 Writing back bytes
+     | 1683911848022 Wrote [5711] bytes to the client
+     | 1683911848022 (W)
+     | 1683911848022 Writing back bytes
+     | 1683911848022 Wrote [5] bytes to the client
+     | 1683911848022 (W)
+     | 1683911848022 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848022 (WKA)
+     | 1683911848022 Read [336] bytes from client
+     | 1683911848022 (R)
+     | 1683911848022 (RP)
+     | 1683911848022 Preamble successfully parsed
+     | 1683911848022 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848022 (RWo)
+     | 1683911848022 (RC)
+     | 1683911848023 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848023 Preamble is [198] bytes long
+     | 1683911848023 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848023 Still writing preamble
+     | 1683911848023 Wrote [198] bytes to the client
+     | 1683911848023 (W)
+     | 1683911848023 Writing back bytes
+     | 1683911848023 Wrote [16392] bytes to the client
+     | 1683911848023 (W)
+     | 1683911848023 Writing back bytes
+     | 1683911848023 Wrote [5810] bytes to the client
+     | 1683911848023 (W)
+     | 1683911848023 Writing back bytes
+     | 1683911848023 Wrote [5] bytes to the client
+     | 1683911848023 (W)
+     | 1683911848023 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848023 (WKA)
+     | 1683911848023 Read [336] bytes from client
+     | 1683911848023 (R)
+     | 1683911848023 (RP)
+     | 1683911848023 Preamble successfully parsed
+     | 1683911848023 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848023 (RWo)
+     | 1683911848023 (RC)
+     | 1683911848024 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848024 Preamble is [198] bytes long
+     | 1683911848024 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848024 Still writing preamble
+     | 1683911848024 Wrote [198] bytes to the client
+     | 1683911848024 (W)
+     | 1683911848024 Writing back bytes
+     | 1683911848024 Wrote [16392] bytes to the client
+     | 1683911848024 (W)
+     | 1683911848024 Writing back bytes
+     | 1683911848024 Wrote [5909] bytes to the client
+     | 1683911848024 (W)
+     | 1683911848024 Writing back bytes
+     | 1683911848024 Wrote [5] bytes to the client
+     | 1683911848024 (W)
+     | 1683911848024 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848024 (WKA)
+     | 1683911848025 Read [336] bytes from client
+     | 1683911848025 (R)
+     | 1683911848025 (RP)
+     | 1683911848025 Preamble successfully parsed
+     | 1683911848025 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848025 (RWo)
+     | 1683911848025 (RC)
+     | 1683911848026 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848026 Preamble is [198] bytes long
+     | 1683911848026 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848026 Still writing preamble
+     | 1683911848026 Wrote [198] bytes to the client
+     | 1683911848026 (W)
+     | 1683911848026 Writing back bytes
+     | 1683911848026 Wrote [16392] bytes to the client
+     | 1683911848026 (W)
+     | 1683911848026 Writing back bytes
+     | 1683911848026 Wrote [6008] bytes to the client
+     | 1683911848026 (W)
+     | 1683911848026 Writing back bytes
+     | 1683911848026 Wrote [5] bytes to the client
+     | 1683911848026 (W)
+     | 1683911848026 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848026 (WKA)
+     | 1683911848026 Read [336] bytes from client
+     | 1683911848026 (R)
+     | 1683911848026 (RP)
+     | 1683911848026 Preamble successfully parsed
+     | 1683911848026 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848026 (RWo)
+     | 1683911848026 (RC)
+     | 1683911848027 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848027 Preamble is [198] bytes long
+     | 1683911848027 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848027 Still writing preamble
+     | 1683911848027 Wrote [198] bytes to the client
+     | 1683911848027 (W)
+     | 1683911848027 Writing back bytes
+     | 1683911848027 Wrote [16392] bytes to the client
+     | 1683911848027 (W)
+     | 1683911848027 Writing back bytes
+     | 1683911848027 Wrote [6107] bytes to the client
+     | 1683911848027 (W)
+     | 1683911848027 Writing back bytes
+     | 1683911848027 Wrote [5] bytes to the client
+     | 1683911848027 (W)
+     | 1683911848027 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848027 (WKA)
+     | 1683911848027 Read [336] bytes from client
+     | 1683911848027 (R)
+     | 1683911848027 (RP)
+     | 1683911848027 Preamble successfully parsed
+     | 1683911848027 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848027 (RWo)
+     | 1683911848027 (RC)
+     | 1683911848028 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848028 Preamble is [198] bytes long
+     | 1683911848028 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848028 Still writing preamble
+     | 1683911848028 Wrote [198] bytes to the client
+     | 1683911848028 (W)
+     | 1683911848028 Writing back bytes
+     | 1683911848028 Wrote [16392] bytes to the client
+     | 1683911848028 (W)
+     | 1683911848028 Writing back bytes
+     | 1683911848028 Wrote [6206] bytes to the client
+     | 1683911848028 (W)
+     | 1683911848028 Writing back bytes
+     | 1683911848028 Wrote [5] bytes to the client
+     | 1683911848028 (W)
+     | 1683911848028 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848028 (WKA)
+     | 1683911848029 Read [336] bytes from client
+     | 1683911848029 (R)
+     | 1683911848029 (RP)
+     | 1683911848029 Preamble successfully parsed
+     | 1683911848029 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848029 (RWo)
+     | 1683911848029 (RC)
+     | 1683911848030 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848030 Preamble is [198] bytes long
+     | 1683911848030 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848030 Still writing preamble
+     | 1683911848030 Wrote [198] bytes to the client
+     | 1683911848030 (W)
+     | 1683911848030 Writing back bytes
+     | 1683911848030 Wrote [16392] bytes to the client
+     | 1683911848030 (W)
+     | 1683911848030 Writing back bytes
+     | 1683911848030 Wrote [6305] bytes to the client
+     | 1683911848030 (W)
+     | 1683911848030 Writing back bytes
+     | 1683911848030 Wrote [5] bytes to the client
+     | 1683911848030 (W)
+     | 1683911848030 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848030 (WKA)
+     | 1683911848030 Read [336] bytes from client
+     | 1683911848030 (R)
+     | 1683911848030 (RP)
+     | 1683911848030 Preamble successfully parsed
+     | 1683911848030 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848030 (RWo)
+     | 1683911848030 (RC)
+     | 1683911848031 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848031 Preamble is [198] bytes long
+     | 1683911848031 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848031 Still writing preamble
+     | 1683911848031 Wrote [198] bytes to the client
+     | 1683911848031 (W)
+     | 1683911848031 Writing back bytes
+     | 1683911848031 Wrote [16392] bytes to the client
+     | 1683911848031 (W)
+     | 1683911848031 Writing back bytes
+     | 1683911848031 Wrote [6404] bytes to the client
+     | 1683911848031 (W)
+     | 1683911848031 Writing back bytes
+     | 1683911848031 Wrote [5] bytes to the client
+     | 1683911848031 (W)
+     | 1683911848031 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848031 (WKA)
+     | 1683911848031 Read [336] bytes from client
+     | 1683911848031 (R)
+     | 1683911848031 (RP)
+     | 1683911848031 Preamble successfully parsed
+     | 1683911848031 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848031 (RWo)
+     | 1683911848031 (RC)
+     | 1683911848032 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848032 Preamble is [198] bytes long
+     | 1683911848032 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848032 Still writing preamble
+     | 1683911848032 Wrote [198] bytes to the client
+     | 1683911848032 (W)
+     | 1683911848032 Writing back bytes
+     | 1683911848032 Wrote [16392] bytes to the client
+     | 1683911848032 (W)
+     | 1683911848032 Writing back bytes
+     | 1683911848032 Wrote [6503] bytes to the client
+     | 1683911848032 (W)
+     | 1683911848032 Writing back bytes
+     | 1683911848032 Wrote [5] bytes to the client
+     | 1683911848032 (W)
+     | 1683911848032 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848032 (WKA)
+     | 1683911848033 Read [336] bytes from client
+     | 1683911848033 (R)
+     | 1683911848033 (RP)
+     | 1683911848033 Preamble successfully parsed
+     | 1683911848033 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848033 (RWo)
+     | 1683911848033 (RC)
+     | 1683911848034 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848034 Preamble is [198] bytes long
+     | 1683911848034 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848034 Still writing preamble
+     | 1683911848034 Wrote [198] bytes to the client
+     | 1683911848034 (W)
+     | 1683911848034 Writing back bytes
+     | 1683911848034 Wrote [16392] bytes to the client
+     | 1683911848034 (W)
+     | 1683911848034 Writing back bytes
+     | 1683911848034 Wrote [6602] bytes to the client
+     | 1683911848034 (W)
+     | 1683911848034 Writing back bytes
+     | 1683911848034 Wrote [5] bytes to the client
+     | 1683911848034 (W)
+     | 1683911848034 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848034 (WKA)
+     | 1683911848034 Read [336] bytes from client
+     | 1683911848034 (R)
+     | 1683911848034 (RP)
+     | 1683911848034 Preamble successfully parsed
+     | 1683911848034 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848034 (RWo)
+     | 1683911848034 (RC)
+     | 1683911848035 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848035 Preamble is [198] bytes long
+     | 1683911848035 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848035 Still writing preamble
+     | 1683911848035 Wrote [198] bytes to the client
+     | 1683911848035 (W)
+     | 1683911848035 Writing back bytes
+     | 1683911848035 Wrote [16392] bytes to the client
+     | 1683911848035 (W)
+     | 1683911848035 Writing back bytes
+     | 1683911848035 Wrote [6701] bytes to the client
+     | 1683911848035 (W)
+     | 1683911848035 Writing back bytes
+     | 1683911848035 Wrote [5] bytes to the client
+     | 1683911848035 (W)
+     | 1683911848035 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848035 (WKA)
+     | 1683911848035 Read [336] bytes from client
+     | 1683911848035 (R)
+     | 1683911848035 (RP)
+     | 1683911848035 Preamble successfully parsed
+     | 1683911848035 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848035 (RWo)
+     | 1683911848035 (RC)
+     | 1683911848036 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848036 Preamble is [198] bytes long
+     | 1683911848036 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848036 Still writing preamble
+     | 1683911848036 Wrote [198] bytes to the client
+     | 1683911848036 (W)
+     | 1683911848036 Writing back bytes
+     | 1683911848036 Wrote [16392] bytes to the client
+     | 1683911848036 (W)
+     | 1683911848036 Writing back bytes
+     | 1683911848036 Wrote [6800] bytes to the client
+     | 1683911848036 (W)
+     | 1683911848036 Writing back bytes
+     | 1683911848036 Wrote [5] bytes to the client
+     | 1683911848036 (W)
+     | 1683911848036 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848036 (WKA)
+     | 1683911848036 Read [336] bytes from client
+     | 1683911848036 (R)
+     | 1683911848036 (RP)
+     | 1683911848036 Preamble successfully parsed
+     | 1683911848036 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848036 (RWo)
+     | 1683911848036 (RC)
+     | 1683911848037 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848037 Preamble is [198] bytes long
+     | 1683911848037 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848037 Still writing preamble
+     | 1683911848037 Wrote [198] bytes to the client
+     | 1683911848037 (W)
+     | 1683911848037 Writing back bytes
+     | 1683911848037 Wrote [16392] bytes to the client
+     | 1683911848037 (W)
+     | 1683911848037 Writing back bytes
+     | 1683911848037 Wrote [6899] bytes to the client
+     | 1683911848037 (W)
+     | 1683911848037 Writing back bytes
+     | 1683911848037 Wrote [5] bytes to the client
+     | 1683911848037 (W)
+     | 1683911848037 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848037 (WKA)
+     | 1683911848038 Read [336] bytes from client
+     | 1683911848038 (R)
+     | 1683911848038 (RP)
+     | 1683911848038 Preamble successfully parsed
+     | 1683911848038 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848038 (RWo)
+     | 1683911848038 (RC)
+     | 1683911848039 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848039 Preamble is [198] bytes long
+     | 1683911848039 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848039 Still writing preamble
+     | 1683911848039 Wrote [198] bytes to the client
+     | 1683911848039 (W)
+     | 1683911848039 Writing back bytes
+     | 1683911848039 Wrote [16392] bytes to the client
+     | 1683911848039 (W)
+     | 1683911848039 Writing back bytes
+     | 1683911848039 Wrote [6998] bytes to the client
+     | 1683911848039 (W)
+     | 1683911848039 Writing back bytes
+     | 1683911848039 Wrote [5] bytes to the client
+     | 1683911848039 (W)
+     | 1683911848039 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848039 (WKA)
+     | 1683911848039 Read [336] bytes from client
+     | 1683911848039 (R)
+     | 1683911848039 (RP)
+     | 1683911848039 Preamble successfully parsed
+     | 1683911848039 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848039 (RWo)
+     | 1683911848039 (RC)
+     | 1683911848040 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848040 Preamble is [198] bytes long
+     | 1683911848040 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848040 Still writing preamble
+     | 1683911848040 Wrote [198] bytes to the client
+     | 1683911848040 (W)
+     | 1683911848040 Writing back bytes
+     | 1683911848040 Wrote [16392] bytes to the client
+     | 1683911848040 (W)
+     | 1683911848040 Writing back bytes
+     | 1683911848040 Wrote [7097] bytes to the client
+     | 1683911848040 (W)
+     | 1683911848040 Writing back bytes
+     | 1683911848040 Wrote [5] bytes to the client
+     | 1683911848040 (W)
+     | 1683911848040 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848040 (WKA)
+     | 1683911848041 Read [336] bytes from client
+     | 1683911848041 (R)
+     | 1683911848041 (RP)
+     | 1683911848041 Preamble successfully parsed
+     | 1683911848041 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848041 (RWo)
+     | 1683911848041 (RC)
+     | 1683911848041 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848041 Preamble is [198] bytes long
+     | 1683911848041 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848041 Still writing preamble
+     | 1683911848041 Wrote [198] bytes to the client
+     | 1683911848041 (W)
+     | 1683911848041 Writing back bytes
+     | 1683911848041 Wrote [16392] bytes to the client
+     | 1683911848041 (W)
+     | 1683911848041 Writing back bytes
+     | 1683911848041 Wrote [7196] bytes to the client
+     | 1683911848041 (W)
+     | 1683911848041 Writing back bytes
+     | 1683911848041 Wrote [5] bytes to the client
+     | 1683911848041 (W)
+     | 1683911848041 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848041 (WKA)
+     | 1683911848042 Read [336] bytes from client
+     | 1683911848042 (R)
+     | 1683911848042 (RP)
+     | 1683911848042 Preamble successfully parsed
+     | 1683911848042 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848042 (RWo)
+     | 1683911848042 (RC)
+     | 1683911848043 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848043 Preamble is [198] bytes long
+     | 1683911848043 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848043 Still writing preamble
+     | 1683911848043 Wrote [198] bytes to the client
+     | 1683911848043 (W)
+     | 1683911848043 Writing back bytes
+     | 1683911848043 Wrote [16392] bytes to the client
+     | 1683911848043 (W)
+     | 1683911848043 Writing back bytes
+     | 1683911848043 Wrote [7295] bytes to the client
+     | 1683911848043 (W)
+     | 1683911848043 Writing back bytes
+     | 1683911848043 Wrote [5] bytes to the client
+     | 1683911848043 (W)
+     | 1683911848043 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848043 (WKA)
+     | 1683911848043 Read [336] bytes from client
+     | 1683911848043 (R)
+     | 1683911848043 (RP)
+     | 1683911848043 Preamble successfully parsed
+     | 1683911848043 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848043 (RWo)
+     | 1683911848043 (RC)
+     | 1683911848044 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848044 Preamble is [198] bytes long
+     | 1683911848044 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848044 Still writing preamble
+     | 1683911848044 Wrote [198] bytes to the client
+     | 1683911848044 (W)
+     | 1683911848044 Writing back bytes
+     | 1683911848044 Wrote [16392] bytes to the client
+     | 1683911848044 (W)
+     | 1683911848044 Writing back bytes
+     | 1683911848044 Wrote [7394] bytes to the client
+     | 1683911848044 (W)
+     | 1683911848044 Writing back bytes
+     | 1683911848044 Wrote [5] bytes to the client
+     | 1683911848044 (W)
+     | 1683911848044 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848044 (WKA)
+     | 1683911848045 Read [336] bytes from client
+     | 1683911848045 (R)
+     | 1683911848045 (RP)
+     | 1683911848045 Preamble successfully parsed
+     | 1683911848045 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848045 (RWo)
+     | 1683911848045 (RC)
+     | 1683911848046 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848046 Preamble is [198] bytes long
+     | 1683911848046 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848046 Still writing preamble
+     | 1683911848046 Wrote [198] bytes to the client
+     | 1683911848046 (W)
+     | 1683911848046 Writing back bytes
+     | 1683911848046 Wrote [16392] bytes to the client
+     | 1683911848046 (W)
+     | 1683911848046 Writing back bytes
+     | 1683911848046 Wrote [7493] bytes to the client
+     | 1683911848046 (W)
+     | 1683911848046 Writing back bytes
+     | 1683911848046 Wrote [5] bytes to the client
+     | 1683911848046 (W)
+     | 1683911848046 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848046 (WKA)
+     | 1683911848046 Read [336] bytes from client
+     | 1683911848046 (R)
+     | 1683911848046 (RP)
+     | 1683911848046 Preamble successfully parsed
+     | 1683911848046 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848046 (RWo)
+     | 1683911848046 (RC)
+     | 1683911848047 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848047 Preamble is [198] bytes long
+     | 1683911848047 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848047 Still writing preamble
+     | 1683911848047 Wrote [198] bytes to the client
+     | 1683911848047 (W)
+     | 1683911848047 Writing back bytes
+     | 1683911848047 Wrote [16392] bytes to the client
+     | 1683911848047 (W)
+     | 1683911848047 Writing back bytes
+     | 1683911848047 Wrote [7592] bytes to the client
+     | 1683911848047 (W)
+     | 1683911848047 Writing back bytes
+     | 1683911848047 Wrote [5] bytes to the client
+     | 1683911848047 (W)
+     | 1683911848047 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848047 (WKA)
+     | 1683911848047 Read [336] bytes from client
+     | 1683911848047 (R)
+     | 1683911848047 (RP)
+     | 1683911848047 Preamble successfully parsed
+     | 1683911848047 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848047 (RWo)
+     | 1683911848047 (RC)
+     | 1683911848048 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848048 Preamble is [198] bytes long
+     | 1683911848048 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848048 Still writing preamble
+     | 1683911848048 Wrote [198] bytes to the client
+     | 1683911848048 (W)
+     | 1683911848048 Writing back bytes
+     | 1683911848048 Wrote [16392] bytes to the client
+     | 1683911848048 (W)
+     | 1683911848048 Writing back bytes
+     | 1683911848048 Wrote [7691] bytes to the client
+     | 1683911848048 (W)
+     | 1683911848048 Writing back bytes
+     | 1683911848048 Wrote [5] bytes to the client
+     | 1683911848048 (W)
+     | 1683911848048 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848048 (WKA)
+     | 1683911848049 Read [336] bytes from client
+     | 1683911848049 (R)
+     | 1683911848049 (RP)
+     | 1683911848049 Preamble successfully parsed
+     | 1683911848049 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848049 (RWo)
+     | 1683911848049 (RC)
+     | 1683911848050 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848050 Preamble is [198] bytes long
+     | 1683911848050 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848050 Still writing preamble
+     | 1683911848050 Wrote [198] bytes to the client
+     | 1683911848050 (W)
+     | 1683911848050 Writing back bytes
+     | 1683911848050 Wrote [16392] bytes to the client
+     | 1683911848050 (W)
+     | 1683911848050 Writing back bytes
+     | 1683911848050 Wrote [7790] bytes to the client
+     | 1683911848050 (W)
+     | 1683911848050 Writing back bytes
+     | 1683911848050 Wrote [5] bytes to the client
+     | 1683911848050 (W)
+     | 1683911848050 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848050 (WKA)
+     | 1683911848050 Read [336] bytes from client
+     | 1683911848050 (R)
+     | 1683911848050 (RP)
+     | 1683911848050 Preamble successfully parsed
+     | 1683911848050 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848050 (RWo)
+     | 1683911848050 (RC)
+     | 1683911848051 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848051 Preamble is [198] bytes long
+     | 1683911848051 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848051 Still writing preamble
+     | 1683911848051 Wrote [198] bytes to the client
+     | 1683911848051 (W)
+     | 1683911848051 Writing back bytes
+     | 1683911848051 Wrote [16392] bytes to the client
+     | 1683911848051 (W)
+     | 1683911848051 Writing back bytes
+     | 1683911848051 Wrote [7889] bytes to the client
+     | 1683911848051 (W)
+     | 1683911848051 Writing back bytes
+     | 1683911848051 Wrote [5] bytes to the client
+     | 1683911848051 (W)
+     | 1683911848051 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848051 (WKA)
+     | 1683911848051 Read [336] bytes from client
+     | 1683911848051 (R)
+     | 1683911848051 (RP)
+     | 1683911848052 Preamble successfully parsed
+     | 1683911848052 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848052 (RWo)
+     | 1683911848052 (RC)
+     | 1683911848052 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848052 Preamble is [198] bytes long
+     | 1683911848053 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848053 Still writing preamble
+     | 1683911848053 Wrote [198] bytes to the client
+     | 1683911848053 (W)
+     | 1683911848053 Writing back bytes
+     | 1683911848053 Wrote [16392] bytes to the client
+     | 1683911848053 (W)
+     | 1683911848053 Writing back bytes
+     | 1683911848053 Wrote [7988] bytes to the client
+     | 1683911848053 (W)
+     | 1683911848053 Writing back bytes
+     | 1683911848053 Wrote [5] bytes to the client
+     | 1683911848053 (W)
+     | 1683911848053 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848053 (WKA)
+     | 1683911848053 Read [336] bytes from client
+     | 1683911848053 (R)
+     | 1683911848053 (RP)
+     | 1683911848053 Preamble successfully parsed
+     | 1683911848053 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848053 (RWo)
+     | 1683911848053 (RC)
+     | 1683911848054 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848054 Preamble is [198] bytes long
+     | 1683911848054 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848054 Still writing preamble
+     | 1683911848054 Wrote [198] bytes to the client
+     | 1683911848054 (W)
+     | 1683911848054 Writing back bytes
+     | 1683911848054 Wrote [16392] bytes to the client
+     | 1683911848054 (W)
+     | 1683911848054 Writing back bytes
+     | 1683911848054 Wrote [8087] bytes to the client
+     | 1683911848054 (W)
+     | 1683911848054 Writing back bytes
+     | 1683911848054 Wrote [5] bytes to the client
+     | 1683911848054 (W)
+     | 1683911848054 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848054 (WKA)
+     | 1683911848054 Flipping a SelectionKey to Read because it wasn't in the right state
+     | 1683911848054 Read [336] bytes from client
+     | 1683911848054 (R)
+     | 1683911848054 (RP)
+     | 1683911848054 Preamble successfully parsed
+     | 1683911848054 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848054 (RWo)
+     | 1683911848054 (RC)
+     | 1683911848055 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848055 Preamble is [198] bytes long
+     | 1683911848055 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848055 Still writing preamble
+     | 1683911848055 Wrote [198] bytes to the client
+     | 1683911848055 (W)
+     | 1683911848055 Writing back bytes
+     | 1683911848055 Wrote [16392] bytes to the client
+     | 1683911848055 (W)
+     | 1683911848055 Writing back bytes
+     | 1683911848055 Wrote [8186] bytes to the client
+     | 1683911848055 (W)
+     | 1683911848055 Writing back bytes
+     | 1683911848055 Wrote [5] bytes to the client
+     | 1683911848055 (W)
+     | 1683911848055 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848055 (WKA)
+     | 1683911848056 Read [336] bytes from client
+     | 1683911848056 (R)
+     | 1683911848056 (RP)
+     | 1683911848056 Preamble successfully parsed
+     | 1683911848056 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848056 (RWo)
+     | 1683911848056 (RC)
+     | 1683911848057 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848057 Preamble is [198] bytes long
+     | 1683911848057 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848057 Still writing preamble
+     | 1683911848057 Wrote [198] bytes to the client
+     | 1683911848057 (W)
+     | 1683911848057 Writing back bytes
+     | 1683911848057 Wrote [16392] bytes to the client
+     | 1683911848057 (W)
+     | 1683911848057 Writing back bytes
+     | 1683911848057 Wrote [8285] bytes to the client
+     | 1683911848057 (W)
+     | 1683911848057 Writing back bytes
+     | 1683911848057 Wrote [5] bytes to the client
+     | 1683911848057 (W)
+     | 1683911848057 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848057 (WKA)
+     | 1683911848057 Read [336] bytes from client
+     | 1683911848057 (R)
+     | 1683911848057 (RP)
+     | 1683911848057 Preamble successfully parsed
+     | 1683911848057 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848057 (RWo)
+     | 1683911848057 (RC)
+     | 1683911848060 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848060 Preamble is [198] bytes long
+     | 1683911848060 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848060 Still writing preamble
+     | 1683911848060 Wrote [198] bytes to the client
+     | 1683911848060 (W)
+     | 1683911848060 Writing back bytes
+     | 1683911848060 Wrote [16392] bytes to the client
+     | 1683911848060 (W)
+     | 1683911848060 Writing back bytes
+     | 1683911848060 Wrote [8384] bytes to the client
+     | 1683911848060 (W)
+     | 1683911848060 Writing back bytes
+     | 1683911848060 Wrote [5] bytes to the client
+     | 1683911848060 (W)
+     | 1683911848060 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848060 (WKA)
+     | 1683911848061 Read [336] bytes from client
+     | 1683911848061 (R)
+     | 1683911848061 (RP)
+     | 1683911848061 Preamble successfully parsed
+     | 1683911848061 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848061 (RWo)
+     | 1683911848061 (RC)
+     | 1683911848062 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848062 Preamble is [198] bytes long
+     | 1683911848062 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848062 Still writing preamble
+     | 1683911848062 Wrote [198] bytes to the client
+     | 1683911848062 (W)
+     | 1683911848062 Writing back bytes
+     | 1683911848062 Wrote [16392] bytes to the client
+     | 1683911848062 (W)
+     | 1683911848062 Writing back bytes
+     | 1683911848062 Wrote [8483] bytes to the client
+     | 1683911848062 (W)
+     | 1683911848062 Writing back bytes
+     | 1683911848062 Wrote [5] bytes to the client
+     | 1683911848062 (W)
+     | 1683911848062 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848062 (WKA)
+     | 1683911848062 Read [336] bytes from client
+     | 1683911848062 (R)
+     | 1683911848062 (RP)
+     | 1683911848063 Preamble successfully parsed
+     | 1683911848063 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848063 (RWo)
+     | 1683911848063 (RC)
+     | 1683911848063 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848063 Preamble is [198] bytes long
+     | 1683911848063 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848063 Still writing preamble
+     | 1683911848063 Wrote [198] bytes to the client
+     | 1683911848063 (W)
+     | 1683911848063 Writing back bytes
+     | 1683911848063 Wrote [16392] bytes to the client
+     | 1683911848063 (W)
+     | 1683911848063 Writing back bytes
+     | 1683911848063 Wrote [8582] bytes to the client
+     | 1683911848063 (W)
+     | 1683911848063 Writing back bytes
+     | 1683911848063 Wrote [5] bytes to the client
+     | 1683911848063 (W)
+     | 1683911848063 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848063 (WKA)
+     | 1683911848064 Read [336] bytes from client
+     | 1683911848064 (R)
+     | 1683911848064 (RP)
+     | 1683911848064 Preamble successfully parsed
+     | 1683911848064 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848064 (RWo)
+     | 1683911848064 (RC)
+     | 1683911848065 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848065 Preamble is [198] bytes long
+     | 1683911848065 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848065 Still writing preamble
+     | 1683911848065 Wrote [198] bytes to the client
+     | 1683911848065 (W)
+     | 1683911848065 Writing back bytes
+     | 1683911848065 Wrote [16392] bytes to the client
+     | 1683911848065 (W)
+     | 1683911848065 Writing back bytes
+     | 1683911848065 Wrote [8681] bytes to the client
+     | 1683911848065 (W)
+     | 1683911848065 Writing back bytes
+     | 1683911848065 Wrote [5] bytes to the client
+     | 1683911848065 (W)
+     | 1683911848065 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848065 (WKA)
+     | 1683911848065 Read [336] bytes from client
+     | 1683911848065 (R)
+     | 1683911848065 (RP)
+     | 1683911848065 Preamble successfully parsed
+     | 1683911848065 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848065 (RWo)
+     | 1683911848065 (RC)
+     | 1683911848066 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848066 Preamble is [198] bytes long
+     | 1683911848066 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848066 Still writing preamble
+     | 1683911848066 Wrote [198] bytes to the client
+     | 1683911848066 (W)
+     | 1683911848066 Writing back bytes
+     | 1683911848066 Wrote [16392] bytes to the client
+     | 1683911848066 (W)
+     | 1683911848066 Writing back bytes
+     | 1683911848066 Wrote [8780] bytes to the client
+     | 1683911848066 (W)
+     | 1683911848066 Writing back bytes
+     | 1683911848066 Wrote [5] bytes to the client
+     | 1683911848066 (W)
+     | 1683911848066 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848066 (WKA)
+     | 1683911848066 Read [336] bytes from client
+     | 1683911848066 (R)
+     | 1683911848066 (RP)
+     | 1683911848066 Preamble successfully parsed
+     | 1683911848066 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848066 (RWo)
+     | 1683911848066 (RC)
+     | 1683911848067 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848067 Preamble is [198] bytes long
+     | 1683911848067 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848067 Still writing preamble
+     | 1683911848067 Wrote [198] bytes to the client
+     | 1683911848067 (W)
+     | 1683911848067 Writing back bytes
+     | 1683911848067 Wrote [16392] bytes to the client
+     | 1683911848067 (W)
+     | 1683911848067 Writing back bytes
+     | 1683911848067 Wrote [8879] bytes to the client
+     | 1683911848067 (W)
+     | 1683911848067 Writing back bytes
+     | 1683911848067 Wrote [5] bytes to the client
+     | 1683911848067 (W)
+     | 1683911848067 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848067 (WKA)
+     | 1683911848068 Read [336] bytes from client
+     | 1683911848068 (R)
+     | 1683911848068 (RP)
+     | 1683911848068 Preamble successfully parsed
+     | 1683911848068 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848068 (RWo)
+     | 1683911848068 (RC)
+     | 1683911848068 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848068 Preamble is [198] bytes long
+     | 1683911848068 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848068 Still writing preamble
+     | 1683911848068 Wrote [198] bytes to the client
+     | 1683911848068 (W)
+     | 1683911848068 Writing back bytes
+     | 1683911848068 Wrote [16392] bytes to the client
+     | 1683911848068 (W)
+     | 1683911848068 Writing back bytes
+     | 1683911848068 Wrote [8978] bytes to the client
+     | 1683911848068 (W)
+     | 1683911848068 Writing back bytes
+     | 1683911848068 Wrote [5] bytes to the client
+     | 1683911848068 (W)
+     | 1683911848068 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848068 (WKA)
+     | 1683911848069 Read [336] bytes from client
+     | 1683911848069 (R)
+     | 1683911848069 (RP)
+     | 1683911848069 Preamble successfully parsed
+     | 1683911848069 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848069 (RWo)
+     | 1683911848069 (RC)
+     | 1683911848069 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848069 Preamble is [198] bytes long
+     | 1683911848069 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848069 Still writing preamble
+     | 1683911848069 Wrote [198] bytes to the client
+     | 1683911848069 (W)
+     | 1683911848069 Writing back bytes
+     | 1683911848069 Wrote [16392] bytes to the client
+     | 1683911848069 (W)
+     | 1683911848069 Writing back bytes
+     | 1683911848069 Wrote [9077] bytes to the client
+     | 1683911848069 (W)
+     | 1683911848069 Writing back bytes
+     | 1683911848069 Wrote [5] bytes to the client
+     | 1683911848069 (W)
+     | 1683911848069 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848069 (WKA)
+     | 1683911848070 Read [336] bytes from client
+     | 1683911848070 (R)
+     | 1683911848070 (RP)
+     | 1683911848070 Preamble successfully parsed
+     | 1683911848070 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848070 (RWo)
+     | 1683911848070 (RC)
+     | 1683911848071 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848071 Preamble is [198] bytes long
+     | 1683911848071 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848071 Still writing preamble
+     | 1683911848071 Wrote [198] bytes to the client
+     | 1683911848071 (W)
+     | 1683911848071 Writing back bytes
+     | 1683911848071 Wrote [16392] bytes to the client
+     | 1683911848071 (W)
+     | 1683911848071 Writing back bytes
+     | 1683911848071 Wrote [9176] bytes to the client
+     | 1683911848071 (W)
+     | 1683911848071 Writing back bytes
+     | 1683911848071 Wrote [5] bytes to the client
+     | 1683911848071 (W)
+     | 1683911848071 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848071 (WKA)
+     | 1683911848071 Read [336] bytes from client
+     | 1683911848071 (R)
+     | 1683911848071 (RP)
+     | 1683911848071 Preamble successfully parsed
+     | 1683911848071 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848071 (RWo)
+     | 1683911848071 (RC)
+     | 1683911848072 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848072 Preamble is [198] bytes long
+     | 1683911848072 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848072 Still writing preamble
+     | 1683911848072 Wrote [198] bytes to the client
+     | 1683911848072 (W)
+     | 1683911848072 Writing back bytes
+     | 1683911848072 Wrote [16392] bytes to the client
+     | 1683911848072 (W)
+     | 1683911848072 Writing back bytes
+     | 1683911848072 Wrote [9275] bytes to the client
+     | 1683911848072 (W)
+     | 1683911848072 Writing back bytes
+     | 1683911848072 Wrote [5] bytes to the client
+     | 1683911848072 (W)
+     | 1683911848072 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848072 (WKA)
+     | 1683911848073 Read [336] bytes from client
+     | 1683911848073 (R)
+     | 1683911848073 (RP)
+     | 1683911848073 Preamble successfully parsed
+     | 1683911848073 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848073 (RWo)
+     | 1683911848073 (RC)
+     | 1683911848073 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848073 Preamble is [198] bytes long
+     | 1683911848073 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848073 Still writing preamble
+     | 1683911848073 Wrote [198] bytes to the client
+     | 1683911848073 (W)
+     | 1683911848073 Writing back bytes
+     | 1683911848073 Wrote [16392] bytes to the client
+     | 1683911848073 (W)
+     | 1683911848073 Writing back bytes
+     | 1683911848073 Wrote [9374] bytes to the client
+     | 1683911848073 (W)
+     | 1683911848073 Writing back bytes
+     | 1683911848073 Wrote [5] bytes to the client
+     | 1683911848073 (W)
+     | 1683911848073 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848073 (WKA)
+     | 1683911848074 Read [336] bytes from client
+     | 1683911848074 (R)
+     | 1683911848074 (RP)
+     | 1683911848074 Preamble successfully parsed
+     | 1683911848074 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848074 (RWo)
+     | 1683911848074 (RC)
+     | 1683911848075 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848075 Preamble is [198] bytes long
+     | 1683911848075 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848075 Still writing preamble
+     | 1683911848075 Wrote [198] bytes to the client
+     | 1683911848075 (W)
+     | 1683911848075 Writing back bytes
+     | 1683911848075 Wrote [16392] bytes to the client
+     | 1683911848075 (W)
+     | 1683911848075 Writing back bytes
+     | 1683911848075 Wrote [9473] bytes to the client
+     | 1683911848075 (W)
+     | 1683911848075 Writing back bytes
+     | 1683911848075 Wrote [5] bytes to the client
+     | 1683911848075 (W)
+     | 1683911848075 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848075 (WKA)
+     | 1683911848075 Read [336] bytes from client
+     | 1683911848075 (R)
+     | 1683911848075 (RP)
+     | 1683911848075 Preamble successfully parsed
+     | 1683911848075 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848075 (RWo)
+     | 1683911848075 (RC)
+     | 1683911848076 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848076 Preamble is [198] bytes long
+     | 1683911848076 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848076 Still writing preamble
+     | 1683911848076 Wrote [198] bytes to the client
+     | 1683911848076 (W)
+     | 1683911848076 Writing back bytes
+     | 1683911848076 Wrote [16392] bytes to the client
+     | 1683911848076 (W)
+     | 1683911848076 Writing back bytes
+     | 1683911848076 Wrote [9572] bytes to the client
+     | 1683911848076 (W)
+     | 1683911848076 Writing back bytes
+     | 1683911848076 Wrote [5] bytes to the client
+     | 1683911848076 (W)
+     | 1683911848076 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848076 (WKA)
+     | 1683911848077 Read [336] bytes from client
+     | 1683911848077 (R)
+     | 1683911848077 (RP)
+     | 1683911848077 Preamble successfully parsed
+     | 1683911848077 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848077 (RWo)
+     | 1683911848077 (RC)
+     | 1683911848078 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848078 Preamble is [198] bytes long
+     | 1683911848078 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848078 Still writing preamble
+     | 1683911848078 Wrote [198] bytes to the client
+     | 1683911848078 (W)
+     | 1683911848078 Writing back bytes
+     | 1683911848078 Wrote [16392] bytes to the client
+     | 1683911848078 (W)
+     | 1683911848078 Writing back bytes
+     | 1683911848078 Wrote [9671] bytes to the client
+     | 1683911848078 (W)
+     | 1683911848078 Writing back bytes
+     | 1683911848078 Wrote [5] bytes to the client
+     | 1683911848078 (W)
+     | 1683911848078 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848078 (WKA)
+     | 1683911848078 Read [336] bytes from client
+     | 1683911848078 (R)
+     | 1683911848078 (RP)
+     | 1683911848078 Preamble successfully parsed
+     | 1683911848078 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848078 (RWo)
+     | 1683911848078 (RC)
+     | 1683911848079 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848079 Preamble is [198] bytes long
+     | 1683911848079 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848079 Still writing preamble
+     | 1683911848079 Wrote [198] bytes to the client
+     | 1683911848079 (W)
+     | 1683911848079 Writing back bytes
+     | 1683911848079 Wrote [16392] bytes to the client
+     | 1683911848079 (W)
+     | 1683911848079 Writing back bytes
+     | 1683911848079 Wrote [9770] bytes to the client
+     | 1683911848079 (W)
+     | 1683911848079 Writing back bytes
+     | 1683911848079 Wrote [5] bytes to the client
+     | 1683911848079 (W)
+     | 1683911848079 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848079 (WKA)
+     | 1683911848079 Read [336] bytes from client
+     | 1683911848079 (R)
+     | 1683911848079 (RP)
+     | 1683911848079 Preamble successfully parsed
+     | 1683911848079 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848079 (RWo)
+     | 1683911848079 (RC)
+     | 1683911848080 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848080 Preamble is [198] bytes long
+     | 1683911848080 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848080 Still writing preamble
+     | 1683911848080 Wrote [198] bytes to the client
+     | 1683911848080 (W)
+     | 1683911848080 Writing back bytes
+     | 1683911848080 Wrote [16392] bytes to the client
+     | 1683911848080 (W)
+     | 1683911848080 Writing back bytes
+     | 1683911848080 Wrote [9869] bytes to the client
+     | 1683911848080 (W)
+     | 1683911848080 Writing back bytes
+     | 1683911848080 Wrote [5] bytes to the client
+     | 1683911848080 (W)
+     | 1683911848080 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848080 (WKA)
+     | 1683911848080 Read [336] bytes from client
+     | 1683911848080 (R)
+     | 1683911848080 (RP)
+     | 1683911848080 Preamble successfully parsed
+     | 1683911848080 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848080 (RWo)
+     | 1683911848080 (RC)
+     | 1683911848081 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848081 Preamble is [198] bytes long
+     | 1683911848081 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848081 Still writing preamble
+     | 1683911848081 Wrote [198] bytes to the client
+     | 1683911848081 (W)
+     | 1683911848081 Writing back bytes
+     | 1683911848081 Wrote [16392] bytes to the client
+     | 1683911848081 (W)
+     | 1683911848081 Writing back bytes
+     | 1683911848081 Wrote [9968] bytes to the client
+     | 1683911848081 (W)
+     | 1683911848081 Writing back bytes
+     | 1683911848081 Wrote [5] bytes to the client
+     | 1683911848081 (W)
+     | 1683911848081 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848081 (WKA)
+     | 1683911848082 Read [336] bytes from client
+     | 1683911848082 (R)
+     | 1683911848082 (RP)
+     | 1683911848082 Preamble successfully parsed
+     | 1683911848082 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848082 (RWo)
+     | 1683911848082 (RC)
+     | 1683911848083 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848083 Preamble is [198] bytes long
+     | 1683911848083 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848083 Still writing preamble
+     | 1683911848083 Wrote [198] bytes to the client
+     | 1683911848083 (W)
+     | 1683911848083 Writing back bytes
+     | 1683911848083 Wrote [16392] bytes to the client
+     | 1683911848083 (W)
+     | 1683911848083 Writing back bytes
+     | 1683911848083 Wrote [10067] bytes to the client
+     | 1683911848083 (W)
+     | 1683911848083 Writing back bytes
+     | 1683911848083 Wrote [5] bytes to the client
+     | 1683911848083 (W)
+     | 1683911848083 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848083 (WKA)
+     | 1683911848083 Read [336] bytes from client
+     | 1683911848083 (R)
+     | 1683911848083 (RP)
+     | 1683911848083 Preamble successfully parsed
+     | 1683911848083 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848083 (RWo)
+     | 1683911848083 (RC)
+     | 1683911848084 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848084 Preamble is [198] bytes long
+     | 1683911848084 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848084 Still writing preamble
+     | 1683911848084 Wrote [198] bytes to the client
+     | 1683911848084 (W)
+     | 1683911848084 Writing back bytes
+     | 1683911848084 Wrote [16392] bytes to the client
+     | 1683911848084 (W)
+     | 1683911848084 Writing back bytes
+     | 1683911848084 Wrote [10166] bytes to the client
+     | 1683911848084 (W)
+     | 1683911848084 Writing back bytes
+     | 1683911848084 Wrote [5] bytes to the client
+     | 1683911848084 (W)
+     | 1683911848084 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848084 (WKA)
+     | 1683911848084 Read [336] bytes from client
+     | 1683911848084 (R)
+     | 1683911848084 (RP)
+     | 1683911848084 Preamble successfully parsed
+     | 1683911848084 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848084 (RWo)
+     | 1683911848084 (RC)
+     | 1683911848085 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848085 Preamble is [198] bytes long
+     | 1683911848085 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848085 Still writing preamble
+     | 1683911848085 Wrote [198] bytes to the client
+     | 1683911848085 (W)
+     | 1683911848085 Writing back bytes
+     | 1683911848085 Wrote [16392] bytes to the client
+     | 1683911848085 (W)
+     | 1683911848085 Writing back bytes
+     | 1683911848085 Wrote [10265] bytes to the client
+     | 1683911848085 (W)
+     | 1683911848085 Writing back bytes
+     | 1683911848085 Wrote [5] bytes to the client
+     | 1683911848085 (W)
+     | 1683911848085 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848085 (WKA)
+     | 1683911848085 Read [336] bytes from client
+     | 1683911848085 (R)
+     | 1683911848085 (RP)
+     | 1683911848085 Preamble successfully parsed
+     | 1683911848085 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848085 (RWo)
+     | 1683911848086 (RC)
+     | 1683911848086 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848086 Preamble is [198] bytes long
+     | 1683911848086 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848086 Still writing preamble
+     | 1683911848086 Wrote [198] bytes to the client
+     | 1683911848086 (W)
+     | 1683911848086 Writing back bytes
+     | 1683911848086 Wrote [16392] bytes to the client
+     | 1683911848086 (W)
+     | 1683911848086 Writing back bytes
+     | 1683911848086 Wrote [10364] bytes to the client
+     | 1683911848086 (W)
+     | 1683911848086 Writing back bytes
+     | 1683911848086 Wrote [5] bytes to the client
+     | 1683911848086 (W)
+     | 1683911848086 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848086 (WKA)
+     | 1683911848087 Read [336] bytes from client
+     | 1683911848087 (R)
+     | 1683911848087 (RP)
+     | 1683911848087 Preamble successfully parsed
+     | 1683911848087 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848087 (RWo)
+     | 1683911848087 (RC)
+     | 1683911848087 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848087 Preamble is [198] bytes long
+     | 1683911848087 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848087 Still writing preamble
+     | 1683911848087 Wrote [198] bytes to the client
+     | 1683911848087 (W)
+     | 1683911848087 Writing back bytes
+     | 1683911848087 Wrote [16392] bytes to the client
+     | 1683911848087 (W)
+     | 1683911848087 Writing back bytes
+     | 1683911848087 Wrote [10463] bytes to the client
+     | 1683911848087 (W)
+     | 1683911848087 Writing back bytes
+     | 1683911848087 Wrote [5] bytes to the client
+     | 1683911848087 (W)
+     | 1683911848087 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848087 (WKA)
+     | 1683911848088 Read [336] bytes from client
+     | 1683911848088 (R)
+     | 1683911848088 (RP)
+     | 1683911848088 Preamble successfully parsed
+     | 1683911848088 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848088 (RWo)
+     | 1683911848088 (RC)
+     | 1683911848089 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848089 Preamble is [198] bytes long
+     | 1683911848089 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848089 Still writing preamble
+     | 1683911848089 Wrote [198] bytes to the client
+     | 1683911848089 (W)
+     | 1683911848089 Writing back bytes
+     | 1683911848089 Wrote [16392] bytes to the client
+     | 1683911848089 (W)
+     | 1683911848089 Writing back bytes
+     | 1683911848089 Wrote [10562] bytes to the client
+     | 1683911848089 (W)
+     | 1683911848089 Writing back bytes
+     | 1683911848089 Wrote [5] bytes to the client
+     | 1683911848089 (W)
+     | 1683911848089 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848089 (WKA)
+     | 1683911848089 Read [336] bytes from client
+     | 1683911848089 (R)
+     | 1683911848089 (RP)
+     | 1683911848089 Preamble successfully parsed
+     | 1683911848089 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848089 (RWo)
+     | 1683911848089 (RC)
+     | 1683911848090 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848090 Preamble is [198] bytes long
+     | 1683911848090 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848090 Still writing preamble
+     | 1683911848090 Wrote [198] bytes to the client
+     | 1683911848090 (W)
+     | 1683911848090 Writing back bytes
+     | 1683911848090 Wrote [16392] bytes to the client
+     | 1683911848090 (W)
+     | 1683911848090 Writing back bytes
+     | 1683911848090 Wrote [10661] bytes to the client
+     | 1683911848090 (W)
+     | 1683911848090 Writing back bytes
+     | 1683911848090 Wrote [5] bytes to the client
+     | 1683911848090 (W)
+     | 1683911848090 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848090 (WKA)
+     | 1683911848090 Read [336] bytes from client
+     | 1683911848090 (R)
+     | 1683911848090 (RP)
+     | 1683911848090 Preamble successfully parsed
+     | 1683911848090 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848090 (RWo)
+     | 1683911848090 (RC)
+     | 1683911848091 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848091 Preamble is [198] bytes long
+     | 1683911848091 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848091 Still writing preamble
+     | 1683911848091 Wrote [198] bytes to the client
+     | 1683911848091 (W)
+     | 1683911848091 Writing back bytes
+     | 1683911848091 Wrote [16392] bytes to the client
+     | 1683911848091 (W)
+     | 1683911848091 Writing back bytes
+     | 1683911848091 Wrote [10760] bytes to the client
+     | 1683911848091 (W)
+     | 1683911848091 Writing back bytes
+     | 1683911848091 Wrote [5] bytes to the client
+     | 1683911848091 (W)
+     | 1683911848091 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848091 (WKA)
+     | 1683911848091 Read [336] bytes from client
+     | 1683911848091 (R)
+     | 1683911848091 (RP)
+     | 1683911848091 Preamble successfully parsed
+     | 1683911848091 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848091 (RWo)
+     | 1683911848091 (RC)
+     | 1683911848092 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848092 Preamble is [198] bytes long
+     | 1683911848092 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848092 Still writing preamble
+     | 1683911848092 Wrote [198] bytes to the client
+     | 1683911848092 (W)
+     | 1683911848092 Writing back bytes
+     | 1683911848092 Wrote [16392] bytes to the client
+     | 1683911848092 (W)
+     | 1683911848092 Writing back bytes
+     | 1683911848092 Wrote [10859] bytes to the client
+     | 1683911848092 (W)
+     | 1683911848092 Writing back bytes
+     | 1683911848092 Wrote [5] bytes to the client
+     | 1683911848092 (W)
+     | 1683911848092 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848092 (WKA)
+     | 1683911848093 Read [336] bytes from client
+     | 1683911848093 (R)
+     | 1683911848093 (RP)
+     | 1683911848093 Preamble successfully parsed
+     | 1683911848093 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848093 (RWo)
+     | 1683911848093 (RC)
+     | 1683911848093 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848093 Preamble is [198] bytes long
+     | 1683911848093 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848093 Still writing preamble
+     | 1683911848093 Wrote [198] bytes to the client
+     | 1683911848093 (W)
+     | 1683911848093 Writing back bytes
+     | 1683911848093 Wrote [16392] bytes to the client
+     | 1683911848093 (W)
+     | 1683911848093 Writing back bytes
+     | 1683911848093 Wrote [10958] bytes to the client
+     | 1683911848093 (W)
+     | 1683911848093 Writing back bytes
+     | 1683911848093 Wrote [5] bytes to the client
+     | 1683911848093 (W)
+     | 1683911848093 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848093 (WKA)
+     | 1683911848094 Read [336] bytes from client
+     | 1683911848094 (R)
+     | 1683911848094 (RP)
+     | 1683911848094 Preamble successfully parsed
+     | 1683911848094 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848094 (RWo)
+     | 1683911848094 (RC)
+     | 1683911848095 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848095 Preamble is [198] bytes long
+     | 1683911848095 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848095 Still writing preamble
+     | 1683911848095 Wrote [198] bytes to the client
+     | 1683911848095 (W)
+     | 1683911848095 Writing back bytes
+     | 1683911848095 Wrote [16392] bytes to the client
+     | 1683911848095 (W)
+     | 1683911848095 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848095 Writing back bytes
+     | 1683911848095 Wrote [11057] bytes to the client
+     | 1683911848095 (W)
+     | 1683911848095 Writing back bytes
+     | 1683911848095 Wrote [5] bytes to the client
+     | 1683911848095 (W)
+     | 1683911848095 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848095 (WKA)
+     | 1683911848095 Read [336] bytes from client
+     | 1683911848095 (R)
+     | 1683911848095 (RP)
+     | 1683911848095 Preamble successfully parsed
+     | 1683911848095 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848095 (RWo)
+     | 1683911848095 (RC)
+     | 1683911848096 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848096 Preamble is [198] bytes long
+     | 1683911848096 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848096 Still writing preamble
+     | 1683911848096 Wrote [198] bytes to the client
+     | 1683911848096 (W)
+     | 1683911848096 Writing back bytes
+     | 1683911848096 Wrote [16392] bytes to the client
+     | 1683911848096 (W)
+     | 1683911848096 Writing back bytes
+     | 1683911848096 Wrote [11156] bytes to the client
+     | 1683911848096 (W)
+     | 1683911848096 Writing back bytes
+     | 1683911848096 Wrote [5] bytes to the client
+     | 1683911848096 (W)
+     | 1683911848096 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848096 (WKA)
+     | 1683911848096 Read [336] bytes from client
+     | 1683911848096 (R)
+     | 1683911848096 (RP)
+     | 1683911848096 Preamble successfully parsed
+     | 1683911848096 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848096 (RWo)
+     | 1683911848096 (RC)
+     | 1683911848097 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848097 Preamble is [198] bytes long
+     | 1683911848097 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848097 Still writing preamble
+     | 1683911848097 Wrote [198] bytes to the client
+     | 1683911848097 (W)
+     | 1683911848097 Writing back bytes
+     | 1683911848097 Wrote [16392] bytes to the client
+     | 1683911848097 (W)
+     | 1683911848097 Writing back bytes
+     | 1683911848097 Wrote [11255] bytes to the client
+     | 1683911848097 (W)
+     | 1683911848097 Writing back bytes
+     | 1683911848097 Wrote [5] bytes to the client
+     | 1683911848097 (W)
+     | 1683911848097 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848097 (WKA)
+     | 1683911848098 Read [336] bytes from client
+     | 1683911848098 (R)
+     | 1683911848098 (RP)
+     | 1683911848098 Preamble successfully parsed
+     | 1683911848098 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848098 (RWo)
+     | 1683911848098 (RC)
+     | 1683911848098 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848098 Preamble is [198] bytes long
+     | 1683911848098 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848098 Still writing preamble
+     | 1683911848098 Wrote [198] bytes to the client
+     | 1683911848098 (W)
+     | 1683911848098 Writing back bytes
+     | 1683911848098 Wrote [16392] bytes to the client
+     | 1683911848098 (W)
+     | 1683911848098 Writing back bytes
+     | 1683911848098 Wrote [11354] bytes to the client
+     | 1683911848098 (W)
+     | 1683911848098 Writing back bytes
+     | 1683911848098 Wrote [5] bytes to the client
+     | 1683911848098 (W)
+     | 1683911848098 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848098 (WKA)
+     | 1683911848099 Read [336] bytes from client
+     | 1683911848099 (R)
+     | 1683911848099 (RP)
+     | 1683911848099 Preamble successfully parsed
+     | 1683911848099 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848099 (RWo)
+     | 1683911848099 (RC)
+     | 1683911848099 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848099 Preamble is [198] bytes long
+     | 1683911848099 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848099 Still writing preamble
+     | 1683911848099 Wrote [198] bytes to the client
+     | 1683911848099 (W)
+     | 1683911848099 Writing back bytes
+     | 1683911848099 Wrote [16392] bytes to the client
+     | 1683911848099 (W)
+     | 1683911848099 Writing back bytes
+     | 1683911848099 Wrote [11453] bytes to the client
+     | 1683911848099 (W)
+     | 1683911848099 Writing back bytes
+     | 1683911848099 Wrote [5] bytes to the client
+     | 1683911848099 (W)
+     | 1683911848099 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848099 (WKA)
+     | 1683911848100 Read [336] bytes from client
+     | 1683911848100 (R)
+     | 1683911848100 (RP)
+     | 1683911848100 Preamble successfully parsed
+     | 1683911848100 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848100 (RWo)
+     | 1683911848100 (RC)
+     | 1683911848101 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848101 Preamble is [198] bytes long
+     | 1683911848101 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848101 Still writing preamble
+     | 1683911848101 Wrote [198] bytes to the client
+     | 1683911848101 (W)
+     | 1683911848101 Writing back bytes
+     | 1683911848101 Wrote [16392] bytes to the client
+     | 1683911848101 (W)
+     | 1683911848101 Writing back bytes
+     | 1683911848101 Wrote [11552] bytes to the client
+     | 1683911848101 (W)
+     | 1683911848101 Writing back bytes
+     | 1683911848101 Wrote [5] bytes to the client
+     | 1683911848101 (W)
+     | 1683911848101 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848101 (WKA)
+     | 1683911848101 Read [336] bytes from client
+     | 1683911848101 (R)
+     | 1683911848101 (RP)
+     | 1683911848101 Preamble successfully parsed
+     | 1683911848101 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848101 (RWo)
+     | 1683911848101 (RC)
+     | 1683911848102 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848102 Preamble is [198] bytes long
+     | 1683911848102 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848102 Still writing preamble
+     | 1683911848102 Wrote [198] bytes to the client
+     | 1683911848102 (W)
+     | 1683911848102 Writing back bytes
+     | 1683911848102 Wrote [16392] bytes to the client
+     | 1683911848102 (W)
+     | 1683911848102 Writing back bytes
+     | 1683911848102 Wrote [11651] bytes to the client
+     | 1683911848102 (W)
+     | 1683911848102 Writing back bytes
+     | 1683911848102 Wrote [5] bytes to the client
+     | 1683911848102 (W)
+     | 1683911848102 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848102 (WKA)
+     | 1683911848102 Read [336] bytes from client
+     | 1683911848102 (R)
+     | 1683911848102 (RP)
+     | 1683911848102 Preamble successfully parsed
+     | 1683911848102 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848102 (RWo)
+     | 1683911848102 (RC)
+     | 1683911848103 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848103 Preamble is [198] bytes long
+     | 1683911848103 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848103 Still writing preamble
+     | 1683911848103 Wrote [198] bytes to the client
+     | 1683911848103 (W)
+     | 1683911848103 Writing back bytes
+     | 1683911848103 Wrote [16392] bytes to the client
+     | 1683911848103 (W)
+     | 1683911848103 Writing back bytes
+     | 1683911848103 Wrote [11750] bytes to the client
+     | 1683911848103 (W)
+     | 1683911848103 Writing back bytes
+     | 1683911848103 Wrote [5] bytes to the client
+     | 1683911848103 (W)
+     | 1683911848103 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848103 (WKA)
+     | 1683911848103 Read [336] bytes from client
+     | 1683911848103 (R)
+     | 1683911848103 (RP)
+     | 1683911848103 Preamble successfully parsed
+     | 1683911848103 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848103 (RWo)
+     | 1683911848103 (RC)
+     | 1683911848104 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848104 Preamble is [198] bytes long
+     | 1683911848104 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848104 Still writing preamble
+     | 1683911848104 Wrote [198] bytes to the client
+     | 1683911848104 (W)
+     | 1683911848104 Writing back bytes
+     | 1683911848104 Wrote [16392] bytes to the client
+     | 1683911848104 (W)
+     | 1683911848104 Writing back bytes
+     | 1683911848104 Wrote [11849] bytes to the client
+     | 1683911848104 (W)
+     | 1683911848104 Writing back bytes
+     | 1683911848104 Wrote [5] bytes to the client
+     | 1683911848104 (W)
+     | 1683911848104 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848104 (WKA)
+     | 1683911848104 Read [336] bytes from client
+     | 1683911848104 (R)
+     | 1683911848104 (RP)
+     | 1683911848104 Preamble successfully parsed
+     | 1683911848104 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848104 (RWo)
+     | 1683911848104 (RC)
+     | 1683911848105 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848105 Preamble is [198] bytes long
+     | 1683911848105 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848105 Still writing preamble
+     | 1683911848105 Wrote [198] bytes to the client
+     | 1683911848105 (W)
+     | 1683911848105 Writing back bytes
+     | 1683911848105 Wrote [16392] bytes to the client
+     | 1683911848105 (W)
+     | 1683911848105 Writing back bytes
+     | 1683911848105 Wrote [11948] bytes to the client
+     | 1683911848105 (W)
+     | 1683911848105 Writing back bytes
+     | 1683911848105 Wrote [5] bytes to the client
+     | 1683911848105 (W)
+     | 1683911848105 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848105 (WKA)
+     | 1683911848106 Read [336] bytes from client
+     | 1683911848106 (R)
+     | 1683911848106 (RP)
+     | 1683911848106 Preamble successfully parsed
+     | 1683911848106 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848106 (RWo)
+     | 1683911848106 (RC)
+     | 1683911848106 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848106 Preamble is [198] bytes long
+     | 1683911848106 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848106 Still writing preamble
+     | 1683911848107 Wrote [198] bytes to the client
+     | 1683911848107 (W)
+     | 1683911848107 Writing back bytes
+     | 1683911848107 Wrote [16392] bytes to the client
+     | 1683911848107 (W)
+     | 1683911848107 Writing back bytes
+     | 1683911848107 Wrote [12047] bytes to the client
+     | 1683911848107 (W)
+     | 1683911848107 Writing back bytes
+     | 1683911848107 Wrote [5] bytes to the client
+     | 1683911848107 (W)
+     | 1683911848107 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848107 (WKA)
+     | 1683911848107 Read [336] bytes from client
+     | 1683911848107 (R)
+     | 1683911848107 (RP)
+     | 1683911848107 Preamble successfully parsed
+     | 1683911848107 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848107 (RWo)
+     | 1683911848107 (RC)
+     | 1683911848108 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848108 Preamble is [198] bytes long
+     | 1683911848108 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848108 Still writing preamble
+     | 1683911848108 Wrote [198] bytes to the client
+     | 1683911848108 (W)
+     | 1683911848108 Writing back bytes
+     | 1683911848108 Wrote [16392] bytes to the client
+     | 1683911848108 (W)
+     | 1683911848108 Writing back bytes
+     | 1683911848108 Wrote [12146] bytes to the client
+     | 1683911848108 (W)
+     | 1683911848108 Writing back bytes
+     | 1683911848108 Wrote [5] bytes to the client
+     | 1683911848108 (W)
+     | 1683911848108 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848108 (WKA)
+     | 1683911848108 Read [336] bytes from client
+     | 1683911848108 (R)
+     | 1683911848108 (RP)
+     | 1683911848108 Preamble successfully parsed
+     | 1683911848108 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848108 (RWo)
+     | 1683911848108 (RC)
+     | 1683911848109 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848109 Preamble is [198] bytes long
+     | 1683911848109 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848109 Still writing preamble
+     | 1683911848109 Wrote [198] bytes to the client
+     | 1683911848109 (W)
+     | 1683911848109 Writing back bytes
+     | 1683911848109 Wrote [16392] bytes to the client
+     | 1683911848109 (W)
+     | 1683911848109 Writing back bytes
+     | 1683911848109 Wrote [12245] bytes to the client
+     | 1683911848109 (W)
+     | 1683911848109 Writing back bytes
+     | 1683911848109 Wrote [5] bytes to the client
+     | 1683911848109 (W)
+     | 1683911848109 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848109 (WKA)
+     | 1683911848109 Read [336] bytes from client
+     | 1683911848109 (R)
+     | 1683911848109 (RP)
+     | 1683911848109 Preamble successfully parsed
+     | 1683911848109 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848109 (RWo)
+     | 1683911848109 (RC)
+     | 1683911848110 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848110 Preamble is [198] bytes long
+     | 1683911848110 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848110 Still writing preamble
+     | 1683911848110 Wrote [198] bytes to the client
+     | 1683911848110 (W)
+     | 1683911848110 Writing back bytes
+     | 1683911848110 Wrote [16392] bytes to the client
+     | 1683911848110 (W)
+     | 1683911848110 Writing back bytes
+     | 1683911848110 Wrote [12344] bytes to the client
+     | 1683911848110 (W)
+     | 1683911848110 Writing back bytes
+     | 1683911848110 Wrote [5] bytes to the client
+     | 1683911848110 (W)
+     | 1683911848110 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848110 (WKA)
+     | 1683911848110 Read [336] bytes from client
+     | 1683911848110 (R)
+     | 1683911848110 (RP)
+     | 1683911848110 Preamble successfully parsed
+     | 1683911848110 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848110 (RWo)
+     | 1683911848110 (RC)
+     | 1683911848111 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848111 Preamble is [198] bytes long
+     | 1683911848111 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848111 Still writing preamble
+     | 1683911848111 Wrote [198] bytes to the client
+     | 1683911848111 (W)
+     | 1683911848111 Writing back bytes
+     | 1683911848111 Wrote [16392] bytes to the client
+     | 1683911848111 (W)
+     | 1683911848111 Writing back bytes
+     | 1683911848111 Wrote [12443] bytes to the client
+     | 1683911848111 (W)
+     | 1683911848111 Writing back bytes
+     | 1683911848111 Wrote [5] bytes to the client
+     | 1683911848111 (W)
+     | 1683911848111 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848111 (WKA)
+     | 1683911848112 Read [336] bytes from client
+     | 1683911848112 (R)
+     | 1683911848112 (RP)
+     | 1683911848112 Preamble successfully parsed
+     | 1683911848112 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848112 (RWo)
+     | 1683911848112 (RC)
+     | 1683911848113 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848113 Preamble is [198] bytes long
+     | 1683911848113 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848113 Still writing preamble
+     | 1683911848113 Wrote [198] bytes to the client
+     | 1683911848113 (W)
+     | 1683911848113 Writing back bytes
+     | 1683911848113 Wrote [16392] bytes to the client
+     | 1683911848113 (W)
+     | 1683911848113 Writing back bytes
+     | 1683911848113 Wrote [12542] bytes to the client
+     | 1683911848113 (W)
+     | 1683911848113 Writing back bytes
+     | 1683911848113 Wrote [5] bytes to the client
+     | 1683911848113 (W)
+     | 1683911848113 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848113 (WKA)
+     | 1683911848113 Read [336] bytes from client
+     | 1683911848113 (R)
+     | 1683911848113 (RP)
+     | 1683911848113 Preamble successfully parsed
+     | 1683911848113 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848113 (RWo)
+     | 1683911848113 (RC)
+     | 1683911848114 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848114 Preamble is [198] bytes long
+     | 1683911848114 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848114 Still writing preamble
+     | 1683911848114 Wrote [198] bytes to the client
+     | 1683911848114 (W)
+     | 1683911848114 Writing back bytes
+     | 1683911848114 Wrote [16392] bytes to the client
+     | 1683911848114 (W)
+     | 1683911848114 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848114 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848114 Writing back bytes
+     | 1683911848114 Wrote [12641] bytes to the client
+     | 1683911848114 (W)
+     | 1683911848114 Writing back bytes
+     | 1683911848114 Wrote [5] bytes to the client
+     | 1683911848114 (W)
+     | 1683911848114 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848114 (WKA)
+     | 1683911848114 Read [336] bytes from client
+     | 1683911848114 (R)
+     | 1683911848114 (RP)
+     | 1683911848114 Preamble successfully parsed
+     | 1683911848114 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848114 (RWo)
+     | 1683911848114 (RC)
+     | 1683911848115 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848115 Preamble is [198] bytes long
+     | 1683911848115 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848115 Still writing preamble
+     | 1683911848115 Wrote [198] bytes to the client
+     | 1683911848115 (W)
+     | 1683911848115 Writing back bytes
+     | 1683911848115 Wrote [16392] bytes to the client
+     | 1683911848115 (W)
+     | 1683911848115 Writing back bytes
+     | 1683911848115 Wrote [12740] bytes to the client
+     | 1683911848115 (W)
+     | 1683911848115 Writing back bytes
+     | 1683911848115 Wrote [5] bytes to the client
+     | 1683911848115 (W)
+     | 1683911848115 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848115 (WKA)
+     | 1683911848115 Read [336] bytes from client
+     | 1683911848115 (R)
+     | 1683911848115 (RP)
+     | 1683911848115 Preamble successfully parsed
+     | 1683911848115 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848115 (RWo)
+     | 1683911848115 (RC)
+     | 1683911848116 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848116 Preamble is [198] bytes long
+     | 1683911848116 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848116 Still writing preamble
+     | 1683911848116 Wrote [198] bytes to the client
+     | 1683911848116 (W)
+     | 1683911848116 Writing back bytes
+     | 1683911848116 Wrote [16392] bytes to the client
+     | 1683911848116 (W)
+     | 1683911848116 Writing back bytes
+     | 1683911848116 Wrote [12839] bytes to the client
+     | 1683911848116 (W)
+     | 1683911848116 Writing back bytes
+     | 1683911848116 Wrote [5] bytes to the client
+     | 1683911848116 (W)
+     | 1683911848116 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848116 (WKA)
+     | 1683911848117 Read [336] bytes from client
+     | 1683911848117 (R)
+     | 1683911848117 (RP)
+     | 1683911848117 Preamble successfully parsed
+     | 1683911848117 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848117 (RWo)
+     | 1683911848117 (RC)
+     | 1683911848117 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848117 Preamble is [198] bytes long
+     | 1683911848117 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848117 Still writing preamble
+     | 1683911848117 Wrote [198] bytes to the client
+     | 1683911848117 (W)
+     | 1683911848117 Writing back bytes
+     | 1683911848117 Wrote [16392] bytes to the client
+     | 1683911848117 (W)
+     | 1683911848117 Writing back bytes
+     | 1683911848117 Wrote [12938] bytes to the client
+     | 1683911848117 (W)
+     | 1683911848117 Writing back bytes
+     | 1683911848117 Wrote [5] bytes to the client
+     | 1683911848117 (W)
+     | 1683911848117 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848117 (WKA)
+     | 1683911848118 Read [336] bytes from client
+     | 1683911848118 (R)
+     | 1683911848118 (RP)
+     | 1683911848118 Preamble successfully parsed
+     | 1683911848118 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848118 (RWo)
+     | 1683911848118 (RC)
+     | 1683911848119 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848119 Preamble is [198] bytes long
+     | 1683911848119 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848119 Still writing preamble
+     | 1683911848119 Wrote [198] bytes to the client
+     | 1683911848119 (W)
+     | 1683911848119 Writing back bytes
+     | 1683911848119 Wrote [16392] bytes to the client
+     | 1683911848119 (W)
+     | 1683911848119 Writing back bytes
+     | 1683911848119 Wrote [13037] bytes to the client
+     | 1683911848119 (W)
+     | 1683911848119 Writing back bytes
+     | 1683911848119 Wrote [5] bytes to the client
+     | 1683911848119 (W)
+     | 1683911848119 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848119 (WKA)
+     | 1683911848119 Read [336] bytes from client
+     | 1683911848119 (R)
+     | 1683911848119 (RP)
+     | 1683911848119 Preamble successfully parsed
+     | 1683911848119 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848119 (RWo)
+     | 1683911848119 (RC)
+     | 1683911848120 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848120 Preamble is [198] bytes long
+     | 1683911848120 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848120 Still writing preamble
+     | 1683911848120 Wrote [198] bytes to the client
+     | 1683911848120 (W)
+     | 1683911848120 Writing back bytes
+     | 1683911848120 Wrote [16392] bytes to the client
+     | 1683911848120 (W)
+     | 1683911848120 Writing back bytes
+     | 1683911848120 Wrote [13136] bytes to the client
+     | 1683911848120 (W)
+     | 1683911848120 Writing back bytes
+     | 1683911848120 Wrote [5] bytes to the client
+     | 1683911848120 (W)
+     | 1683911848120 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848120 (WKA)
+     | 1683911848122 Read [336] bytes from client
+     | 1683911848122 (R)
+     | 1683911848122 (RP)
+     | 1683911848122 Preamble successfully parsed
+     | 1683911848122 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848122 (RWo)
+     | 1683911848122 (RC)
+     | 1683911848122 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848122 Preamble is [198] bytes long
+     | 1683911848122 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848122 Still writing preamble
+     | 1683911848122 Wrote [198] bytes to the client
+     | 1683911848122 (W)
+     | 1683911848122 Writing back bytes
+     | 1683911848122 Wrote [16392] bytes to the client
+     | 1683911848122 (W)
+     | 1683911848122 Writing back bytes
+     | 1683911848122 Wrote [13235] bytes to the client
+     | 1683911848122 (W)
+     | 1683911848122 Writing back bytes
+     | 1683911848122 Wrote [5] bytes to the client
+     | 1683911848122 (W)
+     | 1683911848122 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848122 (WKA)
+     | 1683911848122 Flipping a SelectionKey to Read because it wasn't in the right state
+     | 1683911848123 Read [336] bytes from client
+     | 1683911848123 (R)
+     | 1683911848123 (RP)
+     | 1683911848123 Preamble successfully parsed
+     | 1683911848123 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848123 (RWo)
+     | 1683911848123 (RC)
+     | 1683911848123 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848123 Preamble is [198] bytes long
+     | 1683911848123 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848123 Still writing preamble
+     | 1683911848123 Wrote [198] bytes to the client
+     | 1683911848123 (W)
+     | 1683911848123 Writing back bytes
+     | 1683911848123 Wrote [16392] bytes to the client
+     | 1683911848123 (W)
+     | 1683911848123 Writing back bytes
+     | 1683911848123 Wrote [13334] bytes to the client
+     | 1683911848123 (W)
+     | 1683911848123 Writing back bytes
+     | 1683911848123 Wrote [5] bytes to the client
+     | 1683911848123 (W)
+     | 1683911848124 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848124 (WKA)
+     | 1683911848124 Flipping a SelectionKey to Read because it wasn't in the right state
+     | 1683911848124 Read [336] bytes from client
+     | 1683911848124 (R)
+     | 1683911848124 (RP)
+     | 1683911848124 Preamble successfully parsed
+     | 1683911848124 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848124 (RWo)
+     | 1683911848124 (RC)
+     | 1683911848125 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848125 Preamble is [198] bytes long
+     | 1683911848125 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848125 Still writing preamble
+     | 1683911848125 Wrote [198] bytes to the client
+     | 1683911848125 (W)
+     | 1683911848125 Writing back bytes
+     | 1683911848125 Wrote [16392] bytes to the client
+     | 1683911848125 (W)
+     | 1683911848125 Writing back bytes
+     | 1683911848125 Wrote [13433] bytes to the client
+     | 1683911848125 (W)
+     | 1683911848125 Writing back bytes
+     | 1683911848125 Wrote [5] bytes to the client
+     | 1683911848125 (W)
+     | 1683911848125 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848125 (WKA)
+     | 1683911848125 Read [336] bytes from client
+     | 1683911848125 (R)
+     | 1683911848125 (RP)
+     | 1683911848125 Preamble successfully parsed
+     | 1683911848125 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848125 (RWo)
+     | 1683911848125 (RC)
+     | 1683911848126 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848126 Preamble is [198] bytes long
+     | 1683911848126 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848126 Still writing preamble
+     | 1683911848126 Wrote [198] bytes to the client
+     | 1683911848126 (W)
+     | 1683911848126 Writing back bytes
+     | 1683911848126 Wrote [16392] bytes to the client
+     | 1683911848126 (W)
+     | 1683911848126 Writing back bytes
+     | 1683911848126 Wrote [13532] bytes to the client
+     | 1683911848126 (W)
+     | 1683911848126 Writing back bytes
+     | 1683911848126 Wrote [5] bytes to the client
+     | 1683911848126 (W)
+     | 1683911848126 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848126 (WKA)
+     | 1683911848126 Read [336] bytes from client
+     | 1683911848126 (R)
+     | 1683911848126 (RP)
+     | 1683911848126 Preamble successfully parsed
+     | 1683911848126 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848126 (RWo)
+     | 1683911848126 (RC)
+     | 1683911848127 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848127 Preamble is [198] bytes long
+     | 1683911848127 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848127 Still writing preamble
+     | 1683911848127 Wrote [198] bytes to the client
+     | 1683911848127 (W)
+     | 1683911848127 Writing back bytes
+     | 1683911848127 Wrote [16392] bytes to the client
+     | 1683911848127 (W)
+     | 1683911848127 Writing back bytes
+     | 1683911848127 Wrote [13631] bytes to the client
+     | 1683911848127 (W)
+     | 1683911848127 Writing back bytes
+     | 1683911848127 Wrote [5] bytes to the client
+     | 1683911848127 (W)
+     | 1683911848127 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848127 (WKA)
+     | 1683911848127 Read [336] bytes from client
+     | 1683911848127 (R)
+     | 1683911848127 (RP)
+     | 1683911848127 Preamble successfully parsed
+     | 1683911848127 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848127 (RWo)
+     | 1683911848127 (RC)
+     | 1683911848128 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848128 Preamble is [198] bytes long
+     | 1683911848128 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848128 Still writing preamble
+     | 1683911848128 Wrote [198] bytes to the client
+     | 1683911848128 (W)
+     | 1683911848128 Writing back bytes
+     | 1683911848128 Wrote [16392] bytes to the client
+     | 1683911848128 (W)
+     | 1683911848129 Writing back bytes
+     | 1683911848129 Wrote [13730] bytes to the client
+     | 1683911848129 (W)
+     | 1683911848129 Writing back bytes
+     | 1683911848129 Wrote [5] bytes to the client
+     | 1683911848129 (W)
+     | 1683911848129 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848129 (WKA)
+     | 1683911848129 Read [336] bytes from client
+     | 1683911848129 (R)
+     | 1683911848129 (RP)
+     | 1683911848129 Preamble successfully parsed
+     | 1683911848129 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848129 (RWo)
+     | 1683911848129 (RC)
+     | 1683911848130 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848130 Preamble is [198] bytes long
+     | 1683911848130 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848130 Still writing preamble
+     | 1683911848130 Wrote [198] bytes to the client
+     | 1683911848130 (W)
+     | 1683911848130 Writing back bytes
+     | 1683911848130 Wrote [16392] bytes to the client
+     | 1683911848130 (W)
+     | 1683911848130 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848130 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848130 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848130 Writing back bytes
+     | 1683911848130 Wrote [13829] bytes to the client
+     | 1683911848130 (W)
+     | 1683911848130 Writing back bytes
+     | 1683911848130 Wrote [5] bytes to the client
+     | 1683911848130 (W)
+     | 1683911848130 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848130 (WKA)
+     | 1683911848130 Read [336] bytes from client
+     | 1683911848130 (R)
+     | 1683911848130 (RP)
+     | 1683911848130 Preamble successfully parsed
+     | 1683911848130 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848130 (RWo)
+     | 1683911848130 (RC)
+     | 1683911848131 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848131 Preamble is [198] bytes long
+     | 1683911848131 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848131 Still writing preamble
+     | 1683911848131 Wrote [198] bytes to the client
+     | 1683911848131 (W)
+     | 1683911848131 Writing back bytes
+     | 1683911848131 Wrote [16392] bytes to the client
+     | 1683911848131 (W)
+     | 1683911848131 Writing back bytes
+     | 1683911848131 Wrote [13928] bytes to the client
+     | 1683911848131 (W)
+     | 1683911848131 Writing back bytes
+     | 1683911848131 Wrote [5] bytes to the client
+     | 1683911848131 (W)
+     | 1683911848131 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848131 (WKA)
+     | 1683911848131 Read [336] bytes from client
+     | 1683911848131 (R)
+     | 1683911848131 (RP)
+     | 1683911848132 Preamble successfully parsed
+     | 1683911848132 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848132 (RWo)
+     | 1683911848132 (RC)
+     | 1683911848132 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848132 Preamble is [198] bytes long
+     | 1683911848132 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848132 Still writing preamble
+     | 1683911848132 Wrote [198] bytes to the client
+     | 1683911848132 (W)
+     | 1683911848132 Writing back bytes
+     | 1683911848132 Wrote [16392] bytes to the client
+     | 1683911848132 (W)
+     | 1683911848132 Writing back bytes
+     | 1683911848132 Wrote [14027] bytes to the client
+     | 1683911848132 (W)
+     | 1683911848132 Writing back bytes
+     | 1683911848132 Wrote [5] bytes to the client
+     | 1683911848132 (W)
+     | 1683911848132 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848132 (WKA)
+     | 1683911848133 Read [336] bytes from client
+     | 1683911848133 (R)
+     | 1683911848133 (RP)
+     | 1683911848133 Preamble successfully parsed
+     | 1683911848133 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848133 (RWo)
+     | 1683911848133 (RC)
+     | 1683911848133 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848133 Preamble is [198] bytes long
+     | 1683911848133 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848133 Still writing preamble
+     | 1683911848133 Wrote [198] bytes to the client
+     | 1683911848133 (W)
+     | 1683911848133 Writing back bytes
+     | 1683911848133 Wrote [16392] bytes to the client
+     | 1683911848133 (W)
+     | 1683911848133 Writing back bytes
+     | 1683911848133 Wrote [14126] bytes to the client
+     | 1683911848133 (W)
+     | 1683911848133 Writing back bytes
+     | 1683911848133 Wrote [5] bytes to the client
+     | 1683911848133 (W)
+     | 1683911848134 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848134 (WKA)
+     | 1683911848134 Read [336] bytes from client
+     | 1683911848134 (R)
+     | 1683911848134 (RP)
+     | 1683911848134 Preamble successfully parsed
+     | 1683911848134 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848134 (RWo)
+     | 1683911848134 (RC)
+     | 1683911848135 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848135 Preamble is [198] bytes long
+     | 1683911848135 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848135 Still writing preamble
+     | 1683911848135 Wrote [198] bytes to the client
+     | 1683911848135 (W)
+     | 1683911848135 Writing back bytes
+     | 1683911848135 Wrote [16392] bytes to the client
+     | 1683911848135 (W)
+     | 1683911848135 Writing back bytes
+     | 1683911848135 Wrote [14225] bytes to the client
+     | 1683911848135 (W)
+     | 1683911848135 Writing back bytes
+     | 1683911848135 Wrote [5] bytes to the client
+     | 1683911848135 (W)
+     | 1683911848135 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848135 (WKA)
+     | 1683911848135 Read [336] bytes from client
+     | 1683911848135 (R)
+     | 1683911848135 (RP)
+     | 1683911848135 Preamble successfully parsed
+     | 1683911848135 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848135 (RWo)
+     | 1683911848135 (RC)
+     | 1683911848136 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848136 Preamble is [198] bytes long
+     | 1683911848136 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848136 Still writing preamble
+     | 1683911848136 Wrote [198] bytes to the client
+     | 1683911848136 (W)
+     | 1683911848136 Writing back bytes
+     | 1683911848136 Wrote [16392] bytes to the client
+     | 1683911848136 (W)
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848136 Writing back bytes
+     | 1683911848136 Wrote [14324] bytes to the client
+     | 1683911848136 (W)
+     | 1683911848136 Writing back bytes
+     | 1683911848136 Wrote [5] bytes to the client
+     | 1683911848136 (W)
+     | 1683911848136 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848136 (WKA)
+     | 1683911848136 Read [336] bytes from client
+     | 1683911848136 (R)
+     | 1683911848136 (RP)
+     | 1683911848136 Preamble successfully parsed
+     | 1683911848136 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848136 (RWo)
+     | 1683911848136 (RC)
+     | 1683911848137 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848137 Preamble is [198] bytes long
+     | 1683911848137 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848137 Still writing preamble
+     | 1683911848137 Wrote [198] bytes to the client
+     | 1683911848137 (W)
+     | 1683911848137 Writing back bytes
+     | 1683911848137 Wrote [16392] bytes to the client
+     | 1683911848137 (W)
+     | 1683911848137 Writing back bytes
+     | 1683911848137 Wrote [14423] bytes to the client
+     | 1683911848137 (W)
+     | 1683911848137 Writing back bytes
+     | 1683911848137 Wrote [5] bytes to the client
+     | 1683911848137 (W)
+     | 1683911848137 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848137 (WKA)
+     | 1683911848137 Read [336] bytes from client
+     | 1683911848137 (R)
+     | 1683911848137 (RP)
+     | 1683911848137 Preamble successfully parsed
+     | 1683911848137 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848137 (RWo)
+     | 1683911848137 (RC)
+     | 1683911848138 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848138 Preamble is [198] bytes long
+     | 1683911848138 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848138 Still writing preamble
+     | 1683911848138 Wrote [198] bytes to the client
+     | 1683911848138 (W)
+     | 1683911848138 Writing back bytes
+     | 1683911848138 Wrote [16392] bytes to the client
+     | 1683911848138 (W)
+     | 1683911848138 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848138 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848138 Writing back bytes
+     | 1683911848138 Wrote [14522] bytes to the client
+     | 1683911848138 (W)
+     | 1683911848138 Writing back bytes
+     | 1683911848138 Wrote [5] bytes to the client
+     | 1683911848138 (W)
+     | 1683911848138 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848138 (WKA)
+     | 1683911848139 Read [336] bytes from client
+     | 1683911848139 (R)
+     | 1683911848139 (RP)
+     | 1683911848139 Preamble successfully parsed
+     | 1683911848139 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848139 (RWo)
+     | 1683911848139 (RC)
+     | 1683911848139 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848139 Preamble is [198] bytes long
+     | 1683911848139 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848139 Still writing preamble
+     | 1683911848139 Wrote [198] bytes to the client
+     | 1683911848139 (W)
+     | 1683911848139 Writing back bytes
+     | 1683911848139 Wrote [16392] bytes to the client
+     | 1683911848139 (W)
+     | 1683911848139 Writing back bytes
+     | 1683911848139 Wrote [14621] bytes to the client
+     | 1683911848139 (W)
+     | 1683911848139 Writing back bytes
+     | 1683911848139 Wrote [5] bytes to the client
+     | 1683911848139 (W)
+     | 1683911848139 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848139 (WKA)
+     | 1683911848140 Read [336] bytes from client
+     | 1683911848140 (R)
+     | 1683911848140 (RP)
+     | 1683911848140 Preamble successfully parsed
+     | 1683911848140 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848140 (RWo)
+     | 1683911848140 (RC)
+     | 1683911848140 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848140 Preamble is [198] bytes long
+     | 1683911848140 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848140 Still writing preamble
+     | 1683911848140 Wrote [198] bytes to the client
+     | 1683911848140 (W)
+     | 1683911848140 Writing back bytes
+     | 1683911848140 Wrote [16392] bytes to the client
+     | 1683911848140 (W)
+     | 1683911848140 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848140 Writing back bytes
+     | 1683911848140 Wrote [14720] bytes to the client
+     | 1683911848140 (W)
+     | 1683911848140 Writing back bytes
+     | 1683911848140 Wrote [5] bytes to the client
+     | 1683911848140 (W)
+     | 1683911848140 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848140 (WKA)
+     | 1683911848141 Read [336] bytes from client
+     | 1683911848141 (R)
+     | 1683911848141 (RP)
+     | 1683911848141 Preamble successfully parsed
+     | 1683911848141 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848141 (RWo)
+     | 1683911848141 (RC)
+     | 1683911848142 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848142 Preamble is [198] bytes long
+     | 1683911848142 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848142 Still writing preamble
+     | 1683911848142 Wrote [198] bytes to the client
+     | 1683911848142 (W)
+     | 1683911848142 Writing back bytes
+     | 1683911848142 Wrote [16392] bytes to the client
+     | 1683911848142 (W)
+     | 1683911848142 Writing back bytes
+     | 1683911848142 Wrote [14819] bytes to the client
+     | 1683911848142 (W)
+     | 1683911848142 Writing back bytes
+     | 1683911848142 Wrote [5] bytes to the client
+     | 1683911848142 (W)
+     | 1683911848142 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848142 (WKA)
+     | 1683911848142 Read [336] bytes from client
+     | 1683911848142 (R)
+     | 1683911848142 (RP)
+     | 1683911848142 Preamble successfully parsed
+     | 1683911848142 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848142 (RWo)
+     | 1683911848142 (RC)
+     | 1683911848143 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848143 Preamble is [198] bytes long
+     | 1683911848143 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848143 Still writing preamble
+     | 1683911848143 Wrote [198] bytes to the client
+     | 1683911848143 (W)
+     | 1683911848143 Writing back bytes
+     | 1683911848143 Wrote [16392] bytes to the client
+     | 1683911848143 (W)
+     | 1683911848143 Writing back bytes
+     | 1683911848143 Wrote [14918] bytes to the client
+     | 1683911848143 (W)
+     | 1683911848143 Writing back bytes
+     | 1683911848143 Wrote [5] bytes to the client
+     | 1683911848143 (W)
+     | 1683911848143 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848143 (WKA)
+     | 1683911848143 Flipping a SelectionKey to Read because it wasn't in the right state
+     | 1683911848143 Read [336] bytes from client
+     | 1683911848143 (R)
+     | 1683911848143 (RP)
+     | 1683911848143 Preamble successfully parsed
+     | 1683911848143 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848143 (RWo)
+     | 1683911848143 (RC)
+     | 1683911848144 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848144 Preamble is [198] bytes long
+     | 1683911848144 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848144 Still writing preamble
+     | 1683911848144 Wrote [198] bytes to the client
+     | 1683911848144 (W)
+     | 1683911848144 Writing back bytes
+     | 1683911848144 Wrote [16392] bytes to the client
+     | 1683911848144 (W)
+     | 1683911848144 Writing back bytes
+     | 1683911848144 Wrote [15017] bytes to the client
+     | 1683911848144 (W)
+     | 1683911848144 Writing back bytes
+     | 1683911848144 Wrote [5] bytes to the client
+     | 1683911848144 (W)
+     | 1683911848144 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848144 (WKA)
+     | 1683911848145 Read [336] bytes from client
+     | 1683911848145 (R)
+     | 1683911848145 (RP)
+     | 1683911848145 Preamble successfully parsed
+     | 1683911848145 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848145 (RWo)
+     | 1683911848145 (RC)
+     | 1683911848146 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848146 Preamble is [198] bytes long
+     | 1683911848146 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848146 Still writing preamble
+     | 1683911848146 Wrote [198] bytes to the client
+     | 1683911848146 (W)
+     | 1683911848146 Writing back bytes
+     | 1683911848146 Wrote [16392] bytes to the client
+     | 1683911848146 (W)
+     | 1683911848146 Writing back bytes
+     | 1683911848146 Wrote [15116] bytes to the client
+     | 1683911848146 (W)
+     | 1683911848146 Writing back bytes
+     | 1683911848146 Wrote [5] bytes to the client
+     | 1683911848146 (W)
+     | 1683911848146 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848146 (WKA)
+     | 1683911848146 Read [336] bytes from client
+     | 1683911848146 (R)
+     | 1683911848146 (RP)
+     | 1683911848146 Preamble successfully parsed
+     | 1683911848146 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848146 (RWo)
+     | 1683911848146 (RC)
+     | 1683911848147 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848147 Preamble is [198] bytes long
+     | 1683911848147 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848147 Still writing preamble
+     | 1683911848147 Wrote [198] bytes to the client
+     | 1683911848147 (W)
+     | 1683911848147 Writing back bytes
+     | 1683911848147 Wrote [16392] bytes to the client
+     | 1683911848147 (W)
+     | 1683911848147 Writing back bytes
+     | 1683911848147 Wrote [15215] bytes to the client
+     | 1683911848147 (W)
+     | 1683911848147 Writing back bytes
+     | 1683911848147 Wrote [5] bytes to the client
+     | 1683911848147 (W)
+     | 1683911848147 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848147 (WKA)
+     | 1683911848147 Read [336] bytes from client
+     | 1683911848147 (R)
+     | 1683911848147 (RP)
+     | 1683911848147 Preamble successfully parsed
+     | 1683911848147 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848147 (RWo)
+     | 1683911848147 (RC)
+     | 1683911848148 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848148 Preamble is [198] bytes long
+     | 1683911848148 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848148 Still writing preamble
+     | 1683911848148 Wrote [198] bytes to the client
+     | 1683911848148 (W)
+     | 1683911848148 Writing back bytes
+     | 1683911848148 Wrote [16392] bytes to the client
+     | 1683911848148 (W)
+     | 1683911848148 Writing back bytes
+     | 1683911848148 Wrote [15314] bytes to the client
+     | 1683911848148 (W)
+     | 1683911848148 Writing back bytes
+     | 1683911848148 Wrote [5] bytes to the client
+     | 1683911848148 (W)
+     | 1683911848148 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848148 (WKA)
+     | 1683911848148 Read [336] bytes from client
+     | 1683911848148 (R)
+     | 1683911848148 (RP)
+     | 1683911848149 Preamble successfully parsed
+     | 1683911848149 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848149 (RWo)
+     | 1683911848149 (RC)
+     | 1683911848149 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848149 Preamble is [198] bytes long
+     | 1683911848149 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848149 Still writing preamble
+     | 1683911848149 Wrote [198] bytes to the client
+     | 1683911848149 (W)
+     | 1683911848149 Writing back bytes
+     | 1683911848149 Wrote [16392] bytes to the client
+     | 1683911848149 (W)
+     | 1683911848149 Writing back bytes
+     | 1683911848149 Wrote [15413] bytes to the client
+     | 1683911848149 (W)
+     | 1683911848149 Writing back bytes
+     | 1683911848149 Wrote [5] bytes to the client
+     | 1683911848149 (W)
+     | 1683911848149 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848149 (WKA)
+     | 1683911848150 Read [336] bytes from client
+     | 1683911848150 (R)
+     | 1683911848150 (RP)
+     | 1683911848150 Preamble successfully parsed
+     | 1683911848150 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848150 (RWo)
+     | 1683911848150 (RC)
+     | 1683911848150 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848150 Preamble is [198] bytes long
+     | 1683911848150 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848150 Still writing preamble
+     | 1683911848150 Wrote [198] bytes to the client
+     | 1683911848150 (W)
+     | 1683911848150 Writing back bytes
+     | 1683911848150 Wrote [16392] bytes to the client
+     | 1683911848150 (W)
+     | 1683911848150 Writing back bytes
+     | 1683911848150 Wrote [15512] bytes to the client
+     | 1683911848150 (W)
+     | 1683911848150 Writing back bytes
+     | 1683911848150 Wrote [5] bytes to the client
+     | 1683911848150 (W)
+     | 1683911848150 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848150 (WKA)
+     | 1683911848151 Read [336] bytes from client
+     | 1683911848151 (R)
+     | 1683911848151 (RP)
+     | 1683911848151 Preamble successfully parsed
+     | 1683911848151 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848151 (RWo)
+     | 1683911848151 (RC)
+     | 1683911848151 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848151 Preamble is [198] bytes long
+     | 1683911848151 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848151 Still writing preamble
+     | 1683911848151 Wrote [198] bytes to the client
+     | 1683911848151 (W)
+     | 1683911848151 Writing back bytes
+     | 1683911848151 Wrote [16392] bytes to the client
+     | 1683911848151 (W)
+     | 1683911848151 Writing back bytes
+     | 1683911848151 Wrote [15611] bytes to the client
+     | 1683911848151 (W)
+     | 1683911848151 Writing back bytes
+     | 1683911848151 Wrote [5] bytes to the client
+     | 1683911848151 (W)
+     | 1683911848151 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848151 (WKA)
+     | 1683911848152 Read [336] bytes from client
+     | 1683911848152 (R)
+     | 1683911848152 (RP)
+     | 1683911848152 Preamble successfully parsed
+     | 1683911848152 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848152 (RWo)
+     | 1683911848152 (RC)
+     | 1683911848153 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848153 Preamble is [198] bytes long
+     | 1683911848153 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848153 Still writing preamble
+     | 1683911848153 Wrote [198] bytes to the client
+     | 1683911848153 (W)
+     | 1683911848153 Writing back bytes
+     | 1683911848153 Wrote [16392] bytes to the client
+     | 1683911848153 (W)
+     | 1683911848153 Writing back bytes
+     | 1683911848153 Wrote [15710] bytes to the client
+     | 1683911848153 (W)
+     | 1683911848153 Writing back bytes
+     | 1683911848153 Wrote [5] bytes to the client
+     | 1683911848153 (W)
+     | 1683911848153 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848153 (WKA)
+     | 1683911848153 Read [336] bytes from client
+     | 1683911848153 (R)
+     | 1683911848153 (RP)
+     | 1683911848153 Preamble successfully parsed
+     | 1683911848153 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848153 (RWo)
+     | 1683911848153 (RC)
+     | 1683911848154 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848154 Preamble is [198] bytes long
+     | 1683911848154 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848154 Still writing preamble
+     | 1683911848154 Wrote [198] bytes to the client
+     | 1683911848154 (W)
+     | 1683911848154 Writing back bytes
+     | 1683911848154 Wrote [16392] bytes to the client
+     | 1683911848154 (W)
+     | 1683911848154 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848154 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848154 Writing back bytes
+     | 1683911848154 Wrote [15809] bytes to the client
+     | 1683911848154 (W)
+     | 1683911848154 Writing back bytes
+     | 1683911848154 Wrote [5] bytes to the client
+     | 1683911848154 (W)
+     | 1683911848154 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848154 (WKA)
+     | 1683911848154 Read [336] bytes from client
+     | 1683911848154 (R)
+     | 1683911848154 (RP)
+     | 1683911848154 Preamble successfully parsed
+     | 1683911848154 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848154 (RWo)
+     | 1683911848154 (RC)
+     | 1683911848155 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848155 Preamble is [198] bytes long
+     | 1683911848155 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848155 Still writing preamble
+     | 1683911848155 Wrote [198] bytes to the client
+     | 1683911848155 (W)
+     | 1683911848155 Writing back bytes
+     | 1683911848155 Wrote [16392] bytes to the client
+     | 1683911848155 (W)
+     | 1683911848155 Writing back bytes
+     | 1683911848155 Wrote [15908] bytes to the client
+     | 1683911848155 (W)
+     | 1683911848155 Writing back bytes
+     | 1683911848155 Wrote [5] bytes to the client
+     | 1683911848155 (W)
+     | 1683911848155 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848155 (WKA)
+     | 1683911848155 Read [336] bytes from client
+     | 1683911848155 (R)
+     | 1683911848155 (RP)
+     | 1683911848155 Preamble successfully parsed
+     | 1683911848155 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848155 (RWo)
+     | 1683911848155 (RC)
+     | 1683911848156 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848156 Preamble is [198] bytes long
+     | 1683911848156 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848156 Still writing preamble
+     | 1683911848156 Wrote [198] bytes to the client
+     | 1683911848156 (W)
+     | 1683911848156 Writing back bytes
+     | 1683911848156 Wrote [16392] bytes to the client
+     | 1683911848156 (W)
+     | 1683911848156 Writing back bytes
+     | 1683911848156 Wrote [16007] bytes to the client
+     | 1683911848156 (W)
+     | 1683911848156 Writing back bytes
+     | 1683911848156 Wrote [5] bytes to the client
+     | 1683911848156 (W)
+     | 1683911848156 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848156 (WKA)
+     | 1683911848156 Read [336] bytes from client
+     | 1683911848156 (R)
+     | 1683911848156 (RP)
+     | 1683911848156 Preamble successfully parsed
+     | 1683911848156 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848156 (RWo)
+     | 1683911848156 (RC)
+     | 1683911848157 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848157 Preamble is [198] bytes long
+     | 1683911848157 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848157 Still writing preamble
+     | 1683911848157 Wrote [198] bytes to the client
+     | 1683911848157 (W)
+     | 1683911848157 Writing back bytes
+     | 1683911848157 Wrote [16392] bytes to the client
+     | 1683911848157 (W)
+     | 1683911848157 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683911848157 Writing back bytes
+     | 1683911848157 Wrote [16106] bytes to the client
+     | 1683911848157 (W)
+     | 1683911848157 Writing back bytes
+     | 1683911848157 Wrote [5] bytes to the client
+     | 1683911848157 (W)
+     | 1683911848157 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848157 (WKA)
+     | 1683911848157 Read [336] bytes from client
+     | 1683911848157 (R)
+     | 1683911848157 (RP)
+     | 1683911848158 Preamble successfully parsed
+     | 1683911848158 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848158 (RWo)
+     | 1683911848158 (RC)
+     | 1683911848158 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848158 Preamble is [198] bytes long
+     | 1683911848158 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848158 Still writing preamble
+     | 1683911848158 Wrote [198] bytes to the client
+     | 1683911848158 (W)
+     | 1683911848158 Writing back bytes
+     | 1683911848158 Wrote [16392] bytes to the client
+     | 1683911848158 (W)
+     | 1683911848158 Writing back bytes
+     | 1683911848158 Wrote [5] bytes to the client
+     | 1683911848158 (W)
+     | 1683911848158 Writing back bytes
+     | 1683911848158 Wrote [16205] bytes to the client
+     | 1683911848158 (W)
+     | 1683911848158 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848158 (WKA)
+     | 1683911848159 Read [336] bytes from client
+     | 1683911848159 (R)
+     | 1683911848159 (RP)
+     | 1683911848159 Preamble successfully parsed
+     | 1683911848159 Client indicated it was NOT sending an entity-body in the request
+     | 1683911848159 (RWo)
+     | 1683911848159 (RC)
+     | 1683911848159 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683911848159 Preamble is [198] bytes long
+     | 1683911848159 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683911848159 Still writing preamble
+     | 1683911848159 Wrote [198] bytes to the client
+     | 1683911848159 (W)
+     | 1683911848159 Writing back bytes
+     | 1683911848159 Wrote [16392] bytes to the client
+     | 1683911848159 (W)
+     | 1683911848159 Writing back bytes
+     | 1683911848159 Wrote [16304] bytes to the client
+     | 1683911848159 (W)
+     | 1683911848159 Writing back bytes
+     | 1683911848159 Wrote [5] bytes to the client
+     | 1683911848159 (W)
+     | 1683911848159 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683911848159 (WKA)
+     | 1683911848159 (HTTPS-C)
+     | 1683911848159 (C)
+     | 1683911848159 Closing connection to client [/127.0.0.1:55927]
+     | 1683911848159 (C)
+-----------------
+
+May 12, 2023 11:17:28.172 AM INFO  org.primeframework.mvc.PrimeMVCRequestHandler - Shutting down Prime MVC
+
+===============================================
+Default Suite
+Total tests run: 1, Passes: 0, Failures: 1, Skips: 0
+===============================================
+
+Disconnected from the target VM, address: '127.0.0.1:55922', transport: 'socket'
+
+Process finished with exit code 0

--- a/src/test/resources/truncated-response-issue.log
+++ b/src/test/resources/truncated-response-issue.log
@@ -1,0 +1,17100 @@
+/Users/bpontarelli/dev/java/jdk-17.0.3+7/Contents/Home/bin/java -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:58164,suspend=y,server=n -ea -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/groovyHotSwap/gragent.jar -javaagent:/Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/captureAgent/debugger-agent.jar -Dfile.encoding=UTF-8 -classpath /Users/bpontarelli/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/231.8770.65/IntelliJ IDEA.app/Contents/lib/idea_rt.jar:/Users/bpontarelli/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/231.8770.65/IntelliJ IDEA.app/Contents/plugins/testng/lib/testng-rt.jar:/Users/bpontarelli/dev/os/prime/prime-mvc/build/classes/test:/Users/bpontarelli/dev/os/prime/prime-mvc/build/classes/main:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0.jar:/Users/bpontarelli/.savant/cache/com/google/inject/guice/5.1.0/guice-5.1.0.jar:/Users/bpontarelli/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar:/Users/bpontarelli/.savant/cache/com/inversoft/restify/4.1.2/restify-4.1.2.jar:/Users/bpontarelli/.savant/cache/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6.jar:/Users/bpontarelli/.savant/cache/io/fusionauth/fusionauth-jwt/5.1.0/fusionauth-jwt-5.1.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.14.0/jackson-databind-2.14.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.14.0/jackson-annotations-2.14.0.jar:/Users/bpontarelli/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.14.0/jackson-core-2.14.0.jar:/Users/bpontarelli/.savant/cache/io/fusionauth/java-http/0.1.14-RC.5.{integration}/java-http-0.1.14-RC.5.{integration}.jar:/Users/bpontarelli/.savant/cache/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar:/Users/bpontarelli/.savant/cache/org/ow2/asm/asm/9.2.0/asm-9.2.0.jar:/Users/bpontarelli/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/Users/bpontarelli/.savant/cache/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.jar:/Users/bpontarelli/.savant/cache/org/easymock/easymock/5.0.1/easymock-5.0.1.jar:/Users/bpontarelli/.savant/cache/org/objenesis/objenesis/3.3.0/objenesis-3.3.0.jar:/Users/bpontarelli/.savant/cache/org/testng/testng/7.7.1/testng-7.7.1.jar:/Users/bpontarelli/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0.jar:/Users/bpontarelli/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar:/Users/bpontarelli/.savant/cache/org/jsoup/jsoup/1.15.3/jsoup-1.15.3.jar:/Users/bpontarelli/.savant/cache/ch/qos/logback/logback-classic/1.4.4/logback-classic-1.4.4.jar:/Users/bpontarelli/.savant/cache/ch/qos/logback/logback-core/1.4.4/logback-core-1.4.4.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0.jar:/Users/bpontarelli/.savant/cache/com/github/java-json-tools/btf/1.3.0/btf-1.3.0.jar:/Users/bpontarelli/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar:/Users/bpontarelli/.savant/cache/com/google/guava/guava/30.1.0-jre/guava-30.1.0-jre.jar:/Users/bpontarelli/.savant/cache/com/google/guava/listenablefuture/9999.0.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0.0-empty-to-avoid-conflict-with-guava.jar:/Users/bpontarelli/.savant/cache/com/google/j2objc/j2objc-annotations/1.3.0/j2objc-annotations-1.3.0.jar:/Users/bpontarelli/.savant/cache/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.jar:/Users/bpontarelli/.savant/cache/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/Users/bpontarelli/.savant/cache/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar:/Users/bpontarelli/.savant/cache/com/inversoft/jackson5/3.0.1/jackson5-3.0.1.jar com.intellij.rt.testng.RemoteTestNGStarter -listener org.primeframework.mvc.PrimeBaseTest$TestListener -usedefaultlisteners false -socket58163 @w@/private/var/folders/z6/t_y9tpcj1p57_r4dy67d5_j40000gn/T/idea_working_dirs_testng.tmp -temp /private/var/folders/z6/t_y9tpcj1p57_r4dy67d5_j40000gn/T/idea_testng.tmp
+Connected to the target VM, address: '127.0.0.1:58164', transport: 'socket'
+May 11, 2023 11:36:19.927 AM INFO  org.testng.internal.Utils - [TestNG] Running:
+  /Users/bpontarelli/Library/Caches/JetBrains/IntelliJIdea2023.1/temp-testng-customsuite.xml
+
+May 11, 2023 11:36:20.176 AM INFO  org.primeframework.mvc.PrimeMVCRequestHandler - Initializing Prime
+May 11, 2023 11:36:20.470 AM INFO  org.primeframework.mvc.TestPrimeMainThread - Prime HTTP server started
+[1] org.primeframework.mvc.PerformanceTest.get
+0
+100
+200
+300
+400
+
+java.lang.AssertionError: Body didn't contain [address0]
+Redirect: [null]
+Body:
+
+
+	at org.primeframework.mvc.test.RequestResult._assertBodyContains(RequestResult.java:1496)
+	at org.primeframework.mvc.test.RequestResult.assertBodyContains(RequestResult.java:260)
+	at org.primeframework.mvc.PerformanceTest.get(PerformanceTest.java:32)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
+	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
+	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:677)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:221)
+	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
+	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:969)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:194)
+	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:148)
+	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
+	at org.testng.TestRunner.privateRun(TestRunner.java:829)
+	at org.testng.TestRunner.run(TestRunner.java:602)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:431)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:391)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:330)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1256)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1176)
+	at org.testng.TestNG.runSuites(TestNG.java:1099)
+	at org.testng.TestNG.run(TestNG.java:1067)
+	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
+	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
+
+
+
+
+Test failure
+-----------------
+Exception: AssertionError
+Message: Body didn't contain [address0]
+Redirect: [null]
+Body:
+
+
+HTTP Trace:
+
+     | 1683826580583 (HTTPS-A)
+     | 1683826580583 (A)
+     | 1683826580583 Accepted connection from client [/127.0.0.1:58169]
+     | 1683826580584 Read [336] bytes from client
+     | 1683826580584 (R)
+     | 1683826580584 (RP)
+     | 1683826580586 Preamble successfully parsed
+     | 1683826580586 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580586 (RWo)
+     | 1683826580589 (RC)
+     | 1683826580767 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580772 Preamble is [198] bytes long
+     | 1683826580772 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580772 Still writing preamble
+     | 1683826580773 Wrote [198] bytes to the client
+     | 1683826580773 (W)
+     | 1683826580773 Writing back bytes
+     | 1683826580774 Wrote [160] bytes to the client
+     | 1683826580774 (W)
+     | 1683826580774 Writing back bytes
+     | 1683826580774 Wrote [5] bytes to the client
+     | 1683826580774 (W)
+     | 1683826580774 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580774 (WKA)
+     | 1683826580777 Read [336] bytes from client
+     | 1683826580777 (R)
+     | 1683826580777 (RP)
+     | 1683826580777 Preamble successfully parsed
+     | 1683826580777 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580777 (RWo)
+     | 1683826580777 (RC)
+     | 1683826580781 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580781 Preamble is [198] bytes long
+     | 1683826580781 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580781 Still writing preamble
+     | 1683826580781 Wrote [198] bytes to the client
+     | 1683826580781 (W)
+     | 1683826580782 Writing back bytes
+     | 1683826580782 Wrote [249] bytes to the client
+     | 1683826580782 (W)
+     | 1683826580782 Writing back bytes
+     | 1683826580782 Wrote [5] bytes to the client
+     | 1683826580782 (W)
+     | 1683826580782 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580782 (WKA)
+     | 1683826580782 Read [336] bytes from client
+     | 1683826580782 (R)
+     | 1683826580782 (RP)
+     | 1683826580782 Preamble successfully parsed
+     | 1683826580782 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580782 (RWo)
+     | 1683826580782 (RC)
+     | 1683826580785 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580786 Preamble is [198] bytes long
+     | 1683826580786 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580786 Still writing preamble
+     | 1683826580786 Wrote [198] bytes to the client
+     | 1683826580786 (W)
+     | 1683826580786 Writing back bytes
+     | 1683826580786 Wrote [339] bytes to the client
+     | 1683826580786 (W)
+     | 1683826580786 Writing back bytes
+     | 1683826580786 Wrote [5] bytes to the client
+     | 1683826580786 (W)
+     | 1683826580786 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580786 (WKA)
+     | 1683826580786 Read [336] bytes from client
+     | 1683826580786 (R)
+     | 1683826580786 (RP)
+     | 1683826580786 Preamble successfully parsed
+     | 1683826580786 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580786 (RWo)
+     | 1683826580786 (RC)
+     | 1683826580790 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580790 Preamble is [198] bytes long
+     | 1683826580790 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580790 Still writing preamble
+     | 1683826580790 Wrote [198] bytes to the client
+     | 1683826580790 (W)
+     | 1683826580790 Writing back bytes
+     | 1683826580790 Wrote [428] bytes to the client
+     | 1683826580790 (W)
+     | 1683826580790 Writing back bytes
+     | 1683826580790 Wrote [5] bytes to the client
+     | 1683826580790 (W)
+     | 1683826580790 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580790 (WKA)
+     | 1683826580791 Read [336] bytes from client
+     | 1683826580791 (R)
+     | 1683826580791 (RP)
+     | 1683826580791 Preamble successfully parsed
+     | 1683826580791 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580791 (RWo)
+     | 1683826580791 (RC)
+     | 1683826580794 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580794 Preamble is [198] bytes long
+     | 1683826580794 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580794 Still writing preamble
+     | 1683826580794 Wrote [198] bytes to the client
+     | 1683826580794 (W)
+     | 1683826580794 Writing back bytes
+     | 1683826580794 Wrote [517] bytes to the client
+     | 1683826580794 (W)
+     | 1683826580794 Writing back bytes
+     | 1683826580794 Wrote [5] bytes to the client
+     | 1683826580794 (W)
+     | 1683826580794 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580794 (WKA)
+     | 1683826580795 Read [336] bytes from client
+     | 1683826580795 (R)
+     | 1683826580795 (RP)
+     | 1683826580795 Preamble successfully parsed
+     | 1683826580795 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580795 (RWo)
+     | 1683826580795 (RC)
+     | 1683826580798 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580798 Preamble is [198] bytes long
+     | 1683826580798 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580798 Still writing preamble
+     | 1683826580798 Wrote [198] bytes to the client
+     | 1683826580798 (W)
+     | 1683826580798 Writing back bytes
+     | 1683826580798 Wrote [606] bytes to the client
+     | 1683826580798 (W)
+     | 1683826580798 Writing back bytes
+     | 1683826580798 Wrote [5] bytes to the client
+     | 1683826580798 (W)
+     | 1683826580798 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580798 (WKA)
+     | 1683826580799 Read [336] bytes from client
+     | 1683826580799 (R)
+     | 1683826580799 (RP)
+     | 1683826580799 Preamble successfully parsed
+     | 1683826580799 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580799 (RWo)
+     | 1683826580799 (RC)
+     | 1683826580802 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580802 Preamble is [198] bytes long
+     | 1683826580802 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580802 Still writing preamble
+     | 1683826580802 Wrote [198] bytes to the client
+     | 1683826580802 (W)
+     | 1683826580802 Writing back bytes
+     | 1683826580802 Wrote [695] bytes to the client
+     | 1683826580802 (W)
+     | 1683826580802 Writing back bytes
+     | 1683826580802 Wrote [5] bytes to the client
+     | 1683826580802 (W)
+     | 1683826580802 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580802 (WKA)
+     | 1683826580802 Read [336] bytes from client
+     | 1683826580802 (R)
+     | 1683826580802 (RP)
+     | 1683826580803 Preamble successfully parsed
+     | 1683826580803 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580803 (RWo)
+     | 1683826580803 (RC)
+     | 1683826580805 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580805 Preamble is [198] bytes long
+     | 1683826580805 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580805 Still writing preamble
+     | 1683826580806 Wrote [198] bytes to the client
+     | 1683826580806 (W)
+     | 1683826580806 Writing back bytes
+     | 1683826580806 Wrote [784] bytes to the client
+     | 1683826580806 (W)
+     | 1683826580806 Writing back bytes
+     | 1683826580806 Wrote [5] bytes to the client
+     | 1683826580806 (W)
+     | 1683826580806 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580806 (WKA)
+     | 1683826580806 Read [336] bytes from client
+     | 1683826580806 (R)
+     | 1683826580806 (RP)
+     | 1683826580806 Preamble successfully parsed
+     | 1683826580806 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580806 (RWo)
+     | 1683826580806 (RC)
+     | 1683826580809 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580809 Preamble is [198] bytes long
+     | 1683826580809 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580809 Still writing preamble
+     | 1683826580809 Wrote [198] bytes to the client
+     | 1683826580809 (W)
+     | 1683826580809 Writing back bytes
+     | 1683826580809 Wrote [873] bytes to the client
+     | 1683826580809 (W)
+     | 1683826580809 Writing back bytes
+     | 1683826580809 Wrote [5] bytes to the client
+     | 1683826580809 (W)
+     | 1683826580809 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580809 (WKA)
+     | 1683826580810 Read [336] bytes from client
+     | 1683826580810 (R)
+     | 1683826580810 (RP)
+     | 1683826580810 Preamble successfully parsed
+     | 1683826580810 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580810 (RWo)
+     | 1683826580810 (RC)
+     | 1683826580813 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580813 Preamble is [198] bytes long
+     | 1683826580813 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580813 Still writing preamble
+     | 1683826580813 Wrote [198] bytes to the client
+     | 1683826580813 (W)
+     | 1683826580813 Writing back bytes
+     | 1683826580813 Wrote [962] bytes to the client
+     | 1683826580813 (W)
+     | 1683826580813 Writing back bytes
+     | 1683826580813 Wrote [5] bytes to the client
+     | 1683826580813 (W)
+     | 1683826580813 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580813 (WKA)
+     | 1683826580814 Read [336] bytes from client
+     | 1683826580814 (R)
+     | 1683826580814 (RP)
+     | 1683826580814 Preamble successfully parsed
+     | 1683826580814 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580814 (RWo)
+     | 1683826580814 (RC)
+     | 1683826580816 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580816 Preamble is [198] bytes long
+     | 1683826580816 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580816 Still writing preamble
+     | 1683826580816 Wrote [198] bytes to the client
+     | 1683826580816 (W)
+     | 1683826580816 Writing back bytes
+     | 1683826580816 Wrote [1056] bytes to the client
+     | 1683826580816 (W)
+     | 1683826580816 Writing back bytes
+     | 1683826580816 Wrote [5] bytes to the client
+     | 1683826580816 (W)
+     | 1683826580816 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580816 (WKA)
+     | 1683826580817 Read [336] bytes from client
+     | 1683826580817 (R)
+     | 1683826580817 (RP)
+     | 1683826580817 Preamble successfully parsed
+     | 1683826580817 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580817 (RWo)
+     | 1683826580817 (RC)
+     | 1683826580819 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580819 Preamble is [198] bytes long
+     | 1683826580819 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580819 Still writing preamble
+     | 1683826580819 Wrote [198] bytes to the client
+     | 1683826580819 (W)
+     | 1683826580819 Writing back bytes
+     | 1683826580819 Wrote [1150] bytes to the client
+     | 1683826580819 (W)
+     | 1683826580819 Writing back bytes
+     | 1683826580819 Wrote [5] bytes to the client
+     | 1683826580819 (W)
+     | 1683826580819 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580819 (WKA)
+     | 1683826580820 Read [336] bytes from client
+     | 1683826580820 (R)
+     | 1683826580820 (RP)
+     | 1683826580820 Preamble successfully parsed
+     | 1683826580820 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580820 (RWo)
+     | 1683826580820 (RC)
+     | 1683826580827 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580827 Preamble is [198] bytes long
+     | 1683826580827 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580827 Still writing preamble
+     | 1683826580827 Wrote [198] bytes to the client
+     | 1683826580827 (W)
+     | 1683826580827 Writing back bytes
+     | 1683826580827 Wrote [1244] bytes to the client
+     | 1683826580827 (W)
+     | 1683826580827 Writing back bytes
+     | 1683826580827 Wrote [5] bytes to the client
+     | 1683826580827 (W)
+     | 1683826580827 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580827 (WKA)
+     | 1683826580827 Read [336] bytes from client
+     | 1683826580827 (R)
+     | 1683826580827 (RP)
+     | 1683826580828 Preamble successfully parsed
+     | 1683826580828 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580828 (RWo)
+     | 1683826580828 (RC)
+     | 1683826580830 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580830 Preamble is [198] bytes long
+     | 1683826580830 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580830 Still writing preamble
+     | 1683826580830 Wrote [198] bytes to the client
+     | 1683826580830 (W)
+     | 1683826580830 Writing back bytes
+     | 1683826580830 Wrote [1338] bytes to the client
+     | 1683826580830 (W)
+     | 1683826580830 Writing back bytes
+     | 1683826580830 Wrote [5] bytes to the client
+     | 1683826580830 (W)
+     | 1683826580830 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580830 (WKA)
+     | 1683826580831 Read [336] bytes from client
+     | 1683826580831 (R)
+     | 1683826580831 (RP)
+     | 1683826580831 Preamble successfully parsed
+     | 1683826580831 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580831 (RWo)
+     | 1683826580831 (RC)
+     | 1683826580833 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580833 Preamble is [198] bytes long
+     | 1683826580833 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580833 Still writing preamble
+     | 1683826580833 Wrote [198] bytes to the client
+     | 1683826580833 (W)
+     | 1683826580833 Writing back bytes
+     | 1683826580833 Wrote [1432] bytes to the client
+     | 1683826580833 (W)
+     | 1683826580833 Writing back bytes
+     | 1683826580833 Wrote [5] bytes to the client
+     | 1683826580833 (W)
+     | 1683826580833 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580833 (WKA)
+     | 1683826580834 Read [336] bytes from client
+     | 1683826580834 (R)
+     | 1683826580834 (RP)
+     | 1683826580834 Preamble successfully parsed
+     | 1683826580834 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580834 (RWo)
+     | 1683826580834 (RC)
+     | 1683826580836 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580836 Preamble is [198] bytes long
+     | 1683826580836 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580836 Still writing preamble
+     | 1683826580836 Wrote [198] bytes to the client
+     | 1683826580836 (W)
+     | 1683826580836 Writing back bytes
+     | 1683826580836 Wrote [1526] bytes to the client
+     | 1683826580836 (W)
+     | 1683826580836 Writing back bytes
+     | 1683826580836 Wrote [5] bytes to the client
+     | 1683826580836 (W)
+     | 1683826580836 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580836 (WKA)
+     | 1683826580837 Read [336] bytes from client
+     | 1683826580837 (R)
+     | 1683826580837 (RP)
+     | 1683826580837 Preamble successfully parsed
+     | 1683826580837 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580837 (RWo)
+     | 1683826580837 (RC)
+     | 1683826580840 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580840 Preamble is [198] bytes long
+     | 1683826580840 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580840 Still writing preamble
+     | 1683826580840 Wrote [198] bytes to the client
+     | 1683826580840 (W)
+     | 1683826580840 Writing back bytes
+     | 1683826580840 Wrote [1620] bytes to the client
+     | 1683826580840 (W)
+     | 1683826580840 Writing back bytes
+     | 1683826580840 Wrote [5] bytes to the client
+     | 1683826580840 (W)
+     | 1683826580840 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580840 (WKA)
+     | 1683826580841 Read [336] bytes from client
+     | 1683826580841 (R)
+     | 1683826580841 (RP)
+     | 1683826580841 Preamble successfully parsed
+     | 1683826580841 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580841 (RWo)
+     | 1683826580841 (RC)
+     | 1683826580844 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580844 Preamble is [198] bytes long
+     | 1683826580844 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580844 Still writing preamble
+     | 1683826580844 Wrote [198] bytes to the client
+     | 1683826580844 (W)
+     | 1683826580844 Writing back bytes
+     | 1683826580844 Wrote [1714] bytes to the client
+     | 1683826580844 (W)
+     | 1683826580844 Writing back bytes
+     | 1683826580844 Wrote [5] bytes to the client
+     | 1683826580844 (W)
+     | 1683826580844 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580844 (WKA)
+     | 1683826580844 Read [336] bytes from client
+     | 1683826580844 (R)
+     | 1683826580844 (RP)
+     | 1683826580844 Preamble successfully parsed
+     | 1683826580844 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580844 (RWo)
+     | 1683826580844 (RC)
+     | 1683826580847 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580847 Preamble is [198] bytes long
+     | 1683826580847 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580847 Still writing preamble
+     | 1683826580847 Wrote [198] bytes to the client
+     | 1683826580847 (W)
+     | 1683826580847 Writing back bytes
+     | 1683826580847 Wrote [1808] bytes to the client
+     | 1683826580847 (W)
+     | 1683826580847 Writing back bytes
+     | 1683826580847 Wrote [5] bytes to the client
+     | 1683826580847 (W)
+     | 1683826580847 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580847 (WKA)
+     | 1683826580847 Read [336] bytes from client
+     | 1683826580847 (R)
+     | 1683826580847 (RP)
+     | 1683826580847 Preamble successfully parsed
+     | 1683826580847 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580847 (RWo)
+     | 1683826580847 (RC)
+     | 1683826580849 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580850 Preamble is [198] bytes long
+     | 1683826580850 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580850 Still writing preamble
+     | 1683826580850 Wrote [198] bytes to the client
+     | 1683826580850 (W)
+     | 1683826580850 Writing back bytes
+     | 1683826580850 Wrote [1902] bytes to the client
+     | 1683826580850 (W)
+     | 1683826580850 Writing back bytes
+     | 1683826580850 Wrote [5] bytes to the client
+     | 1683826580850 (W)
+     | 1683826580850 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580850 (WKA)
+     | 1683826580850 Read [336] bytes from client
+     | 1683826580850 (R)
+     | 1683826580850 (RP)
+     | 1683826580850 Preamble successfully parsed
+     | 1683826580850 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580850 (RWo)
+     | 1683826580850 (RC)
+     | 1683826580852 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580852 Preamble is [198] bytes long
+     | 1683826580852 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580852 Still writing preamble
+     | 1683826580852 Wrote [198] bytes to the client
+     | 1683826580852 (W)
+     | 1683826580852 Writing back bytes
+     | 1683826580852 Wrote [1996] bytes to the client
+     | 1683826580852 (W)
+     | 1683826580852 Writing back bytes
+     | 1683826580852 Wrote [5] bytes to the client
+     | 1683826580852 (W)
+     | 1683826580852 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580852 (WKA)
+     | 1683826580853 Read [336] bytes from client
+     | 1683826580853 (R)
+     | 1683826580853 (RP)
+     | 1683826580853 Preamble successfully parsed
+     | 1683826580853 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580853 (RWo)
+     | 1683826580853 (RC)
+     | 1683826580855 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580855 Preamble is [198] bytes long
+     | 1683826580855 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580855 Still writing preamble
+     | 1683826580856 Wrote [198] bytes to the client
+     | 1683826580856 (W)
+     | 1683826580856 Writing back bytes
+     | 1683826580856 Wrote [2090] bytes to the client
+     | 1683826580856 (W)
+     | 1683826580856 Writing back bytes
+     | 1683826580856 Wrote [5] bytes to the client
+     | 1683826580856 (W)
+     | 1683826580856 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580856 (WKA)
+     | 1683826580856 Read [336] bytes from client
+     | 1683826580856 (R)
+     | 1683826580856 (RP)
+     | 1683826580856 Preamble successfully parsed
+     | 1683826580856 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580856 (RWo)
+     | 1683826580857 (RC)
+     | 1683826580858 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580859 Preamble is [198] bytes long
+     | 1683826580859 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580859 Still writing preamble
+     | 1683826580859 Wrote [198] bytes to the client
+     | 1683826580859 (W)
+     | 1683826580859 Writing back bytes
+     | 1683826580859 Wrote [2184] bytes to the client
+     | 1683826580859 (W)
+     | 1683826580859 Writing back bytes
+     | 1683826580859 Wrote [5] bytes to the client
+     | 1683826580859 (W)
+     | 1683826580859 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580859 (WKA)
+     | 1683826580859 Read [336] bytes from client
+     | 1683826580859 (R)
+     | 1683826580859 (RP)
+     | 1683826580859 Preamble successfully parsed
+     | 1683826580859 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580859 (RWo)
+     | 1683826580859 (RC)
+     | 1683826580861 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580861 Preamble is [198] bytes long
+     | 1683826580861 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580861 Still writing preamble
+     | 1683826580861 Wrote [198] bytes to the client
+     | 1683826580861 (W)
+     | 1683826580861 Writing back bytes
+     | 1683826580861 Wrote [2278] bytes to the client
+     | 1683826580861 (W)
+     | 1683826580861 Writing back bytes
+     | 1683826580861 Wrote [5] bytes to the client
+     | 1683826580861 (W)
+     | 1683826580861 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580861 (WKA)
+     | 1683826580862 Read [336] bytes from client
+     | 1683826580862 (R)
+     | 1683826580862 (RP)
+     | 1683826580862 Preamble successfully parsed
+     | 1683826580862 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580862 (RWo)
+     | 1683826580862 (RC)
+     | 1683826580864 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580864 Preamble is [198] bytes long
+     | 1683826580864 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580864 Still writing preamble
+     | 1683826580864 Wrote [198] bytes to the client
+     | 1683826580864 (W)
+     | 1683826580864 Writing back bytes
+     | 1683826580864 Wrote [2372] bytes to the client
+     | 1683826580864 (W)
+     | 1683826580864 Writing back bytes
+     | 1683826580864 Wrote [5] bytes to the client
+     | 1683826580864 (W)
+     | 1683826580864 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580864 (WKA)
+     | 1683826580865 Read [336] bytes from client
+     | 1683826580865 (R)
+     | 1683826580865 (RP)
+     | 1683826580865 Preamble successfully parsed
+     | 1683826580865 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580865 (RWo)
+     | 1683826580865 (RC)
+     | 1683826580867 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580867 Preamble is [198] bytes long
+     | 1683826580867 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580867 Still writing preamble
+     | 1683826580867 Wrote [198] bytes to the client
+     | 1683826580867 (W)
+     | 1683826580867 Writing back bytes
+     | 1683826580867 Wrote [2466] bytes to the client
+     | 1683826580867 (W)
+     | 1683826580867 Writing back bytes
+     | 1683826580867 Wrote [5] bytes to the client
+     | 1683826580867 (W)
+     | 1683826580867 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580867 (WKA)
+     | 1683826580868 Read [336] bytes from client
+     | 1683826580868 (R)
+     | 1683826580868 (RP)
+     | 1683826580868 Preamble successfully parsed
+     | 1683826580868 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580868 (RWo)
+     | 1683826580868 (RC)
+     | 1683826580870 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580870 Preamble is [198] bytes long
+     | 1683826580870 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580870 Still writing preamble
+     | 1683826580870 Wrote [198] bytes to the client
+     | 1683826580870 (W)
+     | 1683826580870 Writing back bytes
+     | 1683826580870 Wrote [2560] bytes to the client
+     | 1683826580870 (W)
+     | 1683826580870 Writing back bytes
+     | 1683826580870 Wrote [5] bytes to the client
+     | 1683826580870 (W)
+     | 1683826580870 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580870 (WKA)
+     | 1683826580870 Read [336] bytes from client
+     | 1683826580870 (R)
+     | 1683826580870 (RP)
+     | 1683826580870 Preamble successfully parsed
+     | 1683826580870 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580870 (RWo)
+     | 1683826580871 (RC)
+     | 1683826580872 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580872 Preamble is [198] bytes long
+     | 1683826580872 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580872 Still writing preamble
+     | 1683826580872 Wrote [198] bytes to the client
+     | 1683826580872 (W)
+     | 1683826580872 Writing back bytes
+     | 1683826580872 Wrote [2654] bytes to the client
+     | 1683826580872 (W)
+     | 1683826580872 Writing back bytes
+     | 1683826580872 Wrote [5] bytes to the client
+     | 1683826580872 (W)
+     | 1683826580872 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580872 (WKA)
+     | 1683826580873 Read [336] bytes from client
+     | 1683826580873 (R)
+     | 1683826580873 (RP)
+     | 1683826580873 Preamble successfully parsed
+     | 1683826580873 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580873 (RWo)
+     | 1683826580873 (RC)
+     | 1683826580875 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580875 Preamble is [198] bytes long
+     | 1683826580875 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580875 Still writing preamble
+     | 1683826580875 Wrote [198] bytes to the client
+     | 1683826580875 (W)
+     | 1683826580875 Writing back bytes
+     | 1683826580875 Wrote [2748] bytes to the client
+     | 1683826580875 (W)
+     | 1683826580875 Writing back bytes
+     | 1683826580875 Wrote [5] bytes to the client
+     | 1683826580875 (W)
+     | 1683826580875 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580875 (WKA)
+     | 1683826580876 Read [336] bytes from client
+     | 1683826580876 (R)
+     | 1683826580876 (RP)
+     | 1683826580876 Preamble successfully parsed
+     | 1683826580876 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580876 (RWo)
+     | 1683826580876 (RC)
+     | 1683826580878 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580878 Preamble is [198] bytes long
+     | 1683826580878 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580878 Still writing preamble
+     | 1683826580878 Wrote [198] bytes to the client
+     | 1683826580878 (W)
+     | 1683826580878 Writing back bytes
+     | 1683826580878 Wrote [2842] bytes to the client
+     | 1683826580878 (W)
+     | 1683826580878 Writing back bytes
+     | 1683826580878 Wrote [5] bytes to the client
+     | 1683826580878 (W)
+     | 1683826580878 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580878 (WKA)
+     | 1683826580879 Read [336] bytes from client
+     | 1683826580879 (R)
+     | 1683826580879 (RP)
+     | 1683826580879 Preamble successfully parsed
+     | 1683826580879 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580879 (RWo)
+     | 1683826580879 (RC)
+     | 1683826580881 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580881 Preamble is [198] bytes long
+     | 1683826580881 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580881 Still writing preamble
+     | 1683826580881 Wrote [198] bytes to the client
+     | 1683826580881 (W)
+     | 1683826580881 Writing back bytes
+     | 1683826580881 Wrote [2936] bytes to the client
+     | 1683826580881 (W)
+     | 1683826580881 Writing back bytes
+     | 1683826580881 Wrote [5] bytes to the client
+     | 1683826580881 (W)
+     | 1683826580881 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580881 (WKA)
+     | 1683826580881 Read [336] bytes from client
+     | 1683826580881 (R)
+     | 1683826580881 (RP)
+     | 1683826580882 Preamble successfully parsed
+     | 1683826580882 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580882 (RWo)
+     | 1683826580882 (RC)
+     | 1683826580884 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580884 Preamble is [198] bytes long
+     | 1683826580884 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580884 Still writing preamble
+     | 1683826580884 Wrote [198] bytes to the client
+     | 1683826580884 (W)
+     | 1683826580884 Writing back bytes
+     | 1683826580884 Wrote [3030] bytes to the client
+     | 1683826580884 (W)
+     | 1683826580884 Writing back bytes
+     | 1683826580884 Wrote [5] bytes to the client
+     | 1683826580884 (W)
+     | 1683826580884 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580884 (WKA)
+     | 1683826580884 Read [336] bytes from client
+     | 1683826580884 (R)
+     | 1683826580884 (RP)
+     | 1683826580884 Preamble successfully parsed
+     | 1683826580884 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580884 (RWo)
+     | 1683826580884 (RC)
+     | 1683826580886 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580886 Preamble is [198] bytes long
+     | 1683826580886 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580886 Still writing preamble
+     | 1683826580886 Wrote [198] bytes to the client
+     | 1683826580886 (W)
+     | 1683826580886 Writing back bytes
+     | 1683826580886 Wrote [3124] bytes to the client
+     | 1683826580886 (W)
+     | 1683826580886 Writing back bytes
+     | 1683826580886 Wrote [5] bytes to the client
+     | 1683826580886 (W)
+     | 1683826580886 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580886 (WKA)
+     | 1683826580887 Read [336] bytes from client
+     | 1683826580887 (R)
+     | 1683826580887 (RP)
+     | 1683826580887 Preamble successfully parsed
+     | 1683826580887 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580887 (RWo)
+     | 1683826580887 (RC)
+     | 1683826580888 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580888 Preamble is [198] bytes long
+     | 1683826580888 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580888 Still writing preamble
+     | 1683826580888 Wrote [198] bytes to the client
+     | 1683826580888 (W)
+     | 1683826580888 Writing back bytes
+     | 1683826580889 Wrote [3218] bytes to the client
+     | 1683826580889 (W)
+     | 1683826580889 Writing back bytes
+     | 1683826580889 Wrote [5] bytes to the client
+     | 1683826580889 (W)
+     | 1683826580889 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580889 (WKA)
+     | 1683826580889 Read [336] bytes from client
+     | 1683826580889 (R)
+     | 1683826580889 (RP)
+     | 1683826580889 Preamble successfully parsed
+     | 1683826580889 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580889 (RWo)
+     | 1683826580889 (RC)
+     | 1683826580891 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580891 Preamble is [198] bytes long
+     | 1683826580891 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580891 Still writing preamble
+     | 1683826580891 Wrote [198] bytes to the client
+     | 1683826580891 (W)
+     | 1683826580891 Writing back bytes
+     | 1683826580891 Wrote [3312] bytes to the client
+     | 1683826580891 (W)
+     | 1683826580891 Writing back bytes
+     | 1683826580891 Wrote [5] bytes to the client
+     | 1683826580891 (W)
+     | 1683826580891 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580891 (WKA)
+     | 1683826580892 Read [336] bytes from client
+     | 1683826580892 (R)
+     | 1683826580892 (RP)
+     | 1683826580892 Preamble successfully parsed
+     | 1683826580892 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580892 (RWo)
+     | 1683826580892 (RC)
+     | 1683826580894 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580894 Preamble is [198] bytes long
+     | 1683826580894 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580894 Still writing preamble
+     | 1683826580894 Wrote [198] bytes to the client
+     | 1683826580894 (W)
+     | 1683826580894 Writing back bytes
+     | 1683826580894 Wrote [3406] bytes to the client
+     | 1683826580894 (W)
+     | 1683826580894 Writing back bytes
+     | 1683826580894 Wrote [5] bytes to the client
+     | 1683826580894 (W)
+     | 1683826580894 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580894 (WKA)
+     | 1683826580894 Read [336] bytes from client
+     | 1683826580894 (R)
+     | 1683826580894 (RP)
+     | 1683826580894 Preamble successfully parsed
+     | 1683826580894 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580894 (RWo)
+     | 1683826580894 (RC)
+     | 1683826580896 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580896 Preamble is [198] bytes long
+     | 1683826580896 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580896 Still writing preamble
+     | 1683826580896 Wrote [198] bytes to the client
+     | 1683826580896 (W)
+     | 1683826580896 Writing back bytes
+     | 1683826580896 Wrote [3500] bytes to the client
+     | 1683826580896 (W)
+     | 1683826580896 Writing back bytes
+     | 1683826580896 Wrote [5] bytes to the client
+     | 1683826580896 (W)
+     | 1683826580896 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580896 (WKA)
+     | 1683826580897 Read [336] bytes from client
+     | 1683826580897 (R)
+     | 1683826580897 (RP)
+     | 1683826580897 Preamble successfully parsed
+     | 1683826580897 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580897 (RWo)
+     | 1683826580897 (RC)
+     | 1683826580898 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580898 Preamble is [198] bytes long
+     | 1683826580898 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580898 Still writing preamble
+     | 1683826580898 Wrote [198] bytes to the client
+     | 1683826580898 (W)
+     | 1683826580898 Writing back bytes
+     | 1683826580898 Wrote [3594] bytes to the client
+     | 1683826580898 (W)
+     | 1683826580898 Writing back bytes
+     | 1683826580898 Wrote [5] bytes to the client
+     | 1683826580898 (W)
+     | 1683826580898 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580898 (WKA)
+     | 1683826580899 Read [336] bytes from client
+     | 1683826580899 (R)
+     | 1683826580899 (RP)
+     | 1683826580899 Preamble successfully parsed
+     | 1683826580899 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580899 (RWo)
+     | 1683826580899 (RC)
+     | 1683826580901 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580901 Preamble is [198] bytes long
+     | 1683826580901 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580901 Still writing preamble
+     | 1683826580901 Wrote [198] bytes to the client
+     | 1683826580901 (W)
+     | 1683826580901 Writing back bytes
+     | 1683826580901 Wrote [3688] bytes to the client
+     | 1683826580901 (W)
+     | 1683826580901 Writing back bytes
+     | 1683826580901 Wrote [5] bytes to the client
+     | 1683826580901 (W)
+     | 1683826580901 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580901 (WKA)
+     | 1683826580902 Read [336] bytes from client
+     | 1683826580902 (R)
+     | 1683826580902 (RP)
+     | 1683826580902 Preamble successfully parsed
+     | 1683826580902 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580902 (RWo)
+     | 1683826580902 (RC)
+     | 1683826580904 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580904 Preamble is [198] bytes long
+     | 1683826580904 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580904 Still writing preamble
+     | 1683826580904 Wrote [198] bytes to the client
+     | 1683826580904 (W)
+     | 1683826580904 Writing back bytes
+     | 1683826580904 Wrote [3782] bytes to the client
+     | 1683826580904 (W)
+     | 1683826580904 Writing back bytes
+     | 1683826580904 Wrote [5] bytes to the client
+     | 1683826580904 (W)
+     | 1683826580904 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580904 (WKA)
+     | 1683826580904 Read [336] bytes from client
+     | 1683826580904 (R)
+     | 1683826580904 (RP)
+     | 1683826580904 Preamble successfully parsed
+     | 1683826580904 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580904 (RWo)
+     | 1683826580905 (RC)
+     | 1683826580906 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580906 Preamble is [198] bytes long
+     | 1683826580906 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580906 Still writing preamble
+     | 1683826580906 Wrote [198] bytes to the client
+     | 1683826580906 (W)
+     | 1683826580906 Writing back bytes
+     | 1683826580906 Wrote [3876] bytes to the client
+     | 1683826580906 (W)
+     | 1683826580906 Writing back bytes
+     | 1683826580906 Wrote [5] bytes to the client
+     | 1683826580906 (W)
+     | 1683826580906 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580906 (WKA)
+     | 1683826580907 Read [336] bytes from client
+     | 1683826580907 (R)
+     | 1683826580907 (RP)
+     | 1683826580907 Preamble successfully parsed
+     | 1683826580907 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580907 (RWo)
+     | 1683826580907 (RC)
+     | 1683826580909 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580909 Preamble is [198] bytes long
+     | 1683826580909 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580909 Still writing preamble
+     | 1683826580909 Wrote [198] bytes to the client
+     | 1683826580909 (W)
+     | 1683826580909 Writing back bytes
+     | 1683826580909 Wrote [3970] bytes to the client
+     | 1683826580909 (W)
+     | 1683826580909 Writing back bytes
+     | 1683826580909 Wrote [5] bytes to the client
+     | 1683826580909 (W)
+     | 1683826580909 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580909 (WKA)
+     | 1683826580909 Read [336] bytes from client
+     | 1683826580909 (R)
+     | 1683826580909 (RP)
+     | 1683826580909 Preamble successfully parsed
+     | 1683826580909 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580909 (RWo)
+     | 1683826580909 (RC)
+     | 1683826580911 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580911 Preamble is [198] bytes long
+     | 1683826580911 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580911 Still writing preamble
+     | 1683826580911 Wrote [198] bytes to the client
+     | 1683826580911 (W)
+     | 1683826580911 Writing back bytes
+     | 1683826580911 Wrote [4064] bytes to the client
+     | 1683826580911 (W)
+     | 1683826580911 Writing back bytes
+     | 1683826580911 Wrote [5] bytes to the client
+     | 1683826580911 (W)
+     | 1683826580911 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580911 (WKA)
+     | 1683826580912 Read [336] bytes from client
+     | 1683826580912 (R)
+     | 1683826580912 (RP)
+     | 1683826580912 Preamble successfully parsed
+     | 1683826580912 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580912 (RWo)
+     | 1683826580912 (RC)
+     | 1683826580913 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580913 Preamble is [198] bytes long
+     | 1683826580913 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580913 Still writing preamble
+     | 1683826580913 Wrote [198] bytes to the client
+     | 1683826580913 (W)
+     | 1683826580913 Writing back bytes
+     | 1683826580913 Wrote [4159] bytes to the client
+     | 1683826580913 (W)
+     | 1683826580913 Writing back bytes
+     | 1683826580913 Wrote [5] bytes to the client
+     | 1683826580913 (W)
+     | 1683826580913 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580913 (WKA)
+     | 1683826580914 Read [336] bytes from client
+     | 1683826580914 (R)
+     | 1683826580914 (RP)
+     | 1683826580914 Preamble successfully parsed
+     | 1683826580914 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580914 (RWo)
+     | 1683826580914 (RC)
+     | 1683826580915 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580916 Preamble is [198] bytes long
+     | 1683826580916 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580916 Still writing preamble
+     | 1683826580916 Wrote [198] bytes to the client
+     | 1683826580916 (W)
+     | 1683826580916 Writing back bytes
+     | 1683826580916 Wrote [4253] bytes to the client
+     | 1683826580916 (W)
+     | 1683826580916 Writing back bytes
+     | 1683826580916 Wrote [5] bytes to the client
+     | 1683826580916 (W)
+     | 1683826580916 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580916 (WKA)
+     | 1683826580916 Read [336] bytes from client
+     | 1683826580916 (R)
+     | 1683826580916 (RP)
+     | 1683826580916 Preamble successfully parsed
+     | 1683826580916 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580916 (RWo)
+     | 1683826580916 (RC)
+     | 1683826580918 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580918 Preamble is [198] bytes long
+     | 1683826580918 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580918 Still writing preamble
+     | 1683826580918 Wrote [198] bytes to the client
+     | 1683826580918 (W)
+     | 1683826580918 Writing back bytes
+     | 1683826580918 Wrote [4347] bytes to the client
+     | 1683826580918 (W)
+     | 1683826580918 Writing back bytes
+     | 1683826580918 Wrote [5] bytes to the client
+     | 1683826580918 (W)
+     | 1683826580918 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580918 (WKA)
+     | 1683826580918 Read [336] bytes from client
+     | 1683826580918 (R)
+     | 1683826580918 (RP)
+     | 1683826580918 Preamble successfully parsed
+     | 1683826580918 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580918 (RWo)
+     | 1683826580918 (RC)
+     | 1683826580920 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580920 Preamble is [198] bytes long
+     | 1683826580920 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580920 Still writing preamble
+     | 1683826580920 Wrote [198] bytes to the client
+     | 1683826580920 (W)
+     | 1683826580920 Writing back bytes
+     | 1683826580920 Wrote [4441] bytes to the client
+     | 1683826580920 (W)
+     | 1683826580920 Writing back bytes
+     | 1683826580920 Wrote [5] bytes to the client
+     | 1683826580920 (W)
+     | 1683826580920 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580920 (WKA)
+     | 1683826580920 Read [336] bytes from client
+     | 1683826580920 (R)
+     | 1683826580920 (RP)
+     | 1683826580921 Preamble successfully parsed
+     | 1683826580921 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580921 (RWo)
+     | 1683826580921 (RC)
+     | 1683826580922 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580922 Preamble is [198] bytes long
+     | 1683826580922 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580922 Still writing preamble
+     | 1683826580922 Wrote [198] bytes to the client
+     | 1683826580922 (W)
+     | 1683826580922 Writing back bytes
+     | 1683826580922 Wrote [4535] bytes to the client
+     | 1683826580922 (W)
+     | 1683826580922 Writing back bytes
+     | 1683826580922 Wrote [5] bytes to the client
+     | 1683826580922 (W)
+     | 1683826580922 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580922 (WKA)
+     | 1683826580923 Read [336] bytes from client
+     | 1683826580923 (R)
+     | 1683826580923 (RP)
+     | 1683826580923 Preamble successfully parsed
+     | 1683826580923 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580923 (RWo)
+     | 1683826580923 (RC)
+     | 1683826580924 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580924 Preamble is [198] bytes long
+     | 1683826580924 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580924 Still writing preamble
+     | 1683826580924 Wrote [198] bytes to the client
+     | 1683826580924 (W)
+     | 1683826580924 Writing back bytes
+     | 1683826580924 Wrote [4629] bytes to the client
+     | 1683826580924 (W)
+     | 1683826580924 Writing back bytes
+     | 1683826580924 Wrote [5] bytes to the client
+     | 1683826580924 (W)
+     | 1683826580924 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580924 (WKA)
+     | 1683826580925 Read [336] bytes from client
+     | 1683826580925 (R)
+     | 1683826580925 (RP)
+     | 1683826580925 Preamble successfully parsed
+     | 1683826580925 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580925 (RWo)
+     | 1683826580925 (RC)
+     | 1683826580927 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580927 Preamble is [198] bytes long
+     | 1683826580927 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580927 Still writing preamble
+     | 1683826580927 Wrote [198] bytes to the client
+     | 1683826580927 (W)
+     | 1683826580927 Writing back bytes
+     | 1683826580927 Wrote [4723] bytes to the client
+     | 1683826580927 (W)
+     | 1683826580927 Writing back bytes
+     | 1683826580927 Wrote [5] bytes to the client
+     | 1683826580927 (W)
+     | 1683826580927 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580927 (WKA)
+     | 1683826580927 Read [336] bytes from client
+     | 1683826580927 (R)
+     | 1683826580927 (RP)
+     | 1683826580927 Preamble successfully parsed
+     | 1683826580927 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580927 (RWo)
+     | 1683826580927 (RC)
+     | 1683826580929 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580929 Preamble is [198] bytes long
+     | 1683826580929 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580929 Still writing preamble
+     | 1683826580929 Wrote [198] bytes to the client
+     | 1683826580929 (W)
+     | 1683826580929 Writing back bytes
+     | 1683826580929 Wrote [4817] bytes to the client
+     | 1683826580929 (W)
+     | 1683826580929 Writing back bytes
+     | 1683826580929 Wrote [5] bytes to the client
+     | 1683826580929 (W)
+     | 1683826580929 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580929 (WKA)
+     | 1683826580930 Read [336] bytes from client
+     | 1683826580930 (R)
+     | 1683826580930 (RP)
+     | 1683826580930 Preamble successfully parsed
+     | 1683826580930 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580930 (RWo)
+     | 1683826580930 (RC)
+     | 1683826580931 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580931 Preamble is [198] bytes long
+     | 1683826580931 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580931 Still writing preamble
+     | 1683826580931 Wrote [198] bytes to the client
+     | 1683826580931 (W)
+     | 1683826580931 Writing back bytes
+     | 1683826580931 Wrote [4911] bytes to the client
+     | 1683826580931 (W)
+     | 1683826580931 Writing back bytes
+     | 1683826580931 Wrote [5] bytes to the client
+     | 1683826580931 (W)
+     | 1683826580931 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580931 (WKA)
+     | 1683826580932 Read [336] bytes from client
+     | 1683826580932 (R)
+     | 1683826580932 (RP)
+     | 1683826580932 Preamble successfully parsed
+     | 1683826580932 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580932 (RWo)
+     | 1683826580932 (RC)
+     | 1683826580933 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580933 Preamble is [198] bytes long
+     | 1683826580934 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580934 Still writing preamble
+     | 1683826580934 Wrote [198] bytes to the client
+     | 1683826580934 (W)
+     | 1683826580934 Writing back bytes
+     | 1683826580934 Wrote [5005] bytes to the client
+     | 1683826580934 (W)
+     | 1683826580934 Writing back bytes
+     | 1683826580934 Wrote [5] bytes to the client
+     | 1683826580934 (W)
+     | 1683826580934 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580934 (WKA)
+     | 1683826580934 Read [336] bytes from client
+     | 1683826580934 (R)
+     | 1683826580934 (RP)
+     | 1683826580934 Preamble successfully parsed
+     | 1683826580934 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580934 (RWo)
+     | 1683826580934 (RC)
+     | 1683826580936 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580936 Preamble is [198] bytes long
+     | 1683826580936 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580936 Still writing preamble
+     | 1683826580936 Wrote [198] bytes to the client
+     | 1683826580936 (W)
+     | 1683826580936 Writing back bytes
+     | 1683826580936 Wrote [5099] bytes to the client
+     | 1683826580936 (W)
+     | 1683826580936 Writing back bytes
+     | 1683826580936 Wrote [5] bytes to the client
+     | 1683826580936 (W)
+     | 1683826580936 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580936 (WKA)
+     | 1683826580936 Read [336] bytes from client
+     | 1683826580936 (R)
+     | 1683826580936 (RP)
+     | 1683826580936 Preamble successfully parsed
+     | 1683826580936 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580936 (RWo)
+     | 1683826580936 (RC)
+     | 1683826580938 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580938 Preamble is [198] bytes long
+     | 1683826580938 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580938 Still writing preamble
+     | 1683826580938 Wrote [198] bytes to the client
+     | 1683826580938 (W)
+     | 1683826580938 Writing back bytes
+     | 1683826580938 Wrote [5193] bytes to the client
+     | 1683826580938 (W)
+     | 1683826580938 Writing back bytes
+     | 1683826580938 Wrote [5] bytes to the client
+     | 1683826580938 (W)
+     | 1683826580938 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580938 (WKA)
+     | 1683826580938 Read [336] bytes from client
+     | 1683826580938 (R)
+     | 1683826580938 (RP)
+     | 1683826580938 Preamble successfully parsed
+     | 1683826580938 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580938 (RWo)
+     | 1683826580938 (RC)
+     | 1683826580940 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580940 Preamble is [198] bytes long
+     | 1683826580940 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580940 Still writing preamble
+     | 1683826580940 Wrote [198] bytes to the client
+     | 1683826580940 (W)
+     | 1683826580940 Writing back bytes
+     | 1683826580940 Wrote [5287] bytes to the client
+     | 1683826580940 (W)
+     | 1683826580940 Writing back bytes
+     | 1683826580940 Wrote [5] bytes to the client
+     | 1683826580940 (W)
+     | 1683826580940 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580940 (WKA)
+     | 1683826580940 Read [336] bytes from client
+     | 1683826580940 (R)
+     | 1683826580940 (RP)
+     | 1683826580940 Preamble successfully parsed
+     | 1683826580940 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580940 (RWo)
+     | 1683826580940 (RC)
+     | 1683826580942 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580942 Preamble is [198] bytes long
+     | 1683826580942 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580942 Still writing preamble
+     | 1683826580942 Wrote [198] bytes to the client
+     | 1683826580942 (W)
+     | 1683826580942 Writing back bytes
+     | 1683826580942 Wrote [5381] bytes to the client
+     | 1683826580942 (W)
+     | 1683826580942 Writing back bytes
+     | 1683826580942 Wrote [5] bytes to the client
+     | 1683826580942 (W)
+     | 1683826580942 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580942 (WKA)
+     | 1683826580942 Read [336] bytes from client
+     | 1683826580942 (R)
+     | 1683826580942 (RP)
+     | 1683826580942 Preamble successfully parsed
+     | 1683826580942 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580942 (RWo)
+     | 1683826580942 (RC)
+     | 1683826580944 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580944 Preamble is [198] bytes long
+     | 1683826580944 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580944 Still writing preamble
+     | 1683826580944 Wrote [198] bytes to the client
+     | 1683826580944 (W)
+     | 1683826580944 Writing back bytes
+     | 1683826580944 Wrote [5475] bytes to the client
+     | 1683826580944 (W)
+     | 1683826580944 Writing back bytes
+     | 1683826580944 Wrote [5] bytes to the client
+     | 1683826580944 (W)
+     | 1683826580944 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580944 (WKA)
+     | 1683826580945 Read [336] bytes from client
+     | 1683826580945 (R)
+     | 1683826580945 (RP)
+     | 1683826580945 Preamble successfully parsed
+     | 1683826580945 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580945 (RWo)
+     | 1683826580945 (RC)
+     | 1683826580946 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580946 Preamble is [198] bytes long
+     | 1683826580946 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580946 Still writing preamble
+     | 1683826580946 Wrote [198] bytes to the client
+     | 1683826580946 (W)
+     | 1683826580946 Writing back bytes
+     | 1683826580946 Wrote [5569] bytes to the client
+     | 1683826580946 (W)
+     | 1683826580946 Writing back bytes
+     | 1683826580946 Wrote [5] bytes to the client
+     | 1683826580946 (W)
+     | 1683826580946 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580946 (WKA)
+     | 1683826580947 Read [336] bytes from client
+     | 1683826580947 (R)
+     | 1683826580947 (RP)
+     | 1683826580947 Preamble successfully parsed
+     | 1683826580947 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580947 (RWo)
+     | 1683826580947 (RC)
+     | 1683826580948 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580948 Preamble is [198] bytes long
+     | 1683826580948 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580948 Still writing preamble
+     | 1683826580948 Wrote [198] bytes to the client
+     | 1683826580948 (W)
+     | 1683826580948 Writing back bytes
+     | 1683826580948 Wrote [5663] bytes to the client
+     | 1683826580948 (W)
+     | 1683826580948 Writing back bytes
+     | 1683826580948 Wrote [5] bytes to the client
+     | 1683826580948 (W)
+     | 1683826580948 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580948 (WKA)
+     | 1683826580948 Read [336] bytes from client
+     | 1683826580948 (R)
+     | 1683826580948 (RP)
+     | 1683826580949 Preamble successfully parsed
+     | 1683826580949 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580949 (RWo)
+     | 1683826580949 (RC)
+     | 1683826580950 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580950 Preamble is [198] bytes long
+     | 1683826580950 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580950 Still writing preamble
+     | 1683826580950 Wrote [198] bytes to the client
+     | 1683826580950 (W)
+     | 1683826580950 Writing back bytes
+     | 1683826580950 Wrote [5757] bytes to the client
+     | 1683826580950 (W)
+     | 1683826580950 Writing back bytes
+     | 1683826580950 Wrote [5] bytes to the client
+     | 1683826580950 (W)
+     | 1683826580950 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580950 (WKA)
+     | 1683826580950 Read [336] bytes from client
+     | 1683826580950 (R)
+     | 1683826580950 (RP)
+     | 1683826580950 Preamble successfully parsed
+     | 1683826580950 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580950 (RWo)
+     | 1683826580951 (RC)
+     | 1683826580952 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580952 Preamble is [198] bytes long
+     | 1683826580952 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580952 Still writing preamble
+     | 1683826580952 Wrote [198] bytes to the client
+     | 1683826580952 (W)
+     | 1683826580952 Writing back bytes
+     | 1683826580952 Wrote [5851] bytes to the client
+     | 1683826580952 (W)
+     | 1683826580952 Writing back bytes
+     | 1683826580952 Wrote [5] bytes to the client
+     | 1683826580952 (W)
+     | 1683826580952 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580952 (WKA)
+     | 1683826580952 Read [336] bytes from client
+     | 1683826580952 (R)
+     | 1683826580952 (RP)
+     | 1683826580952 Preamble successfully parsed
+     | 1683826580952 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580952 (RWo)
+     | 1683826580952 (RC)
+     | 1683826580953 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580953 Preamble is [198] bytes long
+     | 1683826580954 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580954 Still writing preamble
+     | 1683826580954 Wrote [198] bytes to the client
+     | 1683826580954 (W)
+     | 1683826580954 Writing back bytes
+     | 1683826580954 Wrote [5945] bytes to the client
+     | 1683826580954 (W)
+     | 1683826580954 Writing back bytes
+     | 1683826580954 Wrote [5] bytes to the client
+     | 1683826580954 (W)
+     | 1683826580954 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580954 (WKA)
+     | 1683826580954 Read [336] bytes from client
+     | 1683826580954 (R)
+     | 1683826580954 (RP)
+     | 1683826580954 Preamble successfully parsed
+     | 1683826580954 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580954 (RWo)
+     | 1683826580954 (RC)
+     | 1683826580956 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580956 Preamble is [198] bytes long
+     | 1683826580956 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580956 Still writing preamble
+     | 1683826580956 Wrote [198] bytes to the client
+     | 1683826580956 (W)
+     | 1683826580956 Writing back bytes
+     | 1683826580956 Wrote [6039] bytes to the client
+     | 1683826580956 (W)
+     | 1683826580956 Writing back bytes
+     | 1683826580956 Wrote [5] bytes to the client
+     | 1683826580956 (W)
+     | 1683826580956 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580956 (WKA)
+     | 1683826580956 Read [336] bytes from client
+     | 1683826580956 (R)
+     | 1683826580956 (RP)
+     | 1683826580956 Preamble successfully parsed
+     | 1683826580956 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580956 (RWo)
+     | 1683826580956 (RC)
+     | 1683826580958 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580958 Preamble is [198] bytes long
+     | 1683826580958 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580958 Still writing preamble
+     | 1683826580958 Wrote [198] bytes to the client
+     | 1683826580958 (W)
+     | 1683826580958 Writing back bytes
+     | 1683826580958 Wrote [6133] bytes to the client
+     | 1683826580958 (W)
+     | 1683826580958 Writing back bytes
+     | 1683826580958 Wrote [5] bytes to the client
+     | 1683826580958 (W)
+     | 1683826580958 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580958 (WKA)
+     | 1683826580958 Read [336] bytes from client
+     | 1683826580958 (R)
+     | 1683826580958 (RP)
+     | 1683826580958 Preamble successfully parsed
+     | 1683826580958 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580958 (RWo)
+     | 1683826580958 (RC)
+     | 1683826580960 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580960 Preamble is [198] bytes long
+     | 1683826580960 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580960 Still writing preamble
+     | 1683826580960 Wrote [198] bytes to the client
+     | 1683826580960 (W)
+     | 1683826580960 Writing back bytes
+     | 1683826580960 Wrote [6227] bytes to the client
+     | 1683826580960 (W)
+     | 1683826580960 Writing back bytes
+     | 1683826580960 Wrote [5] bytes to the client
+     | 1683826580960 (W)
+     | 1683826580960 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580960 (WKA)
+     | 1683826580960 Read [336] bytes from client
+     | 1683826580960 (R)
+     | 1683826580960 (RP)
+     | 1683826580960 Preamble successfully parsed
+     | 1683826580960 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580960 (RWo)
+     | 1683826580960 (RC)
+     | 1683826580961 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580961 Preamble is [198] bytes long
+     | 1683826580961 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580961 Still writing preamble
+     | 1683826580961 Wrote [198] bytes to the client
+     | 1683826580961 (W)
+     | 1683826580961 Writing back bytes
+     | 1683826580961 Wrote [6321] bytes to the client
+     | 1683826580961 (W)
+     | 1683826580961 Writing back bytes
+     | 1683826580961 Wrote [5] bytes to the client
+     | 1683826580961 (W)
+     | 1683826580961 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580961 (WKA)
+     | 1683826580962 Read [336] bytes from client
+     | 1683826580962 (R)
+     | 1683826580962 (RP)
+     | 1683826580962 Preamble successfully parsed
+     | 1683826580962 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580962 (RWo)
+     | 1683826580962 (RC)
+     | 1683826580963 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580963 Preamble is [198] bytes long
+     | 1683826580963 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580963 Still writing preamble
+     | 1683826580963 Wrote [198] bytes to the client
+     | 1683826580963 (W)
+     | 1683826580963 Writing back bytes
+     | 1683826580963 Wrote [6415] bytes to the client
+     | 1683826580963 (W)
+     | 1683826580963 Writing back bytes
+     | 1683826580963 Wrote [5] bytes to the client
+     | 1683826580963 (W)
+     | 1683826580963 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580963 (WKA)
+     | 1683826580964 Read [336] bytes from client
+     | 1683826580964 (R)
+     | 1683826580964 (RP)
+     | 1683826580964 Preamble successfully parsed
+     | 1683826580964 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580964 (RWo)
+     | 1683826580964 (RC)
+     | 1683826580965 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580965 Preamble is [198] bytes long
+     | 1683826580965 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580965 Still writing preamble
+     | 1683826580965 Wrote [198] bytes to the client
+     | 1683826580965 (W)
+     | 1683826580965 Writing back bytes
+     | 1683826580965 Wrote [6509] bytes to the client
+     | 1683826580965 (W)
+     | 1683826580965 Writing back bytes
+     | 1683826580965 Wrote [5] bytes to the client
+     | 1683826580965 (W)
+     | 1683826580965 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580965 (WKA)
+     | 1683826580965 Read [336] bytes from client
+     | 1683826580965 (R)
+     | 1683826580965 (RP)
+     | 1683826580966 Preamble successfully parsed
+     | 1683826580966 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580966 (RWo)
+     | 1683826580966 (RC)
+     | 1683826580967 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580967 Preamble is [198] bytes long
+     | 1683826580967 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580967 Still writing preamble
+     | 1683826580967 Wrote [198] bytes to the client
+     | 1683826580967 (W)
+     | 1683826580967 Writing back bytes
+     | 1683826580967 Wrote [6603] bytes to the client
+     | 1683826580967 (W)
+     | 1683826580967 Writing back bytes
+     | 1683826580967 Wrote [5] bytes to the client
+     | 1683826580967 (W)
+     | 1683826580967 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580967 (WKA)
+     | 1683826580967 Read [336] bytes from client
+     | 1683826580967 (R)
+     | 1683826580967 (RP)
+     | 1683826580967 Preamble successfully parsed
+     | 1683826580967 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580967 (RWo)
+     | 1683826580967 (RC)
+     | 1683826580969 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580969 Preamble is [198] bytes long
+     | 1683826580969 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580969 Still writing preamble
+     | 1683826580969 Wrote [198] bytes to the client
+     | 1683826580969 (W)
+     | 1683826580969 Writing back bytes
+     | 1683826580969 Wrote [6697] bytes to the client
+     | 1683826580969 (W)
+     | 1683826580969 Writing back bytes
+     | 1683826580969 Wrote [5] bytes to the client
+     | 1683826580969 (W)
+     | 1683826580969 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580969 (WKA)
+     | 1683826580969 Read [336] bytes from client
+     | 1683826580969 (R)
+     | 1683826580969 (RP)
+     | 1683826580969 Preamble successfully parsed
+     | 1683826580969 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580969 (RWo)
+     | 1683826580969 (RC)
+     | 1683826580971 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580971 Preamble is [198] bytes long
+     | 1683826580971 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580971 Still writing preamble
+     | 1683826580971 Wrote [198] bytes to the client
+     | 1683826580971 (W)
+     | 1683826580971 Writing back bytes
+     | 1683826580971 Wrote [6791] bytes to the client
+     | 1683826580971 (W)
+     | 1683826580971 Writing back bytes
+     | 1683826580971 Wrote [5] bytes to the client
+     | 1683826580971 (W)
+     | 1683826580971 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580971 (WKA)
+     | 1683826580971 Read [336] bytes from client
+     | 1683826580971 (R)
+     | 1683826580971 (RP)
+     | 1683826580971 Preamble successfully parsed
+     | 1683826580971 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580971 (RWo)
+     | 1683826580971 (RC)
+     | 1683826580972 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580972 Preamble is [198] bytes long
+     | 1683826580972 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580972 Still writing preamble
+     | 1683826580973 Wrote [198] bytes to the client
+     | 1683826580973 (W)
+     | 1683826580973 Writing back bytes
+     | 1683826580973 Wrote [6885] bytes to the client
+     | 1683826580973 (W)
+     | 1683826580973 Writing back bytes
+     | 1683826580973 Wrote [5] bytes to the client
+     | 1683826580973 (W)
+     | 1683826580973 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580973 (WKA)
+     | 1683826580973 Read [336] bytes from client
+     | 1683826580973 (R)
+     | 1683826580973 (RP)
+     | 1683826580973 Preamble successfully parsed
+     | 1683826580973 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580973 (RWo)
+     | 1683826580973 (RC)
+     | 1683826580974 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580974 Preamble is [198] bytes long
+     | 1683826580974 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580974 Still writing preamble
+     | 1683826580974 Wrote [198] bytes to the client
+     | 1683826580974 (W)
+     | 1683826580974 Writing back bytes
+     | 1683826580974 Wrote [6979] bytes to the client
+     | 1683826580974 (W)
+     | 1683826580974 Writing back bytes
+     | 1683826580974 Wrote [5] bytes to the client
+     | 1683826580974 (W)
+     | 1683826580974 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580974 (WKA)
+     | 1683826580975 Read [336] bytes from client
+     | 1683826580975 (R)
+     | 1683826580975 (RP)
+     | 1683826580975 Preamble successfully parsed
+     | 1683826580975 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580975 (RWo)
+     | 1683826580975 (RC)
+     | 1683826580976 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580976 Preamble is [198] bytes long
+     | 1683826580976 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580976 Still writing preamble
+     | 1683826580976 Wrote [198] bytes to the client
+     | 1683826580976 (W)
+     | 1683826580976 Writing back bytes
+     | 1683826580976 Wrote [7073] bytes to the client
+     | 1683826580976 (W)
+     | 1683826580976 Writing back bytes
+     | 1683826580976 Wrote [5] bytes to the client
+     | 1683826580976 (W)
+     | 1683826580976 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580976 (WKA)
+     | 1683826580976 Read [336] bytes from client
+     | 1683826580976 (R)
+     | 1683826580976 (RP)
+     | 1683826580976 Preamble successfully parsed
+     | 1683826580976 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580976 (RWo)
+     | 1683826580976 (RC)
+     | 1683826580978 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580978 Preamble is [198] bytes long
+     | 1683826580978 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580978 Still writing preamble
+     | 1683826580978 Wrote [198] bytes to the client
+     | 1683826580978 (W)
+     | 1683826580978 Writing back bytes
+     | 1683826580978 Wrote [7167] bytes to the client
+     | 1683826580978 (W)
+     | 1683826580978 Writing back bytes
+     | 1683826580978 Wrote [5] bytes to the client
+     | 1683826580978 (W)
+     | 1683826580978 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580978 (WKA)
+     | 1683826580978 Read [336] bytes from client
+     | 1683826580978 (R)
+     | 1683826580978 (RP)
+     | 1683826580979 Preamble successfully parsed
+     | 1683826580979 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580979 (RWo)
+     | 1683826580979 (RC)
+     | 1683826580980 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580980 Preamble is [198] bytes long
+     | 1683826580980 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580980 Still writing preamble
+     | 1683826580980 Wrote [198] bytes to the client
+     | 1683826580980 (W)
+     | 1683826580980 Writing back bytes
+     | 1683826580980 Wrote [7261] bytes to the client
+     | 1683826580980 (W)
+     | 1683826580980 Writing back bytes
+     | 1683826580980 Wrote [5] bytes to the client
+     | 1683826580980 (W)
+     | 1683826580980 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580980 (WKA)
+     | 1683826580980 Read [336] bytes from client
+     | 1683826580980 (R)
+     | 1683826580980 (RP)
+     | 1683826580980 Preamble successfully parsed
+     | 1683826580980 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580980 (RWo)
+     | 1683826580980 (RC)
+     | 1683826580982 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580982 Preamble is [198] bytes long
+     | 1683826580982 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580982 Still writing preamble
+     | 1683826580982 Wrote [198] bytes to the client
+     | 1683826580982 (W)
+     | 1683826580982 Writing back bytes
+     | 1683826580982 Wrote [7355] bytes to the client
+     | 1683826580982 (W)
+     | 1683826580982 Writing back bytes
+     | 1683826580982 Wrote [5] bytes to the client
+     | 1683826580982 (W)
+     | 1683826580982 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580982 (WKA)
+     | 1683826580982 Read [336] bytes from client
+     | 1683826580982 (R)
+     | 1683826580982 (RP)
+     | 1683826580982 Preamble successfully parsed
+     | 1683826580982 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580982 (RWo)
+     | 1683826580982 (RC)
+     | 1683826580984 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580984 Preamble is [198] bytes long
+     | 1683826580984 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580984 Still writing preamble
+     | 1683826580984 Wrote [198] bytes to the client
+     | 1683826580984 (W)
+     | 1683826580984 Writing back bytes
+     | 1683826580984 Wrote [7449] bytes to the client
+     | 1683826580984 (W)
+     | 1683826580984 Writing back bytes
+     | 1683826580984 Wrote [5] bytes to the client
+     | 1683826580984 (W)
+     | 1683826580984 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580984 (WKA)
+     | 1683826580984 Read [336] bytes from client
+     | 1683826580984 (R)
+     | 1683826580984 (RP)
+     | 1683826580984 Preamble successfully parsed
+     | 1683826580984 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580984 (RWo)
+     | 1683826580984 (RC)
+     | 1683826580986 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580986 Preamble is [198] bytes long
+     | 1683826580986 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580986 Still writing preamble
+     | 1683826580986 Wrote [198] bytes to the client
+     | 1683826580986 (W)
+     | 1683826580986 Writing back bytes
+     | 1683826580986 Wrote [7543] bytes to the client
+     | 1683826580986 (W)
+     | 1683826580986 Writing back bytes
+     | 1683826580986 Wrote [5] bytes to the client
+     | 1683826580986 (W)
+     | 1683826580986 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580986 (WKA)
+     | 1683826580986 Read [336] bytes from client
+     | 1683826580986 (R)
+     | 1683826580986 (RP)
+     | 1683826580986 Preamble successfully parsed
+     | 1683826580986 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580986 (RWo)
+     | 1683826580986 (RC)
+     | 1683826580987 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580987 Preamble is [198] bytes long
+     | 1683826580987 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580987 Still writing preamble
+     | 1683826580987 Wrote [198] bytes to the client
+     | 1683826580987 (W)
+     | 1683826580987 Writing back bytes
+     | 1683826580987 Wrote [7637] bytes to the client
+     | 1683826580987 (W)
+     | 1683826580987 Writing back bytes
+     | 1683826580987 Wrote [5] bytes to the client
+     | 1683826580987 (W)
+     | 1683826580987 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580987 (WKA)
+     | 1683826580988 Read [336] bytes from client
+     | 1683826580988 (R)
+     | 1683826580988 (RP)
+     | 1683826580988 Preamble successfully parsed
+     | 1683826580988 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580988 (RWo)
+     | 1683826580988 (RC)
+     | 1683826580989 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580989 Preamble is [198] bytes long
+     | 1683826580989 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580989 Still writing preamble
+     | 1683826580989 Wrote [198] bytes to the client
+     | 1683826580989 (W)
+     | 1683826580990 Writing back bytes
+     | 1683826580990 Wrote [7731] bytes to the client
+     | 1683826580990 (W)
+     | 1683826580990 Writing back bytes
+     | 1683826580990 Wrote [5] bytes to the client
+     | 1683826580990 (W)
+     | 1683826580990 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580990 (WKA)
+     | 1683826580990 Read [336] bytes from client
+     | 1683826580990 (R)
+     | 1683826580990 (RP)
+     | 1683826580990 Preamble successfully parsed
+     | 1683826580990 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580990 (RWo)
+     | 1683826580990 (RC)
+     | 1683826580991 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580992 Preamble is [198] bytes long
+     | 1683826580992 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580992 Still writing preamble
+     | 1683826580992 Wrote [198] bytes to the client
+     | 1683826580992 (W)
+     | 1683826580992 Writing back bytes
+     | 1683826580992 Wrote [7825] bytes to the client
+     | 1683826580992 (W)
+     | 1683826580992 Writing back bytes
+     | 1683826580992 Wrote [5] bytes to the client
+     | 1683826580992 (W)
+     | 1683826580992 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580992 (WKA)
+     | 1683826580992 Read [336] bytes from client
+     | 1683826580992 (R)
+     | 1683826580992 (RP)
+     | 1683826580992 Preamble successfully parsed
+     | 1683826580992 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580992 (RWo)
+     | 1683826580992 (RC)
+     | 1683826580993 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580994 Preamble is [198] bytes long
+     | 1683826580994 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580994 Still writing preamble
+     | 1683826580994 Wrote [198] bytes to the client
+     | 1683826580994 (W)
+     | 1683826580994 Writing back bytes
+     | 1683826580994 Wrote [7919] bytes to the client
+     | 1683826580994 (W)
+     | 1683826580994 Writing back bytes
+     | 1683826580994 Wrote [5] bytes to the client
+     | 1683826580994 (W)
+     | 1683826580994 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580994 (WKA)
+     | 1683826580994 Read [336] bytes from client
+     | 1683826580994 (R)
+     | 1683826580994 (RP)
+     | 1683826580994 Preamble successfully parsed
+     | 1683826580994 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580994 (RWo)
+     | 1683826580994 (RC)
+     | 1683826580995 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580995 Preamble is [198] bytes long
+     | 1683826580995 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580995 Still writing preamble
+     | 1683826580995 Wrote [198] bytes to the client
+     | 1683826580995 (W)
+     | 1683826580995 Writing back bytes
+     | 1683826580995 Wrote [8013] bytes to the client
+     | 1683826580995 (W)
+     | 1683826580995 Writing back bytes
+     | 1683826580995 Wrote [5] bytes to the client
+     | 1683826580995 (W)
+     | 1683826580995 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580995 (WKA)
+     | 1683826580996 Read [336] bytes from client
+     | 1683826580996 (R)
+     | 1683826580996 (RP)
+     | 1683826580996 Preamble successfully parsed
+     | 1683826580996 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580996 (RWo)
+     | 1683826580996 (RC)
+     | 1683826580997 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580997 Preamble is [198] bytes long
+     | 1683826580997 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580997 Still writing preamble
+     | 1683826580997 Wrote [198] bytes to the client
+     | 1683826580997 (W)
+     | 1683826580997 Writing back bytes
+     | 1683826580997 Wrote [8107] bytes to the client
+     | 1683826580997 (W)
+     | 1683826580997 Writing back bytes
+     | 1683826580997 Wrote [5] bytes to the client
+     | 1683826580997 (W)
+     | 1683826580997 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580997 (WKA)
+     | 1683826580998 Read [336] bytes from client
+     | 1683826580998 (R)
+     | 1683826580998 (RP)
+     | 1683826580998 Preamble successfully parsed
+     | 1683826580998 Client indicated it was NOT sending an entity-body in the request
+     | 1683826580998 (RWo)
+     | 1683826580998 (RC)
+     | 1683826580999 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826580999 Preamble is [198] bytes long
+     | 1683826580999 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826580999 Still writing preamble
+     | 1683826580999 Wrote [198] bytes to the client
+     | 1683826580999 (W)
+     | 1683826580999 Writing back bytes
+     | 1683826580999 Wrote [8201] bytes to the client
+     | 1683826580999 (W)
+     | 1683826580999 Writing back bytes
+     | 1683826580999 Wrote [5] bytes to the client
+     | 1683826580999 (W)
+     | 1683826580999 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826580999 (WKA)
+     | 1683826581000 Read [336] bytes from client
+     | 1683826581000 (R)
+     | 1683826581000 (RP)
+     | 1683826581000 Preamble successfully parsed
+     | 1683826581000 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581000 (RWo)
+     | 1683826581000 (RC)
+     | 1683826581001 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581001 Preamble is [198] bytes long
+     | 1683826581001 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581001 Still writing preamble
+     | 1683826581001 Wrote [198] bytes to the client
+     | 1683826581001 (W)
+     | 1683826581001 Writing back bytes
+     | 1683826581001 Wrote [8295] bytes to the client
+     | 1683826581001 (W)
+     | 1683826581001 Writing back bytes
+     | 1683826581001 Wrote [5] bytes to the client
+     | 1683826581001 (W)
+     | 1683826581001 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581001 (WKA)
+     | 1683826581001 Read [336] bytes from client
+     | 1683826581001 (R)
+     | 1683826581001 (RP)
+     | 1683826581001 Preamble successfully parsed
+     | 1683826581001 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581001 (RWo)
+     | 1683826581001 (RC)
+     | 1683826581003 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581003 Preamble is [198] bytes long
+     | 1683826581003 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581003 Still writing preamble
+     | 1683826581003 Wrote [198] bytes to the client
+     | 1683826581003 (W)
+     | 1683826581003 Writing back bytes
+     | 1683826581003 Wrote [8389] bytes to the client
+     | 1683826581003 (W)
+     | 1683826581003 Writing back bytes
+     | 1683826581003 Wrote [5] bytes to the client
+     | 1683826581003 (W)
+     | 1683826581003 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581003 (WKA)
+     | 1683826581003 Read [336] bytes from client
+     | 1683826581003 (R)
+     | 1683826581003 (RP)
+     | 1683826581003 Preamble successfully parsed
+     | 1683826581003 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581003 (RWo)
+     | 1683826581003 (RC)
+     | 1683826581004 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581004 Preamble is [198] bytes long
+     | 1683826581004 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581004 Still writing preamble
+     | 1683826581004 Wrote [198] bytes to the client
+     | 1683826581004 (W)
+     | 1683826581004 Writing back bytes
+     | 1683826581005 Wrote [8483] bytes to the client
+     | 1683826581005 (W)
+     | 1683826581005 Writing back bytes
+     | 1683826581005 Wrote [5] bytes to the client
+     | 1683826581005 (W)
+     | 1683826581005 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581005 (WKA)
+     | 1683826581005 Read [336] bytes from client
+     | 1683826581005 (R)
+     | 1683826581005 (RP)
+     | 1683826581005 Preamble successfully parsed
+     | 1683826581005 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581005 (RWo)
+     | 1683826581005 (RC)
+     | 1683826581006 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581006 Preamble is [198] bytes long
+     | 1683826581006 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581006 Still writing preamble
+     | 1683826581006 Wrote [198] bytes to the client
+     | 1683826581006 (W)
+     | 1683826581006 Writing back bytes
+     | 1683826581006 Wrote [8577] bytes to the client
+     | 1683826581006 (W)
+     | 1683826581006 Writing back bytes
+     | 1683826581006 Wrote [5] bytes to the client
+     | 1683826581006 (W)
+     | 1683826581006 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581006 (WKA)
+     | 1683826581007 Read [336] bytes from client
+     | 1683826581007 (R)
+     | 1683826581007 (RP)
+     | 1683826581007 Preamble successfully parsed
+     | 1683826581007 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581007 (RWo)
+     | 1683826581007 (RC)
+     | 1683826581008 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581008 Preamble is [198] bytes long
+     | 1683826581008 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581008 Still writing preamble
+     | 1683826581008 Wrote [198] bytes to the client
+     | 1683826581008 (W)
+     | 1683826581008 Writing back bytes
+     | 1683826581008 Wrote [8671] bytes to the client
+     | 1683826581008 (W)
+     | 1683826581008 Writing back bytes
+     | 1683826581008 Wrote [5] bytes to the client
+     | 1683826581008 (W)
+     | 1683826581008 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581008 (WKA)
+     | 1683826581009 Read [336] bytes from client
+     | 1683826581009 (R)
+     | 1683826581009 (RP)
+     | 1683826581009 Preamble successfully parsed
+     | 1683826581009 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581009 (RWo)
+     | 1683826581009 (RC)
+     | 1683826581010 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581010 Preamble is [198] bytes long
+     | 1683826581010 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581010 Still writing preamble
+     | 1683826581010 Wrote [198] bytes to the client
+     | 1683826581010 (W)
+     | 1683826581010 Writing back bytes
+     | 1683826581010 Wrote [8765] bytes to the client
+     | 1683826581010 (W)
+     | 1683826581010 Writing back bytes
+     | 1683826581010 Wrote [5] bytes to the client
+     | 1683826581010 (W)
+     | 1683826581010 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581010 (WKA)
+     | 1683826581011 Read [336] bytes from client
+     | 1683826581011 (R)
+     | 1683826581011 (RP)
+     | 1683826581011 Preamble successfully parsed
+     | 1683826581011 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581011 (RWo)
+     | 1683826581011 (RC)
+     | 1683826581012 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581012 Preamble is [198] bytes long
+     | 1683826581012 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581012 Still writing preamble
+     | 1683826581012 Wrote [198] bytes to the client
+     | 1683826581012 (W)
+     | 1683826581012 Writing back bytes
+     | 1683826581012 Wrote [8859] bytes to the client
+     | 1683826581012 (W)
+     | 1683826581012 Writing back bytes
+     | 1683826581012 Wrote [5] bytes to the client
+     | 1683826581012 (W)
+     | 1683826581012 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581012 (WKA)
+     | 1683826581013 Read [336] bytes from client
+     | 1683826581013 (R)
+     | 1683826581013 (RP)
+     | 1683826581013 Preamble successfully parsed
+     | 1683826581013 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581013 (RWo)
+     | 1683826581013 (RC)
+     | 1683826581014 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581014 Preamble is [198] bytes long
+     | 1683826581014 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581014 Still writing preamble
+     | 1683826581014 Wrote [198] bytes to the client
+     | 1683826581014 (W)
+     | 1683826581014 Writing back bytes
+     | 1683826581014 Wrote [8953] bytes to the client
+     | 1683826581014 (W)
+     | 1683826581014 Writing back bytes
+     | 1683826581014 Wrote [5] bytes to the client
+     | 1683826581014 (W)
+     | 1683826581014 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581014 (WKA)
+     | 1683826581015 Read [336] bytes from client
+     | 1683826581015 (R)
+     | 1683826581015 (RP)
+     | 1683826581015 Preamble successfully parsed
+     | 1683826581015 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581015 (RWo)
+     | 1683826581015 (RC)
+     | 1683826581016 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581016 Preamble is [198] bytes long
+     | 1683826581016 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581016 Still writing preamble
+     | 1683826581016 Wrote [198] bytes to the client
+     | 1683826581016 (W)
+     | 1683826581016 Writing back bytes
+     | 1683826581016 Wrote [9047] bytes to the client
+     | 1683826581016 (W)
+     | 1683826581016 Writing back bytes
+     | 1683826581016 Wrote [5] bytes to the client
+     | 1683826581016 (W)
+     | 1683826581016 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581016 (WKA)
+     | 1683826581017 Read [336] bytes from client
+     | 1683826581017 (R)
+     | 1683826581017 (RP)
+     | 1683826581017 Preamble successfully parsed
+     | 1683826581017 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581017 (RWo)
+     | 1683826581017 (RC)
+     | 1683826581018 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581018 Preamble is [198] bytes long
+     | 1683826581018 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581018 Still writing preamble
+     | 1683826581018 Wrote [198] bytes to the client
+     | 1683826581018 (W)
+     | 1683826581018 Writing back bytes
+     | 1683826581018 Wrote [9141] bytes to the client
+     | 1683826581018 (W)
+     | 1683826581018 Writing back bytes
+     | 1683826581018 Wrote [5] bytes to the client
+     | 1683826581018 (W)
+     | 1683826581018 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581018 (WKA)
+     | 1683826581018 Read [336] bytes from client
+     | 1683826581018 (R)
+     | 1683826581018 (RP)
+     | 1683826581018 Preamble successfully parsed
+     | 1683826581018 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581018 (RWo)
+     | 1683826581018 (RC)
+     | 1683826581020 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581020 Preamble is [198] bytes long
+     | 1683826581020 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581020 Still writing preamble
+     | 1683826581020 Wrote [198] bytes to the client
+     | 1683826581020 (W)
+     | 1683826581020 Writing back bytes
+     | 1683826581020 Wrote [9235] bytes to the client
+     | 1683826581020 (W)
+     | 1683826581020 Writing back bytes
+     | 1683826581020 Wrote [5] bytes to the client
+     | 1683826581020 (W)
+     | 1683826581020 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581020 (WKA)
+     | 1683826581020 Read [336] bytes from client
+     | 1683826581020 (R)
+     | 1683826581020 (RP)
+     | 1683826581020 Preamble successfully parsed
+     | 1683826581020 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581020 (RWo)
+     | 1683826581020 (RC)
+     | 1683826581021 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581021 Preamble is [198] bytes long
+     | 1683826581021 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581021 Still writing preamble
+     | 1683826581021 Wrote [198] bytes to the client
+     | 1683826581021 (W)
+     | 1683826581021 Writing back bytes
+     | 1683826581021 Wrote [9329] bytes to the client
+     | 1683826581021 (W)
+     | 1683826581021 Writing back bytes
+     | 1683826581021 Wrote [5] bytes to the client
+     | 1683826581021 (W)
+     | 1683826581021 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581021 (WKA)
+     | 1683826581022 Read [336] bytes from client
+     | 1683826581022 (R)
+     | 1683826581022 (RP)
+     | 1683826581022 Preamble successfully parsed
+     | 1683826581022 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581022 (RWo)
+     | 1683826581022 (RC)
+     | 1683826581023 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581023 Preamble is [198] bytes long
+     | 1683826581023 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581023 Still writing preamble
+     | 1683826581023 Wrote [198] bytes to the client
+     | 1683826581023 (W)
+     | 1683826581023 Writing back bytes
+     | 1683826581023 Wrote [9423] bytes to the client
+     | 1683826581023 (W)
+     | 1683826581023 Writing back bytes
+     | 1683826581023 Wrote [5] bytes to the client
+     | 1683826581023 (W)
+     | 1683826581023 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581023 (WKA)
+     | 1683826581023 Read [336] bytes from client
+     | 1683826581023 (R)
+     | 1683826581023 (RP)
+     | 1683826581023 Preamble successfully parsed
+     | 1683826581023 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581023 (RWo)
+     | 1683826581023 (RC)
+     | 1683826581025 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581025 Preamble is [198] bytes long
+     | 1683826581025 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581025 Still writing preamble
+     | 1683826581025 Wrote [198] bytes to the client
+     | 1683826581025 (W)
+     | 1683826581025 Writing back bytes
+     | 1683826581025 Wrote [9522] bytes to the client
+     | 1683826581025 (W)
+     | 1683826581025 Writing back bytes
+     | 1683826581025 Wrote [5] bytes to the client
+     | 1683826581025 (W)
+     | 1683826581025 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581025 (WKA)
+     | 1683826581025 Read [336] bytes from client
+     | 1683826581025 (R)
+     | 1683826581025 (RP)
+     | 1683826581025 Preamble successfully parsed
+     | 1683826581025 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581025 (RWo)
+     | 1683826581025 (RC)
+     | 1683826581027 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581027 Preamble is [198] bytes long
+     | 1683826581027 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581027 Still writing preamble
+     | 1683826581027 Wrote [198] bytes to the client
+     | 1683826581027 (W)
+     | 1683826581027 Writing back bytes
+     | 1683826581027 Wrote [9621] bytes to the client
+     | 1683826581027 (W)
+     | 1683826581027 Writing back bytes
+     | 1683826581027 Wrote [5] bytes to the client
+     | 1683826581027 (W)
+     | 1683826581027 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581027 (WKA)
+     | 1683826581027 Read [336] bytes from client
+     | 1683826581027 (R)
+     | 1683826581027 (RP)
+     | 1683826581027 Preamble successfully parsed
+     | 1683826581027 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581027 (RWo)
+     | 1683826581027 (RC)
+     | 1683826581029 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581029 Preamble is [198] bytes long
+     | 1683826581029 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581029 Still writing preamble
+     | 1683826581029 Wrote [198] bytes to the client
+     | 1683826581029 (W)
+     | 1683826581029 Writing back bytes
+     | 1683826581029 Wrote [9720] bytes to the client
+     | 1683826581029 (W)
+     | 1683826581029 Writing back bytes
+     | 1683826581029 Wrote [5] bytes to the client
+     | 1683826581029 (W)
+     | 1683826581029 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581029 (WKA)
+     | 1683826581029 Read [336] bytes from client
+     | 1683826581029 (R)
+     | 1683826581029 (RP)
+     | 1683826581029 Preamble successfully parsed
+     | 1683826581029 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581029 (RWo)
+     | 1683826581029 (RC)
+     | 1683826581031 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581031 Preamble is [198] bytes long
+     | 1683826581031 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581031 Still writing preamble
+     | 1683826581031 Wrote [198] bytes to the client
+     | 1683826581031 (W)
+     | 1683826581031 Writing back bytes
+     | 1683826581031 Wrote [9819] bytes to the client
+     | 1683826581031 (W)
+     | 1683826581031 Writing back bytes
+     | 1683826581031 Wrote [5] bytes to the client
+     | 1683826581031 (W)
+     | 1683826581031 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581031 (WKA)
+     | 1683826581031 Read [336] bytes from client
+     | 1683826581031 (R)
+     | 1683826581031 (RP)
+     | 1683826581031 Preamble successfully parsed
+     | 1683826581031 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581031 (RWo)
+     | 1683826581031 (RC)
+     | 1683826581033 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581033 Preamble is [198] bytes long
+     | 1683826581033 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581033 Still writing preamble
+     | 1683826581033 Wrote [198] bytes to the client
+     | 1683826581033 (W)
+     | 1683826581033 Writing back bytes
+     | 1683826581033 Wrote [9918] bytes to the client
+     | 1683826581033 (W)
+     | 1683826581033 Writing back bytes
+     | 1683826581033 Wrote [5] bytes to the client
+     | 1683826581033 (W)
+     | 1683826581033 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581033 (WKA)
+     | 1683826581033 Read [336] bytes from client
+     | 1683826581033 (R)
+     | 1683826581033 (RP)
+     | 1683826581033 Preamble successfully parsed
+     | 1683826581033 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581033 (RWo)
+     | 1683826581033 (RC)
+     | 1683826581034 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581034 Preamble is [198] bytes long
+     | 1683826581034 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581034 Still writing preamble
+     | 1683826581034 Wrote [198] bytes to the client
+     | 1683826581034 (W)
+     | 1683826581034 Writing back bytes
+     | 1683826581034 Wrote [10017] bytes to the client
+     | 1683826581034 (W)
+     | 1683826581034 Writing back bytes
+     | 1683826581034 Wrote [5] bytes to the client
+     | 1683826581034 (W)
+     | 1683826581034 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581034 (WKA)
+     | 1683826581035 Read [336] bytes from client
+     | 1683826581035 (R)
+     | 1683826581035 (RP)
+     | 1683826581035 Preamble successfully parsed
+     | 1683826581035 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581035 (RWo)
+     | 1683826581035 (RC)
+     | 1683826581036 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581036 Preamble is [198] bytes long
+     | 1683826581036 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581036 Still writing preamble
+     | 1683826581036 Wrote [198] bytes to the client
+     | 1683826581036 (W)
+     | 1683826581036 Writing back bytes
+     | 1683826581036 Wrote [10116] bytes to the client
+     | 1683826581036 (W)
+     | 1683826581036 Writing back bytes
+     | 1683826581036 Wrote [5] bytes to the client
+     | 1683826581036 (W)
+     | 1683826581036 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581036 (WKA)
+     | 1683826581036 Read [336] bytes from client
+     | 1683826581036 (R)
+     | 1683826581036 (RP)
+     | 1683826581036 Preamble successfully parsed
+     | 1683826581036 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581036 (RWo)
+     | 1683826581036 (RC)
+     | 1683826581038 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581038 Preamble is [198] bytes long
+     | 1683826581038 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581038 Still writing preamble
+     | 1683826581038 Wrote [198] bytes to the client
+     | 1683826581038 (W)
+     | 1683826581038 Writing back bytes
+     | 1683826581038 Wrote [10215] bytes to the client
+     | 1683826581038 (W)
+     | 1683826581038 Writing back bytes
+     | 1683826581038 Wrote [5] bytes to the client
+     | 1683826581038 (W)
+     | 1683826581038 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581038 (WKA)
+     | 1683826581038 Read [336] bytes from client
+     | 1683826581038 (R)
+     | 1683826581038 (RP)
+     | 1683826581038 Preamble successfully parsed
+     | 1683826581038 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581038 (RWo)
+     | 1683826581038 (RC)
+     | 1683826581039 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581039 Preamble is [198] bytes long
+     | 1683826581039 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581039 Still writing preamble
+     | 1683826581039 Wrote [198] bytes to the client
+     | 1683826581039 (W)
+     | 1683826581039 Writing back bytes
+     | 1683826581039 Wrote [10314] bytes to the client
+     | 1683826581039 (W)
+     | 1683826581039 Writing back bytes
+     | 1683826581039 Wrote [5] bytes to the client
+     | 1683826581039 (W)
+     | 1683826581039 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581039 (WKA)
+     | 1683826581040 Read [336] bytes from client
+     | 1683826581040 (R)
+     | 1683826581040 (RP)
+     | 1683826581040 Preamble successfully parsed
+     | 1683826581040 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581040 (RWo)
+     | 1683826581040 (RC)
+     | 1683826581041 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581041 Preamble is [198] bytes long
+     | 1683826581041 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581041 Still writing preamble
+     | 1683826581041 Wrote [198] bytes to the client
+     | 1683826581041 (W)
+     | 1683826581041 Writing back bytes
+     | 1683826581041 Wrote [10413] bytes to the client
+     | 1683826581041 (W)
+     | 1683826581041 Writing back bytes
+     | 1683826581041 Wrote [5] bytes to the client
+     | 1683826581041 (W)
+     | 1683826581041 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581041 (WKA)
+     | 1683826581041 Read [336] bytes from client
+     | 1683826581041 (R)
+     | 1683826581041 (RP)
+     | 1683826581041 Preamble successfully parsed
+     | 1683826581041 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581041 (RWo)
+     | 1683826581041 (RC)
+     | 1683826581043 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581043 Preamble is [198] bytes long
+     | 1683826581043 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581043 Still writing preamble
+     | 1683826581043 Wrote [198] bytes to the client
+     | 1683826581043 (W)
+     | 1683826581043 Writing back bytes
+     | 1683826581043 Wrote [10512] bytes to the client
+     | 1683826581043 (W)
+     | 1683826581043 Writing back bytes
+     | 1683826581043 Wrote [5] bytes to the client
+     | 1683826581043 (W)
+     | 1683826581043 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581043 (WKA)
+     | 1683826581043 Read [336] bytes from client
+     | 1683826581043 (R)
+     | 1683826581043 (RP)
+     | 1683826581043 Preamble successfully parsed
+     | 1683826581043 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581043 (RWo)
+     | 1683826581043 (RC)
+     | 1683826581045 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581045 Preamble is [198] bytes long
+     | 1683826581045 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581045 Still writing preamble
+     | 1683826581045 Wrote [198] bytes to the client
+     | 1683826581045 (W)
+     | 1683826581045 Writing back bytes
+     | 1683826581045 Wrote [10611] bytes to the client
+     | 1683826581045 (W)
+     | 1683826581045 Writing back bytes
+     | 1683826581045 Wrote [5] bytes to the client
+     | 1683826581045 (W)
+     | 1683826581045 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581045 (WKA)
+     | 1683826581045 Read [336] bytes from client
+     | 1683826581045 (R)
+     | 1683826581045 (RP)
+     | 1683826581045 Preamble successfully parsed
+     | 1683826581045 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581045 (RWo)
+     | 1683826581045 (RC)
+     | 1683826581046 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581046 Preamble is [198] bytes long
+     | 1683826581046 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581046 Still writing preamble
+     | 1683826581046 Wrote [198] bytes to the client
+     | 1683826581046 (W)
+     | 1683826581046 Writing back bytes
+     | 1683826581046 Wrote [10710] bytes to the client
+     | 1683826581046 (W)
+     | 1683826581046 Writing back bytes
+     | 1683826581046 Wrote [5] bytes to the client
+     | 1683826581046 (W)
+     | 1683826581046 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581046 (WKA)
+     | 1683826581047 Read [336] bytes from client
+     | 1683826581047 (R)
+     | 1683826581047 (RP)
+     | 1683826581047 Preamble successfully parsed
+     | 1683826581047 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581047 (RWo)
+     | 1683826581047 (RC)
+     | 1683826581048 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581048 Preamble is [198] bytes long
+     | 1683826581048 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581048 Still writing preamble
+     | 1683826581048 Wrote [198] bytes to the client
+     | 1683826581048 (W)
+     | 1683826581048 Writing back bytes
+     | 1683826581048 Wrote [10809] bytes to the client
+     | 1683826581048 (W)
+     | 1683826581048 Writing back bytes
+     | 1683826581048 Wrote [5] bytes to the client
+     | 1683826581048 (W)
+     | 1683826581048 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581048 (WKA)
+     | 1683826581048 Read [336] bytes from client
+     | 1683826581048 (R)
+     | 1683826581048 (RP)
+     | 1683826581048 Preamble successfully parsed
+     | 1683826581048 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581048 (RWo)
+     | 1683826581048 (RC)
+     | 1683826581050 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581050 Preamble is [198] bytes long
+     | 1683826581050 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581050 Still writing preamble
+     | 1683826581050 Wrote [198] bytes to the client
+     | 1683826581050 (W)
+     | 1683826581050 Writing back bytes
+     | 1683826581050 Wrote [10908] bytes to the client
+     | 1683826581050 (W)
+     | 1683826581050 Writing back bytes
+     | 1683826581050 Wrote [5] bytes to the client
+     | 1683826581050 (W)
+     | 1683826581050 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581050 (WKA)
+     | 1683826581050 Read [336] bytes from client
+     | 1683826581050 (R)
+     | 1683826581050 (RP)
+     | 1683826581051 Preamble successfully parsed
+     | 1683826581051 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581051 (RWo)
+     | 1683826581051 (RC)
+     | 1683826581052 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581052 Preamble is [198] bytes long
+     | 1683826581052 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581052 Still writing preamble
+     | 1683826581052 Wrote [198] bytes to the client
+     | 1683826581052 (W)
+     | 1683826581052 Writing back bytes
+     | 1683826581052 Wrote [11007] bytes to the client
+     | 1683826581052 (W)
+     | 1683826581052 Writing back bytes
+     | 1683826581052 Wrote [5] bytes to the client
+     | 1683826581052 (W)
+     | 1683826581052 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581052 (WKA)
+     | 1683826581052 Read [336] bytes from client
+     | 1683826581052 (R)
+     | 1683826581052 (RP)
+     | 1683826581052 Preamble successfully parsed
+     | 1683826581052 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581052 (RWo)
+     | 1683826581053 (RC)
+     | 1683826581054 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581054 Preamble is [198] bytes long
+     | 1683826581054 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581054 Still writing preamble
+     | 1683826581054 Wrote [198] bytes to the client
+     | 1683826581054 (W)
+     | 1683826581054 Writing back bytes
+     | 1683826581054 Wrote [11106] bytes to the client
+     | 1683826581054 (W)
+     | 1683826581054 Writing back bytes
+     | 1683826581054 Wrote [5] bytes to the client
+     | 1683826581054 (W)
+     | 1683826581054 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581054 (WKA)
+     | 1683826581054 Read [336] bytes from client
+     | 1683826581054 (R)
+     | 1683826581054 (RP)
+     | 1683826581054 Preamble successfully parsed
+     | 1683826581054 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581054 (RWo)
+     | 1683826581054 (RC)
+     | 1683826581055 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581055 Preamble is [198] bytes long
+     | 1683826581055 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581055 Still writing preamble
+     | 1683826581055 Wrote [198] bytes to the client
+     | 1683826581055 (W)
+     | 1683826581055 Writing back bytes
+     | 1683826581055 Wrote [11205] bytes to the client
+     | 1683826581055 (W)
+     | 1683826581055 Writing back bytes
+     | 1683826581055 Wrote [5] bytes to the client
+     | 1683826581055 (W)
+     | 1683826581055 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581055 (WKA)
+     | 1683826581056 Read [336] bytes from client
+     | 1683826581056 (R)
+     | 1683826581056 (RP)
+     | 1683826581056 Preamble successfully parsed
+     | 1683826581056 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581056 (RWo)
+     | 1683826581056 (RC)
+     | 1683826581057 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581057 Preamble is [198] bytes long
+     | 1683826581057 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581057 Still writing preamble
+     | 1683826581057 Wrote [198] bytes to the client
+     | 1683826581057 (W)
+     | 1683826581057 Writing back bytes
+     | 1683826581057 Wrote [11304] bytes to the client
+     | 1683826581057 (W)
+     | 1683826581057 Writing back bytes
+     | 1683826581057 Wrote [5] bytes to the client
+     | 1683826581057 (W)
+     | 1683826581057 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581057 (WKA)
+     | 1683826581058 Read [336] bytes from client
+     | 1683826581058 (R)
+     | 1683826581058 (RP)
+     | 1683826581058 Preamble successfully parsed
+     | 1683826581058 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581058 (RWo)
+     | 1683826581058 (RC)
+     | 1683826581059 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581059 Preamble is [198] bytes long
+     | 1683826581059 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581059 Still writing preamble
+     | 1683826581059 Wrote [198] bytes to the client
+     | 1683826581059 (W)
+     | 1683826581059 Writing back bytes
+     | 1683826581059 Wrote [11403] bytes to the client
+     | 1683826581059 (W)
+     | 1683826581059 Writing back bytes
+     | 1683826581059 Wrote [5] bytes to the client
+     | 1683826581059 (W)
+     | 1683826581059 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581059 (WKA)
+     | 1683826581060 Read [336] bytes from client
+     | 1683826581060 (R)
+     | 1683826581060 (RP)
+     | 1683826581060 Preamble successfully parsed
+     | 1683826581060 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581060 (RWo)
+     | 1683826581060 (RC)
+     | 1683826581061 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581061 Preamble is [198] bytes long
+     | 1683826581061 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581061 Still writing preamble
+     | 1683826581061 Wrote [198] bytes to the client
+     | 1683826581061 (W)
+     | 1683826581061 Writing back bytes
+     | 1683826581061 Wrote [11502] bytes to the client
+     | 1683826581061 (W)
+     | 1683826581061 Writing back bytes
+     | 1683826581061 Wrote [5] bytes to the client
+     | 1683826581061 (W)
+     | 1683826581061 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581061 (WKA)
+     | 1683826581062 Read [336] bytes from client
+     | 1683826581062 (R)
+     | 1683826581062 (RP)
+     | 1683826581062 Preamble successfully parsed
+     | 1683826581062 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581062 (RWo)
+     | 1683826581062 (RC)
+     | 1683826581063 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581063 Preamble is [198] bytes long
+     | 1683826581063 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581063 Still writing preamble
+     | 1683826581063 Wrote [198] bytes to the client
+     | 1683826581063 (W)
+     | 1683826581063 Writing back bytes
+     | 1683826581063 Wrote [11601] bytes to the client
+     | 1683826581063 (W)
+     | 1683826581063 Writing back bytes
+     | 1683826581063 Wrote [5] bytes to the client
+     | 1683826581063 (W)
+     | 1683826581063 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581063 (WKA)
+     | 1683826581063 Read [336] bytes from client
+     | 1683826581063 (R)
+     | 1683826581063 (RP)
+     | 1683826581063 Preamble successfully parsed
+     | 1683826581063 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581063 (RWo)
+     | 1683826581063 (RC)
+     | 1683826581064 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581064 Preamble is [198] bytes long
+     | 1683826581064 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581064 Still writing preamble
+     | 1683826581065 Wrote [198] bytes to the client
+     | 1683826581065 (W)
+     | 1683826581065 Writing back bytes
+     | 1683826581065 Wrote [11700] bytes to the client
+     | 1683826581065 (W)
+     | 1683826581065 Writing back bytes
+     | 1683826581065 Wrote [5] bytes to the client
+     | 1683826581065 (W)
+     | 1683826581065 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581065 (WKA)
+     | 1683826581065 Read [336] bytes from client
+     | 1683826581065 (R)
+     | 1683826581065 (RP)
+     | 1683826581065 Preamble successfully parsed
+     | 1683826581065 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581065 (RWo)
+     | 1683826581065 (RC)
+     | 1683826581066 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581066 Preamble is [198] bytes long
+     | 1683826581066 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581066 Still writing preamble
+     | 1683826581066 Wrote [198] bytes to the client
+     | 1683826581066 (W)
+     | 1683826581066 Writing back bytes
+     | 1683826581066 Wrote [11799] bytes to the client
+     | 1683826581066 (W)
+     | 1683826581066 Writing back bytes
+     | 1683826581066 Wrote [5] bytes to the client
+     | 1683826581066 (W)
+     | 1683826581066 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581066 (WKA)
+     | 1683826581067 Read [336] bytes from client
+     | 1683826581067 (R)
+     | 1683826581067 (RP)
+     | 1683826581067 Preamble successfully parsed
+     | 1683826581067 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581067 (RWo)
+     | 1683826581067 (RC)
+     | 1683826581068 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581068 Preamble is [198] bytes long
+     | 1683826581068 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581068 Still writing preamble
+     | 1683826581068 Wrote [198] bytes to the client
+     | 1683826581068 (W)
+     | 1683826581068 Writing back bytes
+     | 1683826581068 Wrote [11898] bytes to the client
+     | 1683826581068 (W)
+     | 1683826581068 Writing back bytes
+     | 1683826581068 Wrote [5] bytes to the client
+     | 1683826581068 (W)
+     | 1683826581068 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581068 (WKA)
+     | 1683826581068 Read [336] bytes from client
+     | 1683826581068 (R)
+     | 1683826581068 (RP)
+     | 1683826581068 Preamble successfully parsed
+     | 1683826581068 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581068 (RWo)
+     | 1683826581068 (RC)
+     | 1683826581069 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581069 Preamble is [198] bytes long
+     | 1683826581069 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581069 Still writing preamble
+     | 1683826581069 Wrote [198] bytes to the client
+     | 1683826581069 (W)
+     | 1683826581069 Writing back bytes
+     | 1683826581069 Wrote [11997] bytes to the client
+     | 1683826581069 (W)
+     | 1683826581069 Writing back bytes
+     | 1683826581069 Wrote [5] bytes to the client
+     | 1683826581069 (W)
+     | 1683826581069 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581069 (WKA)
+     | 1683826581070 Read [336] bytes from client
+     | 1683826581070 (R)
+     | 1683826581070 (RP)
+     | 1683826581070 Preamble successfully parsed
+     | 1683826581070 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581070 (RWo)
+     | 1683826581070 (RC)
+     | 1683826581071 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581071 Preamble is [198] bytes long
+     | 1683826581071 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581071 Still writing preamble
+     | 1683826581071 Wrote [198] bytes to the client
+     | 1683826581071 (W)
+     | 1683826581071 Writing back bytes
+     | 1683826581071 Wrote [12096] bytes to the client
+     | 1683826581071 (W)
+     | 1683826581071 Writing back bytes
+     | 1683826581071 Wrote [5] bytes to the client
+     | 1683826581071 (W)
+     | 1683826581071 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581071 (WKA)
+     | 1683826581072 Read [336] bytes from client
+     | 1683826581072 (R)
+     | 1683826581072 (RP)
+     | 1683826581072 Preamble successfully parsed
+     | 1683826581072 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581072 (RWo)
+     | 1683826581072 (RC)
+     | 1683826581075 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581075 Preamble is [198] bytes long
+     | 1683826581075 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581075 Still writing preamble
+     | 1683826581076 Wrote [198] bytes to the client
+     | 1683826581076 (W)
+     | 1683826581076 Writing back bytes
+     | 1683826581076 Wrote [12195] bytes to the client
+     | 1683826581076 (W)
+     | 1683826581076 Writing back bytes
+     | 1683826581076 Wrote [5] bytes to the client
+     | 1683826581076 (W)
+     | 1683826581076 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581076 (WKA)
+     | 1683826581076 Read [336] bytes from client
+     | 1683826581076 (R)
+     | 1683826581076 (RP)
+     | 1683826581076 Preamble successfully parsed
+     | 1683826581076 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581076 (RWo)
+     | 1683826581076 (RC)
+     | 1683826581077 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581077 Preamble is [198] bytes long
+     | 1683826581077 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581077 Still writing preamble
+     | 1683826581077 Wrote [198] bytes to the client
+     | 1683826581077 (W)
+     | 1683826581077 Writing back bytes
+     | 1683826581077 Wrote [12294] bytes to the client
+     | 1683826581077 (W)
+     | 1683826581077 Writing back bytes
+     | 1683826581077 Wrote [5] bytes to the client
+     | 1683826581077 (W)
+     | 1683826581077 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581077 (WKA)
+     | 1683826581079 Read [336] bytes from client
+     | 1683826581079 (R)
+     | 1683826581079 (RP)
+     | 1683826581079 Preamble successfully parsed
+     | 1683826581079 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581079 (RWo)
+     | 1683826581080 (RC)
+     | 1683826581080 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581080 Preamble is [198] bytes long
+     | 1683826581080 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581080 Still writing preamble
+     | 1683826581080 Wrote [198] bytes to the client
+     | 1683826581080 (W)
+     | 1683826581080 Writing back bytes
+     | 1683826581080 Wrote [12393] bytes to the client
+     | 1683826581080 (W)
+     | 1683826581080 Writing back bytes
+     | 1683826581080 Wrote [5] bytes to the client
+     | 1683826581080 (W)
+     | 1683826581080 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581080 (WKA)
+     | 1683826581081 Read [336] bytes from client
+     | 1683826581081 (R)
+     | 1683826581081 (RP)
+     | 1683826581081 Preamble successfully parsed
+     | 1683826581081 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581081 (RWo)
+     | 1683826581081 (RC)
+     | 1683826581082 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581082 Preamble is [198] bytes long
+     | 1683826581082 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581082 Still writing preamble
+     | 1683826581082 Wrote [198] bytes to the client
+     | 1683826581082 (W)
+     | 1683826581082 Writing back bytes
+     | 1683826581082 Wrote [12492] bytes to the client
+     | 1683826581082 (W)
+     | 1683826581082 Writing back bytes
+     | 1683826581082 Wrote [5] bytes to the client
+     | 1683826581082 (W)
+     | 1683826581082 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581082 (WKA)
+     | 1683826581082 Read [336] bytes from client
+     | 1683826581082 (R)
+     | 1683826581082 (RP)
+     | 1683826581082 Preamble successfully parsed
+     | 1683826581082 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581082 (RWo)
+     | 1683826581082 (RC)
+     | 1683826581083 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581083 Preamble is [198] bytes long
+     | 1683826581083 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581083 Still writing preamble
+     | 1683826581083 Wrote [198] bytes to the client
+     | 1683826581083 (W)
+     | 1683826581083 Writing back bytes
+     | 1683826581083 Wrote [12591] bytes to the client
+     | 1683826581083 (W)
+     | 1683826581083 Writing back bytes
+     | 1683826581083 Wrote [5] bytes to the client
+     | 1683826581083 (W)
+     | 1683826581083 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581083 (WKA)
+     | 1683826581084 Read [336] bytes from client
+     | 1683826581084 (R)
+     | 1683826581084 (RP)
+     | 1683826581084 Preamble successfully parsed
+     | 1683826581084 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581084 (RWo)
+     | 1683826581084 (RC)
+     | 1683826581085 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581085 Preamble is [198] bytes long
+     | 1683826581085 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581085 Still writing preamble
+     | 1683826581085 Wrote [198] bytes to the client
+     | 1683826581085 (W)
+     | 1683826581085 Writing back bytes
+     | 1683826581085 Wrote [12690] bytes to the client
+     | 1683826581085 (W)
+     | 1683826581085 Writing back bytes
+     | 1683826581085 Wrote [5] bytes to the client
+     | 1683826581085 (W)
+     | 1683826581085 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581085 (WKA)
+     | 1683826581085 Read [336] bytes from client
+     | 1683826581085 (R)
+     | 1683826581085 (RP)
+     | 1683826581085 Preamble successfully parsed
+     | 1683826581085 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581085 (RWo)
+     | 1683826581085 (RC)
+     | 1683826581086 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581086 Preamble is [198] bytes long
+     | 1683826581086 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581086 Still writing preamble
+     | 1683826581086 Wrote [198] bytes to the client
+     | 1683826581086 (W)
+     | 1683826581086 Writing back bytes
+     | 1683826581086 Wrote [12789] bytes to the client
+     | 1683826581086 (W)
+     | 1683826581086 Writing back bytes
+     | 1683826581086 Wrote [5] bytes to the client
+     | 1683826581086 (W)
+     | 1683826581086 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581086 (WKA)
+     | 1683826581087 Read [336] bytes from client
+     | 1683826581087 (R)
+     | 1683826581087 (RP)
+     | 1683826581087 Preamble successfully parsed
+     | 1683826581087 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581087 (RWo)
+     | 1683826581087 (RC)
+     | 1683826581088 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581088 Preamble is [198] bytes long
+     | 1683826581088 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581088 Still writing preamble
+     | 1683826581088 Wrote [198] bytes to the client
+     | 1683826581088 (W)
+     | 1683826581088 Writing back bytes
+     | 1683826581088 Wrote [12888] bytes to the client
+     | 1683826581088 (W)
+     | 1683826581088 Writing back bytes
+     | 1683826581088 Wrote [5] bytes to the client
+     | 1683826581088 (W)
+     | 1683826581088 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581088 (WKA)
+     | 1683826581088 Read [336] bytes from client
+     | 1683826581088 (R)
+     | 1683826581088 (RP)
+     | 1683826581088 Preamble successfully parsed
+     | 1683826581088 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581088 (RWo)
+     | 1683826581088 (RC)
+     | 1683826581090 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581090 Preamble is [198] bytes long
+     | 1683826581090 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581090 Still writing preamble
+     | 1683826581090 Wrote [198] bytes to the client
+     | 1683826581090 (W)
+     | 1683826581090 Writing back bytes
+     | 1683826581090 Wrote [12987] bytes to the client
+     | 1683826581090 (W)
+     | 1683826581090 Writing back bytes
+     | 1683826581090 Wrote [5] bytes to the client
+     | 1683826581090 (W)
+     | 1683826581090 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581090 (WKA)
+     | 1683826581090 Read [336] bytes from client
+     | 1683826581090 (R)
+     | 1683826581090 (RP)
+     | 1683826581091 Preamble successfully parsed
+     | 1683826581091 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581091 (RWo)
+     | 1683826581091 (RC)
+     | 1683826581092 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581092 Preamble is [198] bytes long
+     | 1683826581092 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581092 Still writing preamble
+     | 1683826581092 Wrote [198] bytes to the client
+     | 1683826581092 (W)
+     | 1683826581092 Writing back bytes
+     | 1683826581092 Wrote [13086] bytes to the client
+     | 1683826581092 (W)
+     | 1683826581092 Writing back bytes
+     | 1683826581092 Wrote [5] bytes to the client
+     | 1683826581092 (W)
+     | 1683826581092 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581092 (WKA)
+     | 1683826581092 Read [336] bytes from client
+     | 1683826581092 (R)
+     | 1683826581092 (RP)
+     | 1683826581092 Preamble successfully parsed
+     | 1683826581092 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581092 (RWo)
+     | 1683826581092 (RC)
+     | 1683826581093 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581093 Preamble is [198] bytes long
+     | 1683826581093 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581093 Still writing preamble
+     | 1683826581093 Wrote [198] bytes to the client
+     | 1683826581093 (W)
+     | 1683826581093 Writing back bytes
+     | 1683826581093 Wrote [13185] bytes to the client
+     | 1683826581093 (W)
+     | 1683826581093 Writing back bytes
+     | 1683826581093 Wrote [5] bytes to the client
+     | 1683826581093 (W)
+     | 1683826581093 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581093 (WKA)
+     | 1683826581094 Read [336] bytes from client
+     | 1683826581094 (R)
+     | 1683826581094 (RP)
+     | 1683826581094 Preamble successfully parsed
+     | 1683826581094 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581094 (RWo)
+     | 1683826581094 (RC)
+     | 1683826581095 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581095 Preamble is [198] bytes long
+     | 1683826581095 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581095 Still writing preamble
+     | 1683826581095 Wrote [198] bytes to the client
+     | 1683826581095 (W)
+     | 1683826581095 Writing back bytes
+     | 1683826581095 Wrote [13284] bytes to the client
+     | 1683826581095 (W)
+     | 1683826581095 Writing back bytes
+     | 1683826581095 Wrote [5] bytes to the client
+     | 1683826581095 (W)
+     | 1683826581095 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581095 (WKA)
+     | 1683826581095 Read [336] bytes from client
+     | 1683826581095 (R)
+     | 1683826581095 (RP)
+     | 1683826581095 Preamble successfully parsed
+     | 1683826581095 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581095 (RWo)
+     | 1683826581095 (RC)
+     | 1683826581096 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581096 Preamble is [198] bytes long
+     | 1683826581096 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581096 Still writing preamble
+     | 1683826581096 Wrote [198] bytes to the client
+     | 1683826581096 (W)
+     | 1683826581096 Writing back bytes
+     | 1683826581096 Wrote [13383] bytes to the client
+     | 1683826581096 (W)
+     | 1683826581096 Writing back bytes
+     | 1683826581096 Wrote [5] bytes to the client
+     | 1683826581096 (W)
+     | 1683826581096 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581096 (WKA)
+     | 1683826581097 Read [336] bytes from client
+     | 1683826581097 (R)
+     | 1683826581097 (RP)
+     | 1683826581097 Preamble successfully parsed
+     | 1683826581097 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581097 (RWo)
+     | 1683826581097 (RC)
+     | 1683826581098 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581098 Preamble is [198] bytes long
+     | 1683826581098 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581098 Still writing preamble
+     | 1683826581098 Wrote [198] bytes to the client
+     | 1683826581098 (W)
+     | 1683826581098 Writing back bytes
+     | 1683826581098 Wrote [13482] bytes to the client
+     | 1683826581098 (W)
+     | 1683826581098 Writing back bytes
+     | 1683826581098 Wrote [5] bytes to the client
+     | 1683826581098 (W)
+     | 1683826581098 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581098 (WKA)
+     | 1683826581098 Read [336] bytes from client
+     | 1683826581098 (R)
+     | 1683826581098 (RP)
+     | 1683826581098 Preamble successfully parsed
+     | 1683826581098 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581098 (RWo)
+     | 1683826581098 (RC)
+     | 1683826581099 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581099 Preamble is [198] bytes long
+     | 1683826581099 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581099 Still writing preamble
+     | 1683826581099 Wrote [198] bytes to the client
+     | 1683826581099 (W)
+     | 1683826581099 Writing back bytes
+     | 1683826581099 Wrote [13581] bytes to the client
+     | 1683826581099 (W)
+     | 1683826581099 Writing back bytes
+     | 1683826581099 Wrote [5] bytes to the client
+     | 1683826581099 (W)
+     | 1683826581099 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581099 (WKA)
+     | 1683826581100 Read [336] bytes from client
+     | 1683826581100 (R)
+     | 1683826581100 (RP)
+     | 1683826581100 Preamble successfully parsed
+     | 1683826581100 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581100 (RWo)
+     | 1683826581100 (RC)
+     | 1683826581101 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581101 Preamble is [198] bytes long
+     | 1683826581101 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581101 Still writing preamble
+     | 1683826581101 Wrote [198] bytes to the client
+     | 1683826581101 (W)
+     | 1683826581101 Writing back bytes
+     | 1683826581101 Wrote [13680] bytes to the client
+     | 1683826581101 (W)
+     | 1683826581101 Writing back bytes
+     | 1683826581101 Wrote [5] bytes to the client
+     | 1683826581101 (W)
+     | 1683826581101 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581101 (WKA)
+     | 1683826581101 Read [336] bytes from client
+     | 1683826581101 (R)
+     | 1683826581101 (RP)
+     | 1683826581101 Preamble successfully parsed
+     | 1683826581101 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581101 (RWo)
+     | 1683826581101 (RC)
+     | 1683826581102 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581102 Preamble is [198] bytes long
+     | 1683826581102 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581102 Still writing preamble
+     | 1683826581102 Wrote [198] bytes to the client
+     | 1683826581102 (W)
+     | 1683826581102 Writing back bytes
+     | 1683826581102 Wrote [13779] bytes to the client
+     | 1683826581102 (W)
+     | 1683826581102 Writing back bytes
+     | 1683826581102 Wrote [5] bytes to the client
+     | 1683826581102 (W)
+     | 1683826581102 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581102 (WKA)
+     | 1683826581102 Read [336] bytes from client
+     | 1683826581102 (R)
+     | 1683826581102 (RP)
+     | 1683826581102 Preamble successfully parsed
+     | 1683826581102 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581102 (RWo)
+     | 1683826581102 (RC)
+     | 1683826581103 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581103 Preamble is [198] bytes long
+     | 1683826581103 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581103 Still writing preamble
+     | 1683826581103 Wrote [198] bytes to the client
+     | 1683826581103 (W)
+     | 1683826581103 Writing back bytes
+     | 1683826581103 Wrote [13878] bytes to the client
+     | 1683826581103 (W)
+     | 1683826581103 Writing back bytes
+     | 1683826581103 Wrote [5] bytes to the client
+     | 1683826581103 (W)
+     | 1683826581103 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581103 (WKA)
+     | 1683826581104 Read [336] bytes from client
+     | 1683826581104 (R)
+     | 1683826581104 (RP)
+     | 1683826581104 Preamble successfully parsed
+     | 1683826581104 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581104 (RWo)
+     | 1683826581104 (RC)
+     | 1683826581105 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581105 Preamble is [198] bytes long
+     | 1683826581105 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581105 Still writing preamble
+     | 1683826581105 Wrote [198] bytes to the client
+     | 1683826581105 (W)
+     | 1683826581105 Writing back bytes
+     | 1683826581105 Wrote [13977] bytes to the client
+     | 1683826581105 (W)
+     | 1683826581105 Writing back bytes
+     | 1683826581105 Wrote [5] bytes to the client
+     | 1683826581105 (W)
+     | 1683826581105 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581105 (WKA)
+     | 1683826581105 Read [336] bytes from client
+     | 1683826581105 (R)
+     | 1683826581105 (RP)
+     | 1683826581105 Preamble successfully parsed
+     | 1683826581105 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581105 (RWo)
+     | 1683826581105 (RC)
+     | 1683826581106 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581106 Preamble is [198] bytes long
+     | 1683826581106 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581106 Still writing preamble
+     | 1683826581106 Wrote [198] bytes to the client
+     | 1683826581106 (W)
+     | 1683826581106 Writing back bytes
+     | 1683826581106 Wrote [14076] bytes to the client
+     | 1683826581106 (W)
+     | 1683826581106 Writing back bytes
+     | 1683826581106 Wrote [5] bytes to the client
+     | 1683826581106 (W)
+     | 1683826581106 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581106 (WKA)
+     | 1683826581107 Read [336] bytes from client
+     | 1683826581107 (R)
+     | 1683826581107 (RP)
+     | 1683826581107 Preamble successfully parsed
+     | 1683826581107 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581107 (RWo)
+     | 1683826581107 (RC)
+     | 1683826581108 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581108 Preamble is [198] bytes long
+     | 1683826581108 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581108 Still writing preamble
+     | 1683826581108 Wrote [198] bytes to the client
+     | 1683826581108 (W)
+     | 1683826581108 Writing back bytes
+     | 1683826581108 Wrote [14175] bytes to the client
+     | 1683826581108 (W)
+     | 1683826581108 Writing back bytes
+     | 1683826581108 Wrote [5] bytes to the client
+     | 1683826581108 (W)
+     | 1683826581108 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581108 (WKA)
+     | 1683826581108 Read [336] bytes from client
+     | 1683826581108 (R)
+     | 1683826581108 (RP)
+     | 1683826581108 Preamble successfully parsed
+     | 1683826581108 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581108 (RWo)
+     | 1683826581108 (RC)
+     | 1683826581109 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581109 Preamble is [198] bytes long
+     | 1683826581109 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581109 Still writing preamble
+     | 1683826581109 Wrote [198] bytes to the client
+     | 1683826581109 (W)
+     | 1683826581109 Writing back bytes
+     | 1683826581109 Wrote [14274] bytes to the client
+     | 1683826581109 (W)
+     | 1683826581109 Writing back bytes
+     | 1683826581109 Wrote [5] bytes to the client
+     | 1683826581109 (W)
+     | 1683826581109 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581109 (WKA)
+     | 1683826581110 Read [336] bytes from client
+     | 1683826581110 (R)
+     | 1683826581110 (RP)
+     | 1683826581110 Preamble successfully parsed
+     | 1683826581110 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581110 (RWo)
+     | 1683826581110 (RC)
+     | 1683826581111 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581111 Preamble is [198] bytes long
+     | 1683826581111 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581111 Still writing preamble
+     | 1683826581111 Wrote [198] bytes to the client
+     | 1683826581111 (W)
+     | 1683826581111 Writing back bytes
+     | 1683826581111 Wrote [14373] bytes to the client
+     | 1683826581111 (W)
+     | 1683826581111 Writing back bytes
+     | 1683826581111 Wrote [5] bytes to the client
+     | 1683826581111 (W)
+     | 1683826581111 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581111 (WKA)
+     | 1683826581111 Read [336] bytes from client
+     | 1683826581111 (R)
+     | 1683826581111 (RP)
+     | 1683826581111 Preamble successfully parsed
+     | 1683826581111 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581111 (RWo)
+     | 1683826581111 (RC)
+     | 1683826581112 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581112 Preamble is [198] bytes long
+     | 1683826581112 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581112 Still writing preamble
+     | 1683826581112 Wrote [198] bytes to the client
+     | 1683826581112 (W)
+     | 1683826581112 Writing back bytes
+     | 1683826581112 Wrote [14472] bytes to the client
+     | 1683826581112 (W)
+     | 1683826581112 Writing back bytes
+     | 1683826581112 Wrote [5] bytes to the client
+     | 1683826581112 (W)
+     | 1683826581112 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581112 (WKA)
+     | 1683826581113 Read [336] bytes from client
+     | 1683826581113 (R)
+     | 1683826581113 (RP)
+     | 1683826581113 Preamble successfully parsed
+     | 1683826581113 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581113 (RWo)
+     | 1683826581113 (RC)
+     | 1683826581114 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581114 Preamble is [198] bytes long
+     | 1683826581114 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581114 Still writing preamble
+     | 1683826581114 Wrote [198] bytes to the client
+     | 1683826581114 (W)
+     | 1683826581114 Writing back bytes
+     | 1683826581114 Wrote [14571] bytes to the client
+     | 1683826581114 (W)
+     | 1683826581114 Writing back bytes
+     | 1683826581114 Wrote [5] bytes to the client
+     | 1683826581114 (W)
+     | 1683826581114 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581114 (WKA)
+     | 1683826581114 Read [336] bytes from client
+     | 1683826581114 (R)
+     | 1683826581114 (RP)
+     | 1683826581114 Preamble successfully parsed
+     | 1683826581114 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581114 (RWo)
+     | 1683826581114 (RC)
+     | 1683826581115 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581115 Preamble is [198] bytes long
+     | 1683826581115 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581115 Still writing preamble
+     | 1683826581115 Wrote [198] bytes to the client
+     | 1683826581115 (W)
+     | 1683826581115 Writing back bytes
+     | 1683826581115 Wrote [14670] bytes to the client
+     | 1683826581115 (W)
+     | 1683826581115 Writing back bytes
+     | 1683826581115 Wrote [5] bytes to the client
+     | 1683826581115 (W)
+     | 1683826581115 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581115 (WKA)
+     | 1683826581115 Read [336] bytes from client
+     | 1683826581115 (R)
+     | 1683826581115 (RP)
+     | 1683826581116 Preamble successfully parsed
+     | 1683826581116 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581116 (RWo)
+     | 1683826581116 (RC)
+     | 1683826581116 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581116 Preamble is [198] bytes long
+     | 1683826581116 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581116 Still writing preamble
+     | 1683826581116 Wrote [198] bytes to the client
+     | 1683826581116 (W)
+     | 1683826581116 Writing back bytes
+     | 1683826581117 Wrote [14769] bytes to the client
+     | 1683826581117 (W)
+     | 1683826581117 Writing back bytes
+     | 1683826581117 Wrote [5] bytes to the client
+     | 1683826581117 (W)
+     | 1683826581117 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581117 (WKA)
+     | 1683826581117 Read [336] bytes from client
+     | 1683826581117 (R)
+     | 1683826581117 (RP)
+     | 1683826581117 Preamble successfully parsed
+     | 1683826581117 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581117 (RWo)
+     | 1683826581117 (RC)
+     | 1683826581118 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581118 Preamble is [198] bytes long
+     | 1683826581118 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581118 Still writing preamble
+     | 1683826581118 Wrote [198] bytes to the client
+     | 1683826581118 (W)
+     | 1683826581118 Writing back bytes
+     | 1683826581118 Wrote [14868] bytes to the client
+     | 1683826581118 (W)
+     | 1683826581118 Writing back bytes
+     | 1683826581118 Wrote [5] bytes to the client
+     | 1683826581118 (W)
+     | 1683826581118 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581118 (WKA)
+     | 1683826581118 Read [336] bytes from client
+     | 1683826581118 (R)
+     | 1683826581118 (RP)
+     | 1683826581118 Preamble successfully parsed
+     | 1683826581118 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581118 (RWo)
+     | 1683826581118 (RC)
+     | 1683826581119 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581119 Preamble is [198] bytes long
+     | 1683826581119 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581119 Still writing preamble
+     | 1683826581119 Wrote [198] bytes to the client
+     | 1683826581119 (W)
+     | 1683826581119 Writing back bytes
+     | 1683826581119 Wrote [14967] bytes to the client
+     | 1683826581119 (W)
+     | 1683826581119 Writing back bytes
+     | 1683826581119 Wrote [5] bytes to the client
+     | 1683826581119 (W)
+     | 1683826581119 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581119 (WKA)
+     | 1683826581120 Read [336] bytes from client
+     | 1683826581120 (R)
+     | 1683826581120 (RP)
+     | 1683826581120 Preamble successfully parsed
+     | 1683826581120 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581120 (RWo)
+     | 1683826581120 (RC)
+     | 1683826581121 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581121 Preamble is [198] bytes long
+     | 1683826581121 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581121 Still writing preamble
+     | 1683826581121 Wrote [198] bytes to the client
+     | 1683826581121 (W)
+     | 1683826581121 Writing back bytes
+     | 1683826581121 Wrote [15066] bytes to the client
+     | 1683826581121 (W)
+     | 1683826581121 Writing back bytes
+     | 1683826581121 Wrote [5] bytes to the client
+     | 1683826581121 (W)
+     | 1683826581121 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581121 (WKA)
+     | 1683826581121 Read [336] bytes from client
+     | 1683826581121 (R)
+     | 1683826581121 (RP)
+     | 1683826581121 Preamble successfully parsed
+     | 1683826581121 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581121 (RWo)
+     | 1683826581121 (RC)
+     | 1683826581123 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581123 Preamble is [198] bytes long
+     | 1683826581123 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581123 Still writing preamble
+     | 1683826581123 Wrote [198] bytes to the client
+     | 1683826581123 (W)
+     | 1683826581123 Writing back bytes
+     | 1683826581123 Wrote [15165] bytes to the client
+     | 1683826581123 (W)
+     | 1683826581123 Writing back bytes
+     | 1683826581123 Wrote [5] bytes to the client
+     | 1683826581123 (W)
+     | 1683826581123 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581123 (WKA)
+     | 1683826581123 Read [336] bytes from client
+     | 1683826581123 (R)
+     | 1683826581123 (RP)
+     | 1683826581123 Preamble successfully parsed
+     | 1683826581123 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581123 (RWo)
+     | 1683826581123 (RC)
+     | 1683826581124 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581124 Preamble is [198] bytes long
+     | 1683826581124 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581124 Still writing preamble
+     | 1683826581124 Wrote [198] bytes to the client
+     | 1683826581124 (W)
+     | 1683826581124 Writing back bytes
+     | 1683826581124 Wrote [15264] bytes to the client
+     | 1683826581124 (W)
+     | 1683826581124 Writing back bytes
+     | 1683826581124 Wrote [5] bytes to the client
+     | 1683826581124 (W)
+     | 1683826581124 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581124 (WKA)
+     | 1683826581124 Read [336] bytes from client
+     | 1683826581124 (R)
+     | 1683826581124 (RP)
+     | 1683826581124 Preamble successfully parsed
+     | 1683826581124 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581124 (RWo)
+     | 1683826581124 (RC)
+     | 1683826581125 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581125 Preamble is [198] bytes long
+     | 1683826581125 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581125 Still writing preamble
+     | 1683826581126 Wrote [198] bytes to the client
+     | 1683826581126 (W)
+     | 1683826581126 Writing back bytes
+     | 1683826581126 Wrote [15363] bytes to the client
+     | 1683826581126 (W)
+     | 1683826581126 Writing back bytes
+     | 1683826581126 Wrote [5] bytes to the client
+     | 1683826581126 (W)
+     | 1683826581126 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581126 (WKA)
+     | 1683826581126 Read [336] bytes from client
+     | 1683826581126 (R)
+     | 1683826581126 (RP)
+     | 1683826581126 Preamble successfully parsed
+     | 1683826581126 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581126 (RWo)
+     | 1683826581126 (RC)
+     | 1683826581127 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581127 Preamble is [198] bytes long
+     | 1683826581127 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581127 Still writing preamble
+     | 1683826581127 Wrote [198] bytes to the client
+     | 1683826581127 (W)
+     | 1683826581127 Writing back bytes
+     | 1683826581127 Wrote [15462] bytes to the client
+     | 1683826581127 (W)
+     | 1683826581127 Writing back bytes
+     | 1683826581127 Wrote [5] bytes to the client
+     | 1683826581127 (W)
+     | 1683826581127 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581127 (WKA)
+     | 1683826581127 Read [336] bytes from client
+     | 1683826581127 (R)
+     | 1683826581127 (RP)
+     | 1683826581127 Preamble successfully parsed
+     | 1683826581127 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581127 (RWo)
+     | 1683826581127 (RC)
+     | 1683826581129 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581129 Preamble is [198] bytes long
+     | 1683826581129 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581129 Still writing preamble
+     | 1683826581129 Wrote [198] bytes to the client
+     | 1683826581129 (W)
+     | 1683826581129 Writing back bytes
+     | 1683826581129 Wrote [15561] bytes to the client
+     | 1683826581129 (W)
+     | 1683826581129 Writing back bytes
+     | 1683826581129 Wrote [5] bytes to the client
+     | 1683826581129 (W)
+     | 1683826581129 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581129 (WKA)
+     | 1683826581129 Read [336] bytes from client
+     | 1683826581129 (R)
+     | 1683826581129 (RP)
+     | 1683826581129 Preamble successfully parsed
+     | 1683826581129 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581129 (RWo)
+     | 1683826581129 (RC)
+     | 1683826581130 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581130 Preamble is [198] bytes long
+     | 1683826581130 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581130 Still writing preamble
+     | 1683826581130 Wrote [198] bytes to the client
+     | 1683826581130 (W)
+     | 1683826581130 Writing back bytes
+     | 1683826581130 Wrote [15660] bytes to the client
+     | 1683826581130 (W)
+     | 1683826581130 Writing back bytes
+     | 1683826581130 Wrote [5] bytes to the client
+     | 1683826581130 (W)
+     | 1683826581130 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581130 (WKA)
+     | 1683826581130 Read [336] bytes from client
+     | 1683826581130 (R)
+     | 1683826581130 (RP)
+     | 1683826581130 Preamble successfully parsed
+     | 1683826581130 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581130 (RWo)
+     | 1683826581130 (RC)
+     | 1683826581131 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581131 Preamble is [198] bytes long
+     | 1683826581131 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581131 Still writing preamble
+     | 1683826581131 Wrote [198] bytes to the client
+     | 1683826581131 (W)
+     | 1683826581131 Writing back bytes
+     | 1683826581132 Wrote [15759] bytes to the client
+     | 1683826581132 (W)
+     | 1683826581132 Writing back bytes
+     | 1683826581132 Wrote [5] bytes to the client
+     | 1683826581132 (W)
+     | 1683826581132 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581132 (WKA)
+     | 1683826581132 Read [336] bytes from client
+     | 1683826581132 (R)
+     | 1683826581132 (RP)
+     | 1683826581132 Preamble successfully parsed
+     | 1683826581132 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581132 (RWo)
+     | 1683826581132 (RC)
+     | 1683826581133 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581133 Preamble is [198] bytes long
+     | 1683826581133 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581133 Still writing preamble
+     | 1683826581133 Wrote [198] bytes to the client
+     | 1683826581133 (W)
+     | 1683826581133 Writing back bytes
+     | 1683826581133 Wrote [15858] bytes to the client
+     | 1683826581133 (W)
+     | 1683826581133 Writing back bytes
+     | 1683826581133 Wrote [5] bytes to the client
+     | 1683826581133 (W)
+     | 1683826581133 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581133 (WKA)
+     | 1683826581133 Read [336] bytes from client
+     | 1683826581133 (R)
+     | 1683826581133 (RP)
+     | 1683826581133 Preamble successfully parsed
+     | 1683826581133 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581133 (RWo)
+     | 1683826581133 (RC)
+     | 1683826581134 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581135 Preamble is [198] bytes long
+     | 1683826581135 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581135 Still writing preamble
+     | 1683826581135 Wrote [198] bytes to the client
+     | 1683826581135 (W)
+     | 1683826581135 Writing back bytes
+     | 1683826581135 Wrote [15957] bytes to the client
+     | 1683826581135 (W)
+     | 1683826581135 Writing back bytes
+     | 1683826581135 Wrote [5] bytes to the client
+     | 1683826581135 (W)
+     | 1683826581135 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581135 (WKA)
+     | 1683826581135 Read [336] bytes from client
+     | 1683826581135 (R)
+     | 1683826581135 (RP)
+     | 1683826581135 Preamble successfully parsed
+     | 1683826581135 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581135 (RWo)
+     | 1683826581135 (RC)
+     | 1683826581136 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581136 Preamble is [198] bytes long
+     | 1683826581136 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581136 Still writing preamble
+     | 1683826581136 Wrote [198] bytes to the client
+     | 1683826581136 (W)
+     | 1683826581136 Writing back bytes
+     | 1683826581136 Wrote [16056] bytes to the client
+     | 1683826581136 (W)
+     | 1683826581136 Writing back bytes
+     | 1683826581136 Wrote [5] bytes to the client
+     | 1683826581136 (W)
+     | 1683826581136 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581136 (WKA)
+     | 1683826581136 Read [336] bytes from client
+     | 1683826581136 (R)
+     | 1683826581136 (RP)
+     | 1683826581136 Preamble successfully parsed
+     | 1683826581136 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581136 (RWo)
+     | 1683826581136 (RC)
+     | 1683826581138 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581138 Preamble is [198] bytes long
+     | 1683826581138 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581138 Still writing preamble
+     | 1683826581138 Wrote [198] bytes to the client
+     | 1683826581138 (W)
+     | 1683826581138 Writing back bytes
+     | 1683826581138 Wrote [16155] bytes to the client
+     | 1683826581138 (W)
+     | 1683826581138 Writing back bytes
+     | 1683826581138 Wrote [5] bytes to the client
+     | 1683826581138 (W)
+     | 1683826581138 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581138 (WKA)
+     | 1683826581138 Read [336] bytes from client
+     | 1683826581138 (R)
+     | 1683826581138 (RP)
+     | 1683826581138 Preamble successfully parsed
+     | 1683826581138 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581138 (RWo)
+     | 1683826581138 (RC)
+     | 1683826581139 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581139 Preamble is [198] bytes long
+     | 1683826581139 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581139 Still writing preamble
+     | 1683826581139 Wrote [198] bytes to the client
+     | 1683826581139 (W)
+     | 1683826581139 Writing back bytes
+     | 1683826581139 Wrote [16254] bytes to the client
+     | 1683826581139 (W)
+     | 1683826581139 Writing back bytes
+     | 1683826581139 Wrote [5] bytes to the client
+     | 1683826581139 (W)
+     | 1683826581139 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581139 (WKA)
+     | 1683826581139 Read [336] bytes from client
+     | 1683826581139 (R)
+     | 1683826581139 (RP)
+     | 1683826581140 Preamble successfully parsed
+     | 1683826581140 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581140 (RWo)
+     | 1683826581140 (RC)
+     | 1683826581141 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581141 Preamble is [198] bytes long
+     | 1683826581141 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581141 Still writing preamble
+     | 1683826581141 Wrote [198] bytes to the client
+     | 1683826581141 (W)
+     | 1683826581141 Writing back bytes
+     | 1683826581141 Wrote [16353] bytes to the client
+     | 1683826581141 (W)
+     | 1683826581141 Writing back bytes
+     | 1683826581141 Wrote [5] bytes to the client
+     | 1683826581141 (W)
+     | 1683826581141 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581141 (WKA)
+     | 1683826581141 Read [336] bytes from client
+     | 1683826581141 (R)
+     | 1683826581141 (RP)
+     | 1683826581141 Preamble successfully parsed
+     | 1683826581141 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581141 (RWo)
+     | 1683826581141 (RC)
+     | 1683826581142 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581142 Preamble is [198] bytes long
+     | 1683826581142 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581142 Still writing preamble
+     | 1683826581142 Wrote [198] bytes to the client
+     | 1683826581142 (W)
+     | 1683826581142 Writing back bytes
+     | 1683826581142 Wrote [16392] bytes to the client
+     | 1683826581142 (W)
+     | 1683826581142 Writing back bytes
+     | 1683826581142 Wrote [66] bytes to the client
+     | 1683826581142 (W)
+     | 1683826581142 Writing back bytes
+     | 1683826581142 Wrote [5] bytes to the client
+     | 1683826581142 (W)
+     | 1683826581142 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581142 (WKA)
+     | 1683826581143 Read [336] bytes from client
+     | 1683826581143 (R)
+     | 1683826581143 (RP)
+     | 1683826581143 Preamble successfully parsed
+     | 1683826581143 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581143 (RWo)
+     | 1683826581143 (RC)
+     | 1683826581144 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581144 Preamble is [198] bytes long
+     | 1683826581144 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581144 Still writing preamble
+     | 1683826581144 Wrote [198] bytes to the client
+     | 1683826581144 (W)
+     | 1683826581144 Writing back bytes
+     | 1683826581144 Wrote [16392] bytes to the client
+     | 1683826581144 (W)
+     | 1683826581144 Writing back bytes
+     | 1683826581144 Wrote [165] bytes to the client
+     | 1683826581144 (W)
+     | 1683826581144 Writing back bytes
+     | 1683826581144 Wrote [5] bytes to the client
+     | 1683826581144 (W)
+     | 1683826581144 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581144 (WKA)
+     | 1683826581144 Read [336] bytes from client
+     | 1683826581144 (R)
+     | 1683826581144 (RP)
+     | 1683826581144 Preamble successfully parsed
+     | 1683826581144 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581144 (RWo)
+     | 1683826581144 (RC)
+     | 1683826581145 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581145 Preamble is [198] bytes long
+     | 1683826581145 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581145 Still writing preamble
+     | 1683826581145 Wrote [198] bytes to the client
+     | 1683826581145 (W)
+     | 1683826581145 Writing back bytes
+     | 1683826581145 Wrote [16392] bytes to the client
+     | 1683826581145 (W)
+     | 1683826581145 Writing back bytes
+     | 1683826581145 Wrote [265] bytes to the client
+     | 1683826581145 (W)
+     | 1683826581145 Writing back bytes
+     | 1683826581145 Wrote [5] bytes to the client
+     | 1683826581145 (W)
+     | 1683826581145 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581145 (WKA)
+     | 1683826581146 Read [336] bytes from client
+     | 1683826581146 (R)
+     | 1683826581146 (RP)
+     | 1683826581146 Preamble successfully parsed
+     | 1683826581146 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581146 (RWo)
+     | 1683826581146 (RC)
+     | 1683826581147 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581147 Preamble is [198] bytes long
+     | 1683826581147 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581147 Still writing preamble
+     | 1683826581147 Wrote [198] bytes to the client
+     | 1683826581147 (W)
+     | 1683826581147 Writing back bytes
+     | 1683826581147 Wrote [16392] bytes to the client
+     | 1683826581147 (W)
+     | 1683826581147 Writing back bytes
+     | 1683826581147 Wrote [364] bytes to the client
+     | 1683826581147 (W)
+     | 1683826581147 Writing back bytes
+     | 1683826581147 Wrote [5] bytes to the client
+     | 1683826581147 (W)
+     | 1683826581147 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581147 (WKA)
+     | 1683826581147 Read [336] bytes from client
+     | 1683826581147 (R)
+     | 1683826581147 (RP)
+     | 1683826581147 Preamble successfully parsed
+     | 1683826581147 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581147 (RWo)
+     | 1683826581147 (RC)
+     | 1683826581148 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581148 Preamble is [198] bytes long
+     | 1683826581148 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581148 Still writing preamble
+     | 1683826581148 Wrote [198] bytes to the client
+     | 1683826581148 (W)
+     | 1683826581148 Writing back bytes
+     | 1683826581148 Wrote [16392] bytes to the client
+     | 1683826581148 (W)
+     | 1683826581148 Writing back bytes
+     | 1683826581148 Wrote [463] bytes to the client
+     | 1683826581148 (W)
+     | 1683826581148 Writing back bytes
+     | 1683826581148 Wrote [5] bytes to the client
+     | 1683826581148 (W)
+     | 1683826581148 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581148 (WKA)
+     | 1683826581149 Read [336] bytes from client
+     | 1683826581149 (R)
+     | 1683826581149 (RP)
+     | 1683826581149 Preamble successfully parsed
+     | 1683826581149 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581149 (RWo)
+     | 1683826581149 (RC)
+     | 1683826581150 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581150 Preamble is [198] bytes long
+     | 1683826581150 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581150 Still writing preamble
+     | 1683826581150 Wrote [198] bytes to the client
+     | 1683826581150 (W)
+     | 1683826581150 Writing back bytes
+     | 1683826581150 Wrote [16392] bytes to the client
+     | 1683826581150 (W)
+     | 1683826581150 Writing back bytes
+     | 1683826581150 Wrote [562] bytes to the client
+     | 1683826581150 (W)
+     | 1683826581150 Writing back bytes
+     | 1683826581150 Wrote [5] bytes to the client
+     | 1683826581150 (W)
+     | 1683826581150 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581150 (WKA)
+     | 1683826581150 Read [336] bytes from client
+     | 1683826581150 (R)
+     | 1683826581150 (RP)
+     | 1683826581150 Preamble successfully parsed
+     | 1683826581150 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581150 (RWo)
+     | 1683826581150 (RC)
+     | 1683826581151 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581151 Preamble is [198] bytes long
+     | 1683826581151 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581151 Still writing preamble
+     | 1683826581151 Wrote [198] bytes to the client
+     | 1683826581151 (W)
+     | 1683826581151 Writing back bytes
+     | 1683826581151 Wrote [16392] bytes to the client
+     | 1683826581151 (W)
+     | 1683826581151 Writing back bytes
+     | 1683826581151 Wrote [661] bytes to the client
+     | 1683826581151 (W)
+     | 1683826581151 Writing back bytes
+     | 1683826581151 Wrote [5] bytes to the client
+     | 1683826581151 (W)
+     | 1683826581151 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581151 (WKA)
+     | 1683826581152 Read [336] bytes from client
+     | 1683826581152 (R)
+     | 1683826581152 (RP)
+     | 1683826581152 Preamble successfully parsed
+     | 1683826581152 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581152 (RWo)
+     | 1683826581152 (RC)
+     | 1683826581153 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581153 Preamble is [198] bytes long
+     | 1683826581153 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581153 Still writing preamble
+     | 1683826581153 Wrote [198] bytes to the client
+     | 1683826581153 (W)
+     | 1683826581153 Writing back bytes
+     | 1683826581153 Wrote [16392] bytes to the client
+     | 1683826581153 (W)
+     | 1683826581153 Writing back bytes
+     | 1683826581153 Wrote [760] bytes to the client
+     | 1683826581153 (W)
+     | 1683826581153 Writing back bytes
+     | 1683826581153 Wrote [5] bytes to the client
+     | 1683826581153 (W)
+     | 1683826581153 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581153 (WKA)
+     | 1683826581153 Read [336] bytes from client
+     | 1683826581153 (R)
+     | 1683826581153 (RP)
+     | 1683826581153 Preamble successfully parsed
+     | 1683826581153 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581153 (RWo)
+     | 1683826581153 (RC)
+     | 1683826581154 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581154 Preamble is [198] bytes long
+     | 1683826581154 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581154 Still writing preamble
+     | 1683826581154 Wrote [198] bytes to the client
+     | 1683826581154 (W)
+     | 1683826581154 Writing back bytes
+     | 1683826581154 Wrote [16392] bytes to the client
+     | 1683826581154 (W)
+     | 1683826581154 Writing back bytes
+     | 1683826581154 Wrote [859] bytes to the client
+     | 1683826581154 (W)
+     | 1683826581154 Writing back bytes
+     | 1683826581154 Wrote [5] bytes to the client
+     | 1683826581154 (W)
+     | 1683826581154 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581154 (WKA)
+     | 1683826581155 Read [336] bytes from client
+     | 1683826581155 (R)
+     | 1683826581155 (RP)
+     | 1683826581155 Preamble successfully parsed
+     | 1683826581155 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581155 (RWo)
+     | 1683826581155 (RC)
+     | 1683826581156 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581156 Preamble is [198] bytes long
+     | 1683826581156 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581156 Still writing preamble
+     | 1683826581156 Wrote [198] bytes to the client
+     | 1683826581156 (W)
+     | 1683826581156 Writing back bytes
+     | 1683826581156 Wrote [16392] bytes to the client
+     | 1683826581156 (W)
+     | 1683826581156 Writing back bytes
+     | 1683826581156 Wrote [958] bytes to the client
+     | 1683826581156 (W)
+     | 1683826581156 Writing back bytes
+     | 1683826581156 Wrote [5] bytes to the client
+     | 1683826581156 (W)
+     | 1683826581156 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581156 (WKA)
+     | 1683826581156 Read [336] bytes from client
+     | 1683826581156 (R)
+     | 1683826581156 (RP)
+     | 1683826581156 Preamble successfully parsed
+     | 1683826581156 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581156 (RWo)
+     | 1683826581156 (RC)
+     | 1683826581157 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581158 Preamble is [198] bytes long
+     | 1683826581158 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581158 Still writing preamble
+     | 1683826581158 Wrote [198] bytes to the client
+     | 1683826581158 (W)
+     | 1683826581158 Writing back bytes
+     | 1683826581158 Wrote [16392] bytes to the client
+     | 1683826581158 (W)
+     | 1683826581158 Writing back bytes
+     | 1683826581158 Wrote [1057] bytes to the client
+     | 1683826581158 (W)
+     | 1683826581158 Writing back bytes
+     | 1683826581158 Wrote [5] bytes to the client
+     | 1683826581158 (W)
+     | 1683826581158 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581158 (WKA)
+     | 1683826581158 Read [336] bytes from client
+     | 1683826581158 (R)
+     | 1683826581158 (RP)
+     | 1683826581158 Preamble successfully parsed
+     | 1683826581158 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581158 (RWo)
+     | 1683826581158 (RC)
+     | 1683826581159 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581159 Preamble is [198] bytes long
+     | 1683826581159 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581159 Still writing preamble
+     | 1683826581159 Wrote [198] bytes to the client
+     | 1683826581159 (W)
+     | 1683826581159 Writing back bytes
+     | 1683826581159 Wrote [16392] bytes to the client
+     | 1683826581159 (W)
+     | 1683826581159 Writing back bytes
+     | 1683826581159 Wrote [1156] bytes to the client
+     | 1683826581159 (W)
+     | 1683826581159 Writing back bytes
+     | 1683826581159 Wrote [5] bytes to the client
+     | 1683826581159 (W)
+     | 1683826581159 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581159 (WKA)
+     | 1683826581160 Read [336] bytes from client
+     | 1683826581160 (R)
+     | 1683826581160 (RP)
+     | 1683826581160 Preamble successfully parsed
+     | 1683826581160 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581160 (RWo)
+     | 1683826581160 (RC)
+     | 1683826581161 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581161 Preamble is [198] bytes long
+     | 1683826581161 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581161 Still writing preamble
+     | 1683826581161 Wrote [198] bytes to the client
+     | 1683826581161 (W)
+     | 1683826581161 Writing back bytes
+     | 1683826581161 Wrote [16392] bytes to the client
+     | 1683826581161 (W)
+     | 1683826581161 Writing back bytes
+     | 1683826581161 Wrote [1255] bytes to the client
+     | 1683826581161 (W)
+     | 1683826581161 Writing back bytes
+     | 1683826581161 Wrote [5] bytes to the client
+     | 1683826581161 (W)
+     | 1683826581161 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581161 (WKA)
+     | 1683826581161 Read [336] bytes from client
+     | 1683826581161 (R)
+     | 1683826581161 (RP)
+     | 1683826581161 Preamble successfully parsed
+     | 1683826581161 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581161 (RWo)
+     | 1683826581161 (RC)
+     | 1683826581162 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581162 Preamble is [198] bytes long
+     | 1683826581162 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581162 Still writing preamble
+     | 1683826581162 Wrote [198] bytes to the client
+     | 1683826581162 (W)
+     | 1683826581162 Writing back bytes
+     | 1683826581162 Wrote [16392] bytes to the client
+     | 1683826581162 (W)
+     | 1683826581162 Writing back bytes
+     | 1683826581162 Wrote [1354] bytes to the client
+     | 1683826581162 (W)
+     | 1683826581162 Writing back bytes
+     | 1683826581162 Wrote [5] bytes to the client
+     | 1683826581162 (W)
+     | 1683826581162 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581162 (WKA)
+     | 1683826581163 Read [336] bytes from client
+     | 1683826581163 (R)
+     | 1683826581163 (RP)
+     | 1683826581163 Preamble successfully parsed
+     | 1683826581163 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581163 (RWo)
+     | 1683826581163 (RC)
+     | 1683826581164 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581164 Preamble is [198] bytes long
+     | 1683826581164 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581164 Still writing preamble
+     | 1683826581164 Wrote [198] bytes to the client
+     | 1683826581164 (W)
+     | 1683826581164 Writing back bytes
+     | 1683826581164 Wrote [16392] bytes to the client
+     | 1683826581164 (W)
+     | 1683826581164 Writing back bytes
+     | 1683826581164 Wrote [1453] bytes to the client
+     | 1683826581164 (W)
+     | 1683826581164 Writing back bytes
+     | 1683826581164 Wrote [5] bytes to the client
+     | 1683826581164 (W)
+     | 1683826581164 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581164 (WKA)
+     | 1683826581164 Read [336] bytes from client
+     | 1683826581164 (R)
+     | 1683826581164 (RP)
+     | 1683826581164 Preamble successfully parsed
+     | 1683826581164 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581164 (RWo)
+     | 1683826581164 (RC)
+     | 1683826581165 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581165 Preamble is [198] bytes long
+     | 1683826581165 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581165 Still writing preamble
+     | 1683826581165 Wrote [198] bytes to the client
+     | 1683826581165 (W)
+     | 1683826581165 Writing back bytes
+     | 1683826581165 Wrote [16392] bytes to the client
+     | 1683826581165 (W)
+     | 1683826581165 Writing back bytes
+     | 1683826581165 Wrote [1552] bytes to the client
+     | 1683826581165 (W)
+     | 1683826581165 Writing back bytes
+     | 1683826581165 Wrote [5] bytes to the client
+     | 1683826581165 (W)
+     | 1683826581165 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581165 (WKA)
+     | 1683826581166 Read [336] bytes from client
+     | 1683826581166 (R)
+     | 1683826581166 (RP)
+     | 1683826581166 Preamble successfully parsed
+     | 1683826581166 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581166 (RWo)
+     | 1683826581166 (RC)
+     | 1683826581167 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581167 Preamble is [198] bytes long
+     | 1683826581167 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581167 Still writing preamble
+     | 1683826581167 Wrote [198] bytes to the client
+     | 1683826581167 (W)
+     | 1683826581167 Writing back bytes
+     | 1683826581167 Wrote [16392] bytes to the client
+     | 1683826581167 (W)
+     | 1683826581167 Writing back bytes
+     | 1683826581167 Wrote [1651] bytes to the client
+     | 1683826581167 (W)
+     | 1683826581167 Writing back bytes
+     | 1683826581167 Wrote [5] bytes to the client
+     | 1683826581167 (W)
+     | 1683826581167 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581167 (WKA)
+     | 1683826581168 Read [336] bytes from client
+     | 1683826581168 (R)
+     | 1683826581168 (RP)
+     | 1683826581168 Preamble successfully parsed
+     | 1683826581168 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581168 (RWo)
+     | 1683826581168 (RC)
+     | 1683826581169 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581169 Preamble is [198] bytes long
+     | 1683826581169 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581169 Still writing preamble
+     | 1683826581169 Wrote [198] bytes to the client
+     | 1683826581169 (W)
+     | 1683826581169 Writing back bytes
+     | 1683826581169 Wrote [16392] bytes to the client
+     | 1683826581169 (W)
+     | 1683826581169 Writing back bytes
+     | 1683826581169 Wrote [1750] bytes to the client
+     | 1683826581169 (W)
+     | 1683826581169 Writing back bytes
+     | 1683826581169 Wrote [5] bytes to the client
+     | 1683826581169 (W)
+     | 1683826581169 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581169 (WKA)
+     | 1683826581169 Read [336] bytes from client
+     | 1683826581169 (R)
+     | 1683826581169 (RP)
+     | 1683826581169 Preamble successfully parsed
+     | 1683826581169 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581169 (RWo)
+     | 1683826581169 (RC)
+     | 1683826581170 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581170 Preamble is [198] bytes long
+     | 1683826581170 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581170 Still writing preamble
+     | 1683826581170 Wrote [198] bytes to the client
+     | 1683826581170 (W)
+     | 1683826581170 Writing back bytes
+     | 1683826581170 Wrote [16392] bytes to the client
+     | 1683826581170 (W)
+     | 1683826581170 Writing back bytes
+     | 1683826581170 Wrote [1849] bytes to the client
+     | 1683826581170 (W)
+     | 1683826581170 Writing back bytes
+     | 1683826581170 Wrote [5] bytes to the client
+     | 1683826581170 (W)
+     | 1683826581170 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581170 (WKA)
+     | 1683826581171 Read [336] bytes from client
+     | 1683826581171 (R)
+     | 1683826581171 (RP)
+     | 1683826581171 Preamble successfully parsed
+     | 1683826581171 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581171 (RWo)
+     | 1683826581171 (RC)
+     | 1683826581172 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581172 Preamble is [198] bytes long
+     | 1683826581172 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581172 Still writing preamble
+     | 1683826581172 Wrote [198] bytes to the client
+     | 1683826581172 (W)
+     | 1683826581172 Writing back bytes
+     | 1683826581172 Wrote [16392] bytes to the client
+     | 1683826581172 (W)
+     | 1683826581172 Writing back bytes
+     | 1683826581172 Wrote [1948] bytes to the client
+     | 1683826581172 (W)
+     | 1683826581172 Writing back bytes
+     | 1683826581172 Wrote [5] bytes to the client
+     | 1683826581172 (W)
+     | 1683826581172 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581172 (WKA)
+     | 1683826581172 Read [336] bytes from client
+     | 1683826581172 (R)
+     | 1683826581172 (RP)
+     | 1683826581172 Preamble successfully parsed
+     | 1683826581172 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581172 (RWo)
+     | 1683826581172 (RC)
+     | 1683826581173 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581173 Preamble is [198] bytes long
+     | 1683826581173 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581173 Still writing preamble
+     | 1683826581173 Wrote [198] bytes to the client
+     | 1683826581173 (W)
+     | 1683826581173 Writing back bytes
+     | 1683826581173 Wrote [16392] bytes to the client
+     | 1683826581173 (W)
+     | 1683826581173 Writing back bytes
+     | 1683826581173 Wrote [2047] bytes to the client
+     | 1683826581173 (W)
+     | 1683826581173 Writing back bytes
+     | 1683826581173 Wrote [5] bytes to the client
+     | 1683826581173 (W)
+     | 1683826581173 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581173 (WKA)
+     | 1683826581173 Read [336] bytes from client
+     | 1683826581173 (R)
+     | 1683826581173 (RP)
+     | 1683826581173 Preamble successfully parsed
+     | 1683826581173 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581173 (RWo)
+     | 1683826581173 (RC)
+     | 1683826581174 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581174 Preamble is [198] bytes long
+     | 1683826581174 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581174 Still writing preamble
+     | 1683826581174 Wrote [198] bytes to the client
+     | 1683826581174 (W)
+     | 1683826581174 Writing back bytes
+     | 1683826581174 Wrote [16392] bytes to the client
+     | 1683826581174 (W)
+     | 1683826581174 Writing back bytes
+     | 1683826581174 Wrote [2146] bytes to the client
+     | 1683826581174 (W)
+     | 1683826581174 Writing back bytes
+     | 1683826581174 Wrote [5] bytes to the client
+     | 1683826581174 (W)
+     | 1683826581174 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581174 (WKA)
+     | 1683826581175 Read [336] bytes from client
+     | 1683826581175 (R)
+     | 1683826581175 (RP)
+     | 1683826581175 Preamble successfully parsed
+     | 1683826581175 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581175 (RWo)
+     | 1683826581175 (RC)
+     | 1683826581176 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581176 Preamble is [198] bytes long
+     | 1683826581176 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581176 Still writing preamble
+     | 1683826581176 Wrote [198] bytes to the client
+     | 1683826581176 (W)
+     | 1683826581176 Writing back bytes
+     | 1683826581176 Wrote [16392] bytes to the client
+     | 1683826581176 (W)
+     | 1683826581176 Writing back bytes
+     | 1683826581176 Wrote [2245] bytes to the client
+     | 1683826581176 (W)
+     | 1683826581176 Writing back bytes
+     | 1683826581176 Wrote [5] bytes to the client
+     | 1683826581176 (W)
+     | 1683826581176 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581176 (WKA)
+     | 1683826581176 Read [336] bytes from client
+     | 1683826581176 (R)
+     | 1683826581176 (RP)
+     | 1683826581176 Preamble successfully parsed
+     | 1683826581176 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581176 (RWo)
+     | 1683826581176 (RC)
+     | 1683826581177 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581177 Preamble is [198] bytes long
+     | 1683826581177 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581177 Still writing preamble
+     | 1683826581177 Wrote [198] bytes to the client
+     | 1683826581177 (W)
+     | 1683826581177 Writing back bytes
+     | 1683826581177 Wrote [16392] bytes to the client
+     | 1683826581177 (W)
+     | 1683826581177 Writing back bytes
+     | 1683826581177 Wrote [2344] bytes to the client
+     | 1683826581177 (W)
+     | 1683826581177 Writing back bytes
+     | 1683826581177 Wrote [5] bytes to the client
+     | 1683826581177 (W)
+     | 1683826581177 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581177 (WKA)
+     | 1683826581177 Read [336] bytes from client
+     | 1683826581177 (R)
+     | 1683826581177 (RP)
+     | 1683826581177 Preamble successfully parsed
+     | 1683826581177 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581177 (RWo)
+     | 1683826581177 (RC)
+     | 1683826581179 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581179 Preamble is [198] bytes long
+     | 1683826581179 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581179 Still writing preamble
+     | 1683826581179 Wrote [198] bytes to the client
+     | 1683826581179 (W)
+     | 1683826581179 Writing back bytes
+     | 1683826581179 Wrote [16392] bytes to the client
+     | 1683826581179 (W)
+     | 1683826581179 Writing back bytes
+     | 1683826581179 Wrote [2443] bytes to the client
+     | 1683826581179 (W)
+     | 1683826581179 Writing back bytes
+     | 1683826581179 Wrote [5] bytes to the client
+     | 1683826581179 (W)
+     | 1683826581179 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581179 (WKA)
+     | 1683826581179 Read [336] bytes from client
+     | 1683826581179 (R)
+     | 1683826581179 (RP)
+     | 1683826581179 Preamble successfully parsed
+     | 1683826581179 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581179 (RWo)
+     | 1683826581179 (RC)
+     | 1683826581180 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581180 Preamble is [198] bytes long
+     | 1683826581180 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581180 Still writing preamble
+     | 1683826581180 Wrote [198] bytes to the client
+     | 1683826581180 (W)
+     | 1683826581180 Writing back bytes
+     | 1683826581180 Wrote [16392] bytes to the client
+     | 1683826581180 (W)
+     | 1683826581180 Writing back bytes
+     | 1683826581180 Wrote [2542] bytes to the client
+     | 1683826581180 (W)
+     | 1683826581180 Writing back bytes
+     | 1683826581180 Wrote [5] bytes to the client
+     | 1683826581180 (W)
+     | 1683826581180 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581180 (WKA)
+     | 1683826581181 Read [336] bytes from client
+     | 1683826581181 (R)
+     | 1683826581181 (RP)
+     | 1683826581181 Preamble successfully parsed
+     | 1683826581181 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581181 (RWo)
+     | 1683826581181 (RC)
+     | 1683826581182 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581182 Preamble is [198] bytes long
+     | 1683826581182 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581182 Still writing preamble
+     | 1683826581182 Wrote [198] bytes to the client
+     | 1683826581182 (W)
+     | 1683826581182 Writing back bytes
+     | 1683826581182 Wrote [16392] bytes to the client
+     | 1683826581182 (W)
+     | 1683826581182 Writing back bytes
+     | 1683826581182 Wrote [2641] bytes to the client
+     | 1683826581182 (W)
+     | 1683826581182 Writing back bytes
+     | 1683826581182 Wrote [5] bytes to the client
+     | 1683826581182 (W)
+     | 1683826581182 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581182 (WKA)
+     | 1683826581182 Read [336] bytes from client
+     | 1683826581182 (R)
+     | 1683826581182 (RP)
+     | 1683826581182 Preamble successfully parsed
+     | 1683826581182 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581182 (RWo)
+     | 1683826581182 (RC)
+     | 1683826581183 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581183 Preamble is [198] bytes long
+     | 1683826581183 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581183 Still writing preamble
+     | 1683826581183 Wrote [198] bytes to the client
+     | 1683826581183 (W)
+     | 1683826581183 Writing back bytes
+     | 1683826581183 Wrote [16392] bytes to the client
+     | 1683826581183 (W)
+     | 1683826581183 Writing back bytes
+     | 1683826581183 Wrote [2740] bytes to the client
+     | 1683826581183 (W)
+     | 1683826581183 Writing back bytes
+     | 1683826581183 Wrote [5] bytes to the client
+     | 1683826581183 (W)
+     | 1683826581183 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581183 (WKA)
+     | 1683826581184 Read [336] bytes from client
+     | 1683826581184 (R)
+     | 1683826581184 (RP)
+     | 1683826581184 Preamble successfully parsed
+     | 1683826581184 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581184 (RWo)
+     | 1683826581184 (RC)
+     | 1683826581184 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581184 Preamble is [198] bytes long
+     | 1683826581184 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581184 Still writing preamble
+     | 1683826581184 Wrote [198] bytes to the client
+     | 1683826581184 (W)
+     | 1683826581184 Writing back bytes
+     | 1683826581184 Wrote [16392] bytes to the client
+     | 1683826581184 (W)
+     | 1683826581184 Writing back bytes
+     | 1683826581184 Wrote [2839] bytes to the client
+     | 1683826581184 (W)
+     | 1683826581184 Writing back bytes
+     | 1683826581184 Wrote [5] bytes to the client
+     | 1683826581184 (W)
+     | 1683826581184 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581184 (WKA)
+     | 1683826581185 Read [336] bytes from client
+     | 1683826581185 (R)
+     | 1683826581185 (RP)
+     | 1683826581185 Preamble successfully parsed
+     | 1683826581185 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581185 (RWo)
+     | 1683826581185 (RC)
+     | 1683826581186 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581186 Preamble is [198] bytes long
+     | 1683826581186 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581186 Still writing preamble
+     | 1683826581186 Wrote [198] bytes to the client
+     | 1683826581186 (W)
+     | 1683826581186 Writing back bytes
+     | 1683826581186 Wrote [16392] bytes to the client
+     | 1683826581186 (W)
+     | 1683826581186 Writing back bytes
+     | 1683826581186 Wrote [2938] bytes to the client
+     | 1683826581186 (W)
+     | 1683826581186 Writing back bytes
+     | 1683826581186 Wrote [5] bytes to the client
+     | 1683826581186 (W)
+     | 1683826581186 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581186 (WKA)
+     | 1683826581186 Read [336] bytes from client
+     | 1683826581186 (R)
+     | 1683826581186 (RP)
+     | 1683826581186 Preamble successfully parsed
+     | 1683826581186 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581186 (RWo)
+     | 1683826581186 (RC)
+     | 1683826581187 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581187 Preamble is [198] bytes long
+     | 1683826581187 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581187 Still writing preamble
+     | 1683826581187 Wrote [198] bytes to the client
+     | 1683826581187 (W)
+     | 1683826581187 Writing back bytes
+     | 1683826581187 Wrote [16392] bytes to the client
+     | 1683826581187 (W)
+     | 1683826581187 Writing back bytes
+     | 1683826581187 Wrote [3037] bytes to the client
+     | 1683826581187 (W)
+     | 1683826581187 Writing back bytes
+     | 1683826581187 Wrote [5] bytes to the client
+     | 1683826581187 (W)
+     | 1683826581187 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581187 (WKA)
+     | 1683826581188 Read [336] bytes from client
+     | 1683826581188 (R)
+     | 1683826581188 (RP)
+     | 1683826581188 Preamble successfully parsed
+     | 1683826581188 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581188 (RWo)
+     | 1683826581188 (RC)
+     | 1683826581189 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581189 Preamble is [198] bytes long
+     | 1683826581189 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581189 Still writing preamble
+     | 1683826581189 Wrote [198] bytes to the client
+     | 1683826581189 (W)
+     | 1683826581189 Writing back bytes
+     | 1683826581189 Wrote [16392] bytes to the client
+     | 1683826581189 (W)
+     | 1683826581189 Writing back bytes
+     | 1683826581189 Wrote [3136] bytes to the client
+     | 1683826581189 (W)
+     | 1683826581189 Writing back bytes
+     | 1683826581189 Wrote [5] bytes to the client
+     | 1683826581189 (W)
+     | 1683826581189 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581189 (WKA)
+     | 1683826581189 Read [336] bytes from client
+     | 1683826581189 (R)
+     | 1683826581189 (RP)
+     | 1683826581190 Preamble successfully parsed
+     | 1683826581190 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581190 (RWo)
+     | 1683826581190 (RC)
+     | 1683826581190 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581191 Preamble is [198] bytes long
+     | 1683826581191 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581191 Still writing preamble
+     | 1683826581191 Wrote [198] bytes to the client
+     | 1683826581191 (W)
+     | 1683826581191 Writing back bytes
+     | 1683826581191 Wrote [16392] bytes to the client
+     | 1683826581191 (W)
+     | 1683826581191 Writing back bytes
+     | 1683826581191 Wrote [3235] bytes to the client
+     | 1683826581191 (W)
+     | 1683826581191 Writing back bytes
+     | 1683826581191 Wrote [5] bytes to the client
+     | 1683826581191 (W)
+     | 1683826581191 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581191 (WKA)
+     | 1683826581191 Read [336] bytes from client
+     | 1683826581191 (R)
+     | 1683826581191 (RP)
+     | 1683826581191 Preamble successfully parsed
+     | 1683826581191 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581191 (RWo)
+     | 1683826581191 (RC)
+     | 1683826581194 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581194 Preamble is [198] bytes long
+     | 1683826581194 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581194 Still writing preamble
+     | 1683826581194 Wrote [198] bytes to the client
+     | 1683826581194 (W)
+     | 1683826581194 Writing back bytes
+     | 1683826581194 Wrote [16392] bytes to the client
+     | 1683826581194 (W)
+     | 1683826581194 Writing back bytes
+     | 1683826581194 Wrote [3334] bytes to the client
+     | 1683826581194 (W)
+     | 1683826581194 Writing back bytes
+     | 1683826581194 Wrote [5] bytes to the client
+     | 1683826581194 (W)
+     | 1683826581194 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581194 (WKA)
+     | 1683826581194 Read [336] bytes from client
+     | 1683826581194 (R)
+     | 1683826581194 (RP)
+     | 1683826581194 Preamble successfully parsed
+     | 1683826581194 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581194 (RWo)
+     | 1683826581194 (RC)
+     | 1683826581195 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581196 Preamble is [198] bytes long
+     | 1683826581196 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581196 Still writing preamble
+     | 1683826581196 Wrote [198] bytes to the client
+     | 1683826581196 (W)
+     | 1683826581196 Writing back bytes
+     | 1683826581196 Wrote [16392] bytes to the client
+     | 1683826581196 (W)
+     | 1683826581196 Writing back bytes
+     | 1683826581196 Wrote [3433] bytes to the client
+     | 1683826581196 (W)
+     | 1683826581196 Writing back bytes
+     | 1683826581196 Wrote [5] bytes to the client
+     | 1683826581196 (W)
+     | 1683826581196 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581196 (WKA)
+     | 1683826581197 Read [336] bytes from client
+     | 1683826581197 (R)
+     | 1683826581197 (RP)
+     | 1683826581197 Preamble successfully parsed
+     | 1683826581197 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581197 (RWo)
+     | 1683826581197 (RC)
+     | 1683826581198 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581198 Preamble is [198] bytes long
+     | 1683826581198 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581198 Still writing preamble
+     | 1683826581198 Wrote [198] bytes to the client
+     | 1683826581198 (W)
+     | 1683826581198 Writing back bytes
+     | 1683826581198 Wrote [16392] bytes to the client
+     | 1683826581198 (W)
+     | 1683826581198 Writing back bytes
+     | 1683826581198 Wrote [3532] bytes to the client
+     | 1683826581199 (W)
+     | 1683826581199 Writing back bytes
+     | 1683826581199 Wrote [5] bytes to the client
+     | 1683826581199 (W)
+     | 1683826581199 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581199 (WKA)
+     | 1683826581199 Read [336] bytes from client
+     | 1683826581199 (R)
+     | 1683826581199 (RP)
+     | 1683826581199 Preamble successfully parsed
+     | 1683826581199 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581199 (RWo)
+     | 1683826581199 (RC)
+     | 1683826581200 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581200 Preamble is [198] bytes long
+     | 1683826581200 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581200 Still writing preamble
+     | 1683826581201 Wrote [198] bytes to the client
+     | 1683826581201 (W)
+     | 1683826581201 Writing back bytes
+     | 1683826581201 Wrote [16392] bytes to the client
+     | 1683826581201 (W)
+     | 1683826581201 Writing back bytes
+     | 1683826581201 Wrote [3631] bytes to the client
+     | 1683826581201 (W)
+     | 1683826581201 Writing back bytes
+     | 1683826581201 Wrote [5] bytes to the client
+     | 1683826581201 (W)
+     | 1683826581201 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581201 (WKA)
+     | 1683826581201 Read [336] bytes from client
+     | 1683826581201 (R)
+     | 1683826581201 (RP)
+     | 1683826581201 Preamble successfully parsed
+     | 1683826581201 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581201 (RWo)
+     | 1683826581201 (RC)
+     | 1683826581202 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581202 Preamble is [198] bytes long
+     | 1683826581202 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581202 Still writing preamble
+     | 1683826581202 Wrote [198] bytes to the client
+     | 1683826581202 (W)
+     | 1683826581202 Writing back bytes
+     | 1683826581202 Wrote [16392] bytes to the client
+     | 1683826581202 (W)
+     | 1683826581202 Writing back bytes
+     | 1683826581202 Wrote [3730] bytes to the client
+     | 1683826581202 (W)
+     | 1683826581202 Writing back bytes
+     | 1683826581202 Wrote [5] bytes to the client
+     | 1683826581202 (W)
+     | 1683826581202 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581202 (WKA)
+     | 1683826581203 Read [336] bytes from client
+     | 1683826581203 (R)
+     | 1683826581203 (RP)
+     | 1683826581203 Preamble successfully parsed
+     | 1683826581203 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581203 (RWo)
+     | 1683826581203 (RC)
+     | 1683826581204 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581204 Preamble is [198] bytes long
+     | 1683826581204 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581204 Still writing preamble
+     | 1683826581204 Wrote [198] bytes to the client
+     | 1683826581204 (W)
+     | 1683826581204 Writing back bytes
+     | 1683826581204 Wrote [16392] bytes to the client
+     | 1683826581204 (W)
+     | 1683826581204 Writing back bytes
+     | 1683826581204 Wrote [3829] bytes to the client
+     | 1683826581204 (W)
+     | 1683826581204 Writing back bytes
+     | 1683826581204 Wrote [5] bytes to the client
+     | 1683826581204 (W)
+     | 1683826581204 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581204 (WKA)
+     | 1683826581205 Read [336] bytes from client
+     | 1683826581205 (R)
+     | 1683826581205 (RP)
+     | 1683826581205 Preamble successfully parsed
+     | 1683826581205 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581205 (RWo)
+     | 1683826581205 (RC)
+     | 1683826581206 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581206 Preamble is [198] bytes long
+     | 1683826581206 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581206 Still writing preamble
+     | 1683826581206 Wrote [198] bytes to the client
+     | 1683826581206 (W)
+     | 1683826581206 Writing back bytes
+     | 1683826581206 Wrote [16392] bytes to the client
+     | 1683826581206 (W)
+     | 1683826581206 Writing back bytes
+     | 1683826581206 Wrote [3928] bytes to the client
+     | 1683826581206 (W)
+     | 1683826581206 Writing back bytes
+     | 1683826581206 Wrote [5] bytes to the client
+     | 1683826581206 (W)
+     | 1683826581206 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581206 (WKA)
+     | 1683826581206 Read [336] bytes from client
+     | 1683826581206 (R)
+     | 1683826581206 (RP)
+     | 1683826581206 Preamble successfully parsed
+     | 1683826581206 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581206 (RWo)
+     | 1683826581206 (RC)
+     | 1683826581208 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581208 Preamble is [198] bytes long
+     | 1683826581208 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581208 Still writing preamble
+     | 1683826581208 Wrote [198] bytes to the client
+     | 1683826581208 (W)
+     | 1683826581208 Writing back bytes
+     | 1683826581208 Wrote [16392] bytes to the client
+     | 1683826581208 (W)
+     | 1683826581208 Writing back bytes
+     | 1683826581208 Wrote [4027] bytes to the client
+     | 1683826581208 (W)
+     | 1683826581208 Writing back bytes
+     | 1683826581208 Wrote [5] bytes to the client
+     | 1683826581208 (W)
+     | 1683826581208 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581208 (WKA)
+     | 1683826581208 Read [336] bytes from client
+     | 1683826581208 (R)
+     | 1683826581208 (RP)
+     | 1683826581208 Preamble successfully parsed
+     | 1683826581208 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581208 (RWo)
+     | 1683826581208 (RC)
+     | 1683826581209 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581209 Preamble is [198] bytes long
+     | 1683826581209 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581209 Still writing preamble
+     | 1683826581209 Wrote [198] bytes to the client
+     | 1683826581209 (W)
+     | 1683826581209 Writing back bytes
+     | 1683826581209 Wrote [16392] bytes to the client
+     | 1683826581209 (W)
+     | 1683826581209 Writing back bytes
+     | 1683826581209 Wrote [4127] bytes to the client
+     | 1683826581209 (W)
+     | 1683826581209 Writing back bytes
+     | 1683826581209 Wrote [5] bytes to the client
+     | 1683826581209 (W)
+     | 1683826581209 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581209 (WKA)
+     | 1683826581210 Read [336] bytes from client
+     | 1683826581210 (R)
+     | 1683826581210 (RP)
+     | 1683826581210 Preamble successfully parsed
+     | 1683826581210 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581210 (RWo)
+     | 1683826581210 (RC)
+     | 1683826581211 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581211 Preamble is [198] bytes long
+     | 1683826581211 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581211 Still writing preamble
+     | 1683826581211 Wrote [198] bytes to the client
+     | 1683826581211 (W)
+     | 1683826581211 Writing back bytes
+     | 1683826581211 Wrote [16392] bytes to the client
+     | 1683826581211 (W)
+     | 1683826581211 Writing back bytes
+     | 1683826581211 Wrote [4226] bytes to the client
+     | 1683826581211 (W)
+     | 1683826581211 Writing back bytes
+     | 1683826581211 Wrote [5] bytes to the client
+     | 1683826581211 (W)
+     | 1683826581211 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581211 (WKA)
+     | 1683826581211 Read [336] bytes from client
+     | 1683826581211 (R)
+     | 1683826581211 (RP)
+     | 1683826581211 Preamble successfully parsed
+     | 1683826581211 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581211 (RWo)
+     | 1683826581211 (RC)
+     | 1683826581212 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581212 Preamble is [198] bytes long
+     | 1683826581212 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581212 Still writing preamble
+     | 1683826581212 Wrote [198] bytes to the client
+     | 1683826581212 (W)
+     | 1683826581212 Writing back bytes
+     | 1683826581212 Wrote [16392] bytes to the client
+     | 1683826581212 (W)
+     | 1683826581212 Writing back bytes
+     | 1683826581212 Wrote [4325] bytes to the client
+     | 1683826581212 (W)
+     | 1683826581212 Writing back bytes
+     | 1683826581212 Wrote [5] bytes to the client
+     | 1683826581212 (W)
+     | 1683826581212 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581212 (WKA)
+     | 1683826581213 Read [336] bytes from client
+     | 1683826581213 (R)
+     | 1683826581213 (RP)
+     | 1683826581213 Preamble successfully parsed
+     | 1683826581213 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581213 (RWo)
+     | 1683826581213 (RC)
+     | 1683826581214 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581214 Preamble is [198] bytes long
+     | 1683826581214 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581214 Still writing preamble
+     | 1683826581214 Wrote [198] bytes to the client
+     | 1683826581214 (W)
+     | 1683826581214 Writing back bytes
+     | 1683826581214 Wrote [16392] bytes to the client
+     | 1683826581214 (W)
+     | 1683826581214 Writing back bytes
+     | 1683826581214 Wrote [4424] bytes to the client
+     | 1683826581214 (W)
+     | 1683826581214 Writing back bytes
+     | 1683826581214 Wrote [5] bytes to the client
+     | 1683826581214 (W)
+     | 1683826581214 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581214 (WKA)
+     | 1683826581214 Read [336] bytes from client
+     | 1683826581214 (R)
+     | 1683826581214 (RP)
+     | 1683826581214 Preamble successfully parsed
+     | 1683826581214 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581214 (RWo)
+     | 1683826581214 (RC)
+     | 1683826581215 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581215 Preamble is [198] bytes long
+     | 1683826581215 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581215 Still writing preamble
+     | 1683826581215 Wrote [198] bytes to the client
+     | 1683826581215 (W)
+     | 1683826581215 Writing back bytes
+     | 1683826581215 Wrote [16392] bytes to the client
+     | 1683826581215 (W)
+     | 1683826581215 Writing back bytes
+     | 1683826581215 Wrote [4523] bytes to the client
+     | 1683826581215 (W)
+     | 1683826581215 Writing back bytes
+     | 1683826581215 Wrote [5] bytes to the client
+     | 1683826581215 (W)
+     | 1683826581215 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581215 (WKA)
+     | 1683826581216 Read [336] bytes from client
+     | 1683826581216 (R)
+     | 1683826581216 (RP)
+     | 1683826581216 Preamble successfully parsed
+     | 1683826581216 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581216 (RWo)
+     | 1683826581216 (RC)
+     | 1683826581217 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581217 Preamble is [198] bytes long
+     | 1683826581217 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581217 Still writing preamble
+     | 1683826581217 Wrote [198] bytes to the client
+     | 1683826581217 (W)
+     | 1683826581217 Writing back bytes
+     | 1683826581217 Wrote [16392] bytes to the client
+     | 1683826581217 (W)
+     | 1683826581217 Writing back bytes
+     | 1683826581217 Wrote [4622] bytes to the client
+     | 1683826581217 (W)
+     | 1683826581217 Writing back bytes
+     | 1683826581217 Wrote [5] bytes to the client
+     | 1683826581217 (W)
+     | 1683826581217 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581217 (WKA)
+     | 1683826581217 Read [336] bytes from client
+     | 1683826581217 (R)
+     | 1683826581217 (RP)
+     | 1683826581217 Preamble successfully parsed
+     | 1683826581217 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581217 (RWo)
+     | 1683826581217 (RC)
+     | 1683826581218 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581218 Preamble is [198] bytes long
+     | 1683826581218 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581218 Still writing preamble
+     | 1683826581218 Wrote [198] bytes to the client
+     | 1683826581218 (W)
+     | 1683826581218 Writing back bytes
+     | 1683826581218 Wrote [16392] bytes to the client
+     | 1683826581218 (W)
+     | 1683826581218 Writing back bytes
+     | 1683826581218 Wrote [4721] bytes to the client
+     | 1683826581218 (W)
+     | 1683826581218 Writing back bytes
+     | 1683826581218 Wrote [5] bytes to the client
+     | 1683826581218 (W)
+     | 1683826581218 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581218 (WKA)
+     | 1683826581219 Read [336] bytes from client
+     | 1683826581219 (R)
+     | 1683826581219 (RP)
+     | 1683826581219 Preamble successfully parsed
+     | 1683826581219 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581219 (RWo)
+     | 1683826581219 (RC)
+     | 1683826581220 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581220 Preamble is [198] bytes long
+     | 1683826581220 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581220 Still writing preamble
+     | 1683826581220 Wrote [198] bytes to the client
+     | 1683826581220 (W)
+     | 1683826581220 Writing back bytes
+     | 1683826581220 Wrote [16392] bytes to the client
+     | 1683826581220 (W)
+     | 1683826581220 Writing back bytes
+     | 1683826581220 Wrote [4820] bytes to the client
+     | 1683826581220 (W)
+     | 1683826581220 Writing back bytes
+     | 1683826581220 Wrote [5] bytes to the client
+     | 1683826581220 (W)
+     | 1683826581220 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581220 (WKA)
+     | 1683826581220 Read [336] bytes from client
+     | 1683826581220 (R)
+     | 1683826581220 (RP)
+     | 1683826581220 Preamble successfully parsed
+     | 1683826581220 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581220 (RWo)
+     | 1683826581220 (RC)
+     | 1683826581221 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581221 Preamble is [198] bytes long
+     | 1683826581221 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581221 Still writing preamble
+     | 1683826581221 Wrote [198] bytes to the client
+     | 1683826581221 (W)
+     | 1683826581221 Writing back bytes
+     | 1683826581221 Wrote [16392] bytes to the client
+     | 1683826581221 (W)
+     | 1683826581221 Writing back bytes
+     | 1683826581221 Wrote [4919] bytes to the client
+     | 1683826581221 (W)
+     | 1683826581221 Writing back bytes
+     | 1683826581221 Wrote [5] bytes to the client
+     | 1683826581221 (W)
+     | 1683826581221 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581221 (WKA)
+     | 1683826581222 Read [336] bytes from client
+     | 1683826581222 (R)
+     | 1683826581222 (RP)
+     | 1683826581222 Preamble successfully parsed
+     | 1683826581222 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581222 (RWo)
+     | 1683826581222 (RC)
+     | 1683826581223 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581223 Preamble is [198] bytes long
+     | 1683826581223 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581223 Still writing preamble
+     | 1683826581223 Wrote [198] bytes to the client
+     | 1683826581223 (W)
+     | 1683826581223 Writing back bytes
+     | 1683826581223 Wrote [16392] bytes to the client
+     | 1683826581223 (W)
+     | 1683826581223 Writing back bytes
+     | 1683826581223 Wrote [5018] bytes to the client
+     | 1683826581223 (W)
+     | 1683826581223 Writing back bytes
+     | 1683826581223 Wrote [5] bytes to the client
+     | 1683826581223 (W)
+     | 1683826581223 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581223 (WKA)
+     | 1683826581223 Read [336] bytes from client
+     | 1683826581223 (R)
+     | 1683826581223 (RP)
+     | 1683826581223 Preamble successfully parsed
+     | 1683826581223 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581223 (RWo)
+     | 1683826581223 (RC)
+     | 1683826581224 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581224 Preamble is [198] bytes long
+     | 1683826581224 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581224 Still writing preamble
+     | 1683826581224 Wrote [198] bytes to the client
+     | 1683826581224 (W)
+     | 1683826581224 Writing back bytes
+     | 1683826581224 Wrote [16392] bytes to the client
+     | 1683826581224 (W)
+     | 1683826581224 Writing back bytes
+     | 1683826581224 Wrote [5117] bytes to the client
+     | 1683826581224 (W)
+     | 1683826581224 Writing back bytes
+     | 1683826581224 Wrote [5] bytes to the client
+     | 1683826581224 (W)
+     | 1683826581224 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581224 (WKA)
+     | 1683826581225 Read [336] bytes from client
+     | 1683826581225 (R)
+     | 1683826581225 (RP)
+     | 1683826581225 Preamble successfully parsed
+     | 1683826581225 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581225 (RWo)
+     | 1683826581225 (RC)
+     | 1683826581226 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581226 Preamble is [198] bytes long
+     | 1683826581226 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581226 Still writing preamble
+     | 1683826581226 Wrote [198] bytes to the client
+     | 1683826581226 (W)
+     | 1683826581226 Writing back bytes
+     | 1683826581226 Wrote [16392] bytes to the client
+     | 1683826581226 (W)
+     | 1683826581226 Writing back bytes
+     | 1683826581226 Wrote [5216] bytes to the client
+     | 1683826581226 (W)
+     | 1683826581226 Writing back bytes
+     | 1683826581226 Wrote [5] bytes to the client
+     | 1683826581226 (W)
+     | 1683826581226 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581226 (WKA)
+     | 1683826581226 Read [336] bytes from client
+     | 1683826581226 (R)
+     | 1683826581226 (RP)
+     | 1683826581226 Preamble successfully parsed
+     | 1683826581226 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581226 (RWo)
+     | 1683826581226 (RC)
+     | 1683826581227 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581227 Preamble is [198] bytes long
+     | 1683826581227 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581227 Still writing preamble
+     | 1683826581227 Wrote [198] bytes to the client
+     | 1683826581227 (W)
+     | 1683826581227 Writing back bytes
+     | 1683826581227 Wrote [16392] bytes to the client
+     | 1683826581227 (W)
+     | 1683826581227 Writing back bytes
+     | 1683826581227 Wrote [5315] bytes to the client
+     | 1683826581227 (W)
+     | 1683826581227 Writing back bytes
+     | 1683826581227 Wrote [5] bytes to the client
+     | 1683826581227 (W)
+     | 1683826581227 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581227 (WKA)
+     | 1683826581228 Read [336] bytes from client
+     | 1683826581228 (R)
+     | 1683826581228 (RP)
+     | 1683826581228 Preamble successfully parsed
+     | 1683826581228 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581228 (RWo)
+     | 1683826581228 (RC)
+     | 1683826581229 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581229 Preamble is [198] bytes long
+     | 1683826581229 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581229 Still writing preamble
+     | 1683826581229 Wrote [198] bytes to the client
+     | 1683826581229 (W)
+     | 1683826581229 Writing back bytes
+     | 1683826581229 Wrote [16392] bytes to the client
+     | 1683826581229 (W)
+     | 1683826581229 Writing back bytes
+     | 1683826581229 Wrote [5414] bytes to the client
+     | 1683826581229 (W)
+     | 1683826581229 Writing back bytes
+     | 1683826581229 Wrote [5] bytes to the client
+     | 1683826581229 (W)
+     | 1683826581229 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581229 (WKA)
+     | 1683826581229 Read [336] bytes from client
+     | 1683826581229 (R)
+     | 1683826581229 (RP)
+     | 1683826581229 Preamble successfully parsed
+     | 1683826581229 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581229 (RWo)
+     | 1683826581229 (RC)
+     | 1683826581230 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581230 Preamble is [198] bytes long
+     | 1683826581230 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581230 Still writing preamble
+     | 1683826581230 Wrote [198] bytes to the client
+     | 1683826581230 (W)
+     | 1683826581230 Writing back bytes
+     | 1683826581230 Wrote [16392] bytes to the client
+     | 1683826581230 (W)
+     | 1683826581230 Writing back bytes
+     | 1683826581230 Wrote [5513] bytes to the client
+     | 1683826581230 (W)
+     | 1683826581230 Writing back bytes
+     | 1683826581230 Wrote [5] bytes to the client
+     | 1683826581230 (W)
+     | 1683826581230 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581230 (WKA)
+     | 1683826581231 Read [336] bytes from client
+     | 1683826581231 (R)
+     | 1683826581231 (RP)
+     | 1683826581231 Preamble successfully parsed
+     | 1683826581231 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581231 (RWo)
+     | 1683826581231 (RC)
+     | 1683826581232 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581232 Preamble is [198] bytes long
+     | 1683826581232 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581232 Still writing preamble
+     | 1683826581232 Wrote [198] bytes to the client
+     | 1683826581232 (W)
+     | 1683826581232 Writing back bytes
+     | 1683826581232 Wrote [16392] bytes to the client
+     | 1683826581232 (W)
+     | 1683826581232 Writing back bytes
+     | 1683826581232 Wrote [5612] bytes to the client
+     | 1683826581232 (W)
+     | 1683826581232 Writing back bytes
+     | 1683826581232 Wrote [5] bytes to the client
+     | 1683826581232 (W)
+     | 1683826581232 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581232 (WKA)
+     | 1683826581233 Read [336] bytes from client
+     | 1683826581233 (R)
+     | 1683826581233 (RP)
+     | 1683826581233 Preamble successfully parsed
+     | 1683826581233 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581233 (RWo)
+     | 1683826581233 (RC)
+     | 1683826581234 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581234 Preamble is [198] bytes long
+     | 1683826581234 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581234 Still writing preamble
+     | 1683826581234 Wrote [198] bytes to the client
+     | 1683826581234 (W)
+     | 1683826581234 Writing back bytes
+     | 1683826581234 Wrote [16392] bytes to the client
+     | 1683826581234 (W)
+     | 1683826581234 Writing back bytes
+     | 1683826581234 Wrote [5711] bytes to the client
+     | 1683826581234 (W)
+     | 1683826581234 Writing back bytes
+     | 1683826581234 Wrote [5] bytes to the client
+     | 1683826581234 (W)
+     | 1683826581234 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581234 (WKA)
+     | 1683826581234 Read [336] bytes from client
+     | 1683826581234 (R)
+     | 1683826581234 (RP)
+     | 1683826581234 Preamble successfully parsed
+     | 1683826581234 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581234 (RWo)
+     | 1683826581234 (RC)
+     | 1683826581235 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581235 Preamble is [198] bytes long
+     | 1683826581235 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581235 Still writing preamble
+     | 1683826581235 Wrote [198] bytes to the client
+     | 1683826581235 (W)
+     | 1683826581235 Writing back bytes
+     | 1683826581235 Wrote [16392] bytes to the client
+     | 1683826581235 (W)
+     | 1683826581235 Writing back bytes
+     | 1683826581235 Wrote [5810] bytes to the client
+     | 1683826581235 (W)
+     | 1683826581235 Writing back bytes
+     | 1683826581235 Wrote [5] bytes to the client
+     | 1683826581235 (W)
+     | 1683826581235 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581235 (WKA)
+     | 1683826581236 Read [336] bytes from client
+     | 1683826581236 (R)
+     | 1683826581236 (RP)
+     | 1683826581236 Preamble successfully parsed
+     | 1683826581236 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581236 (RWo)
+     | 1683826581236 (RC)
+     | 1683826581236 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581237 Preamble is [198] bytes long
+     | 1683826581237 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581237 Still writing preamble
+     | 1683826581237 Wrote [198] bytes to the client
+     | 1683826581237 (W)
+     | 1683826581237 Writing back bytes
+     | 1683826581237 Wrote [16392] bytes to the client
+     | 1683826581237 (W)
+     | 1683826581237 Writing back bytes
+     | 1683826581237 Wrote [5909] bytes to the client
+     | 1683826581237 (W)
+     | 1683826581237 Writing back bytes
+     | 1683826581237 Wrote [5] bytes to the client
+     | 1683826581237 (W)
+     | 1683826581237 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581237 (WKA)
+     | 1683826581237 Read [336] bytes from client
+     | 1683826581237 (R)
+     | 1683826581237 (RP)
+     | 1683826581237 Preamble successfully parsed
+     | 1683826581237 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581237 (RWo)
+     | 1683826581237 (RC)
+     | 1683826581238 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581238 Preamble is [198] bytes long
+     | 1683826581238 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581238 Still writing preamble
+     | 1683826581238 Wrote [198] bytes to the client
+     | 1683826581238 (W)
+     | 1683826581238 Writing back bytes
+     | 1683826581238 Wrote [16392] bytes to the client
+     | 1683826581238 (W)
+     | 1683826581238 Writing back bytes
+     | 1683826581238 Wrote [6008] bytes to the client
+     | 1683826581238 (W)
+     | 1683826581238 Writing back bytes
+     | 1683826581238 Wrote [5] bytes to the client
+     | 1683826581238 (W)
+     | 1683826581238 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581238 (WKA)
+     | 1683826581238 Read [336] bytes from client
+     | 1683826581238 (R)
+     | 1683826581238 (RP)
+     | 1683826581238 Preamble successfully parsed
+     | 1683826581238 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581238 (RWo)
+     | 1683826581238 (RC)
+     | 1683826581239 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581239 Preamble is [198] bytes long
+     | 1683826581239 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581239 Still writing preamble
+     | 1683826581240 Wrote [198] bytes to the client
+     | 1683826581240 (W)
+     | 1683826581240 Writing back bytes
+     | 1683826581240 Wrote [16392] bytes to the client
+     | 1683826581240 (W)
+     | 1683826581240 Writing back bytes
+     | 1683826581240 Wrote [6107] bytes to the client
+     | 1683826581240 (W)
+     | 1683826581240 Writing back bytes
+     | 1683826581240 Wrote [5] bytes to the client
+     | 1683826581240 (W)
+     | 1683826581240 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581240 (WKA)
+     | 1683826581240 Read [336] bytes from client
+     | 1683826581240 (R)
+     | 1683826581240 (RP)
+     | 1683826581240 Preamble successfully parsed
+     | 1683826581240 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581240 (RWo)
+     | 1683826581240 (RC)
+     | 1683826581241 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581241 Preamble is [198] bytes long
+     | 1683826581241 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581241 Still writing preamble
+     | 1683826581241 Wrote [198] bytes to the client
+     | 1683826581241 (W)
+     | 1683826581241 Writing back bytes
+     | 1683826581241 Wrote [16392] bytes to the client
+     | 1683826581241 (W)
+     | 1683826581241 Writing back bytes
+     | 1683826581241 Wrote [6206] bytes to the client
+     | 1683826581241 (W)
+     | 1683826581241 Writing back bytes
+     | 1683826581241 Wrote [5] bytes to the client
+     | 1683826581241 (W)
+     | 1683826581241 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581241 (WKA)
+     | 1683826581242 Read [336] bytes from client
+     | 1683826581242 (R)
+     | 1683826581242 (RP)
+     | 1683826581242 Preamble successfully parsed
+     | 1683826581242 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581242 (RWo)
+     | 1683826581242 (RC)
+     | 1683826581242 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581243 Preamble is [198] bytes long
+     | 1683826581243 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581243 Still writing preamble
+     | 1683826581243 Wrote [198] bytes to the client
+     | 1683826581243 (W)
+     | 1683826581243 Writing back bytes
+     | 1683826581243 Wrote [16392] bytes to the client
+     | 1683826581243 (W)
+     | 1683826581243 Writing back bytes
+     | 1683826581243 Wrote [6305] bytes to the client
+     | 1683826581243 (W)
+     | 1683826581243 Writing back bytes
+     | 1683826581243 Wrote [5] bytes to the client
+     | 1683826581243 (W)
+     | 1683826581243 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581243 (WKA)
+     | 1683826581243 Read [336] bytes from client
+     | 1683826581243 (R)
+     | 1683826581243 (RP)
+     | 1683826581243 Preamble successfully parsed
+     | 1683826581243 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581243 (RWo)
+     | 1683826581243 (RC)
+     | 1683826581244 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581244 Preamble is [198] bytes long
+     | 1683826581244 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581244 Still writing preamble
+     | 1683826581244 Wrote [198] bytes to the client
+     | 1683826581244 (W)
+     | 1683826581244 Writing back bytes
+     | 1683826581244 Wrote [16392] bytes to the client
+     | 1683826581244 (W)
+     | 1683826581244 Writing back bytes
+     | 1683826581244 Wrote [6404] bytes to the client
+     | 1683826581244 (W)
+     | 1683826581244 Writing back bytes
+     | 1683826581244 Wrote [5] bytes to the client
+     | 1683826581244 (W)
+     | 1683826581244 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581244 (WKA)
+     | 1683826581244 Read [336] bytes from client
+     | 1683826581244 (R)
+     | 1683826581244 (RP)
+     | 1683826581244 Preamble successfully parsed
+     | 1683826581244 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581244 (RWo)
+     | 1683826581244 (RC)
+     | 1683826581245 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581245 Preamble is [198] bytes long
+     | 1683826581245 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581245 Still writing preamble
+     | 1683826581245 Wrote [198] bytes to the client
+     | 1683826581245 (W)
+     | 1683826581245 Writing back bytes
+     | 1683826581245 Wrote [16392] bytes to the client
+     | 1683826581245 (W)
+     | 1683826581245 Writing back bytes
+     | 1683826581245 Wrote [6503] bytes to the client
+     | 1683826581245 (W)
+     | 1683826581245 Writing back bytes
+     | 1683826581245 Wrote [5] bytes to the client
+     | 1683826581245 (W)
+     | 1683826581245 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581245 (WKA)
+     | 1683826581246 Read [336] bytes from client
+     | 1683826581246 (R)
+     | 1683826581246 (RP)
+     | 1683826581246 Preamble successfully parsed
+     | 1683826581246 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581246 (RWo)
+     | 1683826581246 (RC)
+     | 1683826581247 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581247 Preamble is [198] bytes long
+     | 1683826581247 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581247 Still writing preamble
+     | 1683826581247 Wrote [198] bytes to the client
+     | 1683826581247 (W)
+     | 1683826581247 Writing back bytes
+     | 1683826581247 Wrote [16392] bytes to the client
+     | 1683826581247 (W)
+     | 1683826581247 Writing back bytes
+     | 1683826581247 Wrote [6602] bytes to the client
+     | 1683826581247 (W)
+     | 1683826581247 Writing back bytes
+     | 1683826581247 Wrote [5] bytes to the client
+     | 1683826581247 (W)
+     | 1683826581247 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581247 (WKA)
+     | 1683826581247 Read [336] bytes from client
+     | 1683826581247 (R)
+     | 1683826581247 (RP)
+     | 1683826581247 Preamble successfully parsed
+     | 1683826581247 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581247 (RWo)
+     | 1683826581247 (RC)
+     | 1683826581248 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581248 Preamble is [198] bytes long
+     | 1683826581248 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581248 Still writing preamble
+     | 1683826581248 Wrote [198] bytes to the client
+     | 1683826581248 (W)
+     | 1683826581248 Writing back bytes
+     | 1683826581248 Wrote [16392] bytes to the client
+     | 1683826581248 (W)
+     | 1683826581248 Writing back bytes
+     | 1683826581248 Wrote [6701] bytes to the client
+     | 1683826581248 (W)
+     | 1683826581248 Writing back bytes
+     | 1683826581248 Wrote [5] bytes to the client
+     | 1683826581248 (W)
+     | 1683826581248 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581248 (WKA)
+     | 1683826581248 Read [336] bytes from client
+     | 1683826581248 (R)
+     | 1683826581248 (RP)
+     | 1683826581248 Preamble successfully parsed
+     | 1683826581248 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581248 (RWo)
+     | 1683826581248 (RC)
+     | 1683826581250 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581250 Preamble is [198] bytes long
+     | 1683826581250 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581250 Still writing preamble
+     | 1683826581250 Wrote [198] bytes to the client
+     | 1683826581250 (W)
+     | 1683826581250 Writing back bytes
+     | 1683826581250 Wrote [16392] bytes to the client
+     | 1683826581250 (W)
+     | 1683826581250 Writing back bytes
+     | 1683826581250 Wrote [6800] bytes to the client
+     | 1683826581250 (W)
+     | 1683826581250 Writing back bytes
+     | 1683826581250 Wrote [5] bytes to the client
+     | 1683826581250 (W)
+     | 1683826581250 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581250 (WKA)
+     | 1683826581250 Read [336] bytes from client
+     | 1683826581250 (R)
+     | 1683826581250 (RP)
+     | 1683826581250 Preamble successfully parsed
+     | 1683826581250 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581250 (RWo)
+     | 1683826581250 (RC)
+     | 1683826581251 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581251 Preamble is [198] bytes long
+     | 1683826581251 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581251 Still writing preamble
+     | 1683826581251 Wrote [198] bytes to the client
+     | 1683826581251 (W)
+     | 1683826581251 Writing back bytes
+     | 1683826581251 Wrote [16392] bytes to the client
+     | 1683826581251 (W)
+     | 1683826581251 Writing back bytes
+     | 1683826581251 Wrote [6899] bytes to the client
+     | 1683826581251 (W)
+     | 1683826581251 Writing back bytes
+     | 1683826581251 Wrote [5] bytes to the client
+     | 1683826581251 (W)
+     | 1683826581251 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581251 (WKA)
+     | 1683826581252 Read [336] bytes from client
+     | 1683826581252 (R)
+     | 1683826581252 (RP)
+     | 1683826581252 Preamble successfully parsed
+     | 1683826581252 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581252 (RWo)
+     | 1683826581252 (RC)
+     | 1683826581253 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581253 Preamble is [198] bytes long
+     | 1683826581253 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581253 Still writing preamble
+     | 1683826581253 Wrote [198] bytes to the client
+     | 1683826581253 (W)
+     | 1683826581253 Writing back bytes
+     | 1683826581253 Wrote [16392] bytes to the client
+     | 1683826581253 (W)
+     | 1683826581253 Writing back bytes
+     | 1683826581253 Wrote [6998] bytes to the client
+     | 1683826581253 (W)
+     | 1683826581253 Writing back bytes
+     | 1683826581253 Wrote [5] bytes to the client
+     | 1683826581253 (W)
+     | 1683826581253 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581253 (WKA)
+     | 1683826581253 Read [336] bytes from client
+     | 1683826581253 (R)
+     | 1683826581253 (RP)
+     | 1683826581253 Preamble successfully parsed
+     | 1683826581253 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581253 (RWo)
+     | 1683826581253 (RC)
+     | 1683826581254 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581254 Preamble is [198] bytes long
+     | 1683826581254 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581254 Still writing preamble
+     | 1683826581254 Wrote [198] bytes to the client
+     | 1683826581254 (W)
+     | 1683826581254 Writing back bytes
+     | 1683826581254 Wrote [16392] bytes to the client
+     | 1683826581254 (W)
+     | 1683826581254 Writing back bytes
+     | 1683826581254 Wrote [7097] bytes to the client
+     | 1683826581254 (W)
+     | 1683826581254 Writing back bytes
+     | 1683826581254 Wrote [5] bytes to the client
+     | 1683826581254 (W)
+     | 1683826581254 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581254 (WKA)
+     | 1683826581255 Read [336] bytes from client
+     | 1683826581255 (R)
+     | 1683826581255 (RP)
+     | 1683826581255 Preamble successfully parsed
+     | 1683826581255 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581255 (RWo)
+     | 1683826581255 (RC)
+     | 1683826581256 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581256 Preamble is [198] bytes long
+     | 1683826581256 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581256 Still writing preamble
+     | 1683826581256 Wrote [198] bytes to the client
+     | 1683826581256 (W)
+     | 1683826581256 Writing back bytes
+     | 1683826581256 Wrote [16392] bytes to the client
+     | 1683826581256 (W)
+     | 1683826581256 Writing back bytes
+     | 1683826581256 Wrote [7196] bytes to the client
+     | 1683826581256 (W)
+     | 1683826581256 Writing back bytes
+     | 1683826581256 Wrote [5] bytes to the client
+     | 1683826581256 (W)
+     | 1683826581256 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581256 (WKA)
+     | 1683826581256 Read [336] bytes from client
+     | 1683826581256 (R)
+     | 1683826581256 (RP)
+     | 1683826581256 Preamble successfully parsed
+     | 1683826581256 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581256 (RWo)
+     | 1683826581256 (RC)
+     | 1683826581258 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581258 Preamble is [198] bytes long
+     | 1683826581258 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581258 Still writing preamble
+     | 1683826581258 Wrote [198] bytes to the client
+     | 1683826581258 (W)
+     | 1683826581258 Writing back bytes
+     | 1683826581258 Wrote [16392] bytes to the client
+     | 1683826581258 (W)
+     | 1683826581258 Writing back bytes
+     | 1683826581258 Wrote [7295] bytes to the client
+     | 1683826581258 (W)
+     | 1683826581258 Writing back bytes
+     | 1683826581258 Wrote [5] bytes to the client
+     | 1683826581258 (W)
+     | 1683826581258 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581258 (WKA)
+     | 1683826581258 Read [336] bytes from client
+     | 1683826581258 (R)
+     | 1683826581258 (RP)
+     | 1683826581258 Preamble successfully parsed
+     | 1683826581258 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581258 (RWo)
+     | 1683826581258 (RC)
+     | 1683826581259 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581259 Preamble is [198] bytes long
+     | 1683826581259 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581259 Still writing preamble
+     | 1683826581259 Wrote [198] bytes to the client
+     | 1683826581259 (W)
+     | 1683826581259 Writing back bytes
+     | 1683826581259 Wrote [16392] bytes to the client
+     | 1683826581259 (W)
+     | 1683826581259 Writing back bytes
+     | 1683826581259 Wrote [7394] bytes to the client
+     | 1683826581259 (W)
+     | 1683826581259 Writing back bytes
+     | 1683826581259 Wrote [5] bytes to the client
+     | 1683826581259 (W)
+     | 1683826581259 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581259 (WKA)
+     | 1683826581259 Read [336] bytes from client
+     | 1683826581259 (R)
+     | 1683826581259 (RP)
+     | 1683826581259 Preamble successfully parsed
+     | 1683826581259 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581259 (RWo)
+     | 1683826581259 (RC)
+     | 1683826581260 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581260 Preamble is [198] bytes long
+     | 1683826581260 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581260 Still writing preamble
+     | 1683826581260 Wrote [198] bytes to the client
+     | 1683826581260 (W)
+     | 1683826581260 Writing back bytes
+     | 1683826581260 Wrote [16392] bytes to the client
+     | 1683826581260 (W)
+     | 1683826581260 Writing back bytes
+     | 1683826581260 Wrote [7493] bytes to the client
+     | 1683826581260 (W)
+     | 1683826581260 Writing back bytes
+     | 1683826581260 Wrote [5] bytes to the client
+     | 1683826581260 (W)
+     | 1683826581260 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581260 (WKA)
+     | 1683826581261 Read [336] bytes from client
+     | 1683826581261 (R)
+     | 1683826581261 (RP)
+     | 1683826581261 Preamble successfully parsed
+     | 1683826581261 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581261 (RWo)
+     | 1683826581261 (RC)
+     | 1683826581262 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581262 Preamble is [198] bytes long
+     | 1683826581262 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581262 Still writing preamble
+     | 1683826581262 Wrote [198] bytes to the client
+     | 1683826581262 (W)
+     | 1683826581262 Writing back bytes
+     | 1683826581262 Wrote [16392] bytes to the client
+     | 1683826581262 (W)
+     | 1683826581262 Writing back bytes
+     | 1683826581262 Wrote [7592] bytes to the client
+     | 1683826581262 (W)
+     | 1683826581262 Writing back bytes
+     | 1683826581262 Wrote [5] bytes to the client
+     | 1683826581262 (W)
+     | 1683826581262 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581262 (WKA)
+     | 1683826581262 Read [336] bytes from client
+     | 1683826581262 (R)
+     | 1683826581262 (RP)
+     | 1683826581262 Preamble successfully parsed
+     | 1683826581262 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581262 (RWo)
+     | 1683826581262 (RC)
+     | 1683826581265 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581266 Preamble is [198] bytes long
+     | 1683826581266 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581266 Still writing preamble
+     | 1683826581266 Wrote [198] bytes to the client
+     | 1683826581266 (W)
+     | 1683826581266 Writing back bytes
+     | 1683826581266 Wrote [16392] bytes to the client
+     | 1683826581266 (W)
+     | 1683826581266 Writing back bytes
+     | 1683826581266 Wrote [7691] bytes to the client
+     | 1683826581266 (W)
+     | 1683826581266 Writing back bytes
+     | 1683826581266 Wrote [5] bytes to the client
+     | 1683826581266 (W)
+     | 1683826581266 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581266 (WKA)
+     | 1683826581266 Read [336] bytes from client
+     | 1683826581266 (R)
+     | 1683826581266 (RP)
+     | 1683826581266 Preamble successfully parsed
+     | 1683826581266 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581266 (RWo)
+     | 1683826581266 (RC)
+     | 1683826581267 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581267 Preamble is [198] bytes long
+     | 1683826581267 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581267 Still writing preamble
+     | 1683826581267 Wrote [198] bytes to the client
+     | 1683826581267 (W)
+     | 1683826581267 Writing back bytes
+     | 1683826581267 Wrote [16392] bytes to the client
+     | 1683826581267 (W)
+     | 1683826581267 Writing back bytes
+     | 1683826581267 Wrote [7790] bytes to the client
+     | 1683826581267 (W)
+     | 1683826581267 Writing back bytes
+     | 1683826581267 Wrote [5] bytes to the client
+     | 1683826581267 (W)
+     | 1683826581267 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581267 (WKA)
+     | 1683826581267 Read [336] bytes from client
+     | 1683826581267 (R)
+     | 1683826581267 (RP)
+     | 1683826581267 Preamble successfully parsed
+     | 1683826581267 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581267 (RWo)
+     | 1683826581267 (RC)
+     | 1683826581268 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581268 Preamble is [198] bytes long
+     | 1683826581268 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581268 Still writing preamble
+     | 1683826581268 Wrote [198] bytes to the client
+     | 1683826581268 (W)
+     | 1683826581268 Writing back bytes
+     | 1683826581268 Wrote [16392] bytes to the client
+     | 1683826581268 (W)
+     | 1683826581268 Writing back bytes
+     | 1683826581268 Wrote [7889] bytes to the client
+     | 1683826581268 (W)
+     | 1683826581268 Writing back bytes
+     | 1683826581268 Wrote [5] bytes to the client
+     | 1683826581268 (W)
+     | 1683826581268 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581268 (WKA)
+     | 1683826581268 Read [336] bytes from client
+     | 1683826581268 (R)
+     | 1683826581268 (RP)
+     | 1683826581269 Preamble successfully parsed
+     | 1683826581269 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581269 (RWo)
+     | 1683826581269 (RC)
+     | 1683826581269 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581269 Preamble is [198] bytes long
+     | 1683826581269 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581269 Still writing preamble
+     | 1683826581269 Wrote [198] bytes to the client
+     | 1683826581269 (W)
+     | 1683826581269 Writing back bytes
+     | 1683826581269 Wrote [16392] bytes to the client
+     | 1683826581269 (W)
+     | 1683826581269 Writing back bytes
+     | 1683826581269 Wrote [7988] bytes to the client
+     | 1683826581269 (W)
+     | 1683826581269 Writing back bytes
+     | 1683826581269 Wrote [5] bytes to the client
+     | 1683826581269 (W)
+     | 1683826581269 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581269 (WKA)
+     | 1683826581270 Read [336] bytes from client
+     | 1683826581270 (R)
+     | 1683826581270 (RP)
+     | 1683826581270 Preamble successfully parsed
+     | 1683826581270 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581270 (RWo)
+     | 1683826581270 (RC)
+     | 1683826581271 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581271 Preamble is [198] bytes long
+     | 1683826581271 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581271 Still writing preamble
+     | 1683826581271 Wrote [198] bytes to the client
+     | 1683826581271 (W)
+     | 1683826581271 Writing back bytes
+     | 1683826581271 Wrote [16392] bytes to the client
+     | 1683826581271 (W)
+     | 1683826581271 Writing back bytes
+     | 1683826581271 Wrote [8087] bytes to the client
+     | 1683826581271 (W)
+     | 1683826581271 Writing back bytes
+     | 1683826581271 Wrote [5] bytes to the client
+     | 1683826581271 (W)
+     | 1683826581271 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581271 (WKA)
+     | 1683826581271 Read [336] bytes from client
+     | 1683826581271 (R)
+     | 1683826581271 (RP)
+     | 1683826581271 Preamble successfully parsed
+     | 1683826581271 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581271 (RWo)
+     | 1683826581271 (RC)
+     | 1683826581272 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581272 Preamble is [198] bytes long
+     | 1683826581272 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581272 Still writing preamble
+     | 1683826581272 Wrote [198] bytes to the client
+     | 1683826581272 (W)
+     | 1683826581272 Writing back bytes
+     | 1683826581272 Wrote [16392] bytes to the client
+     | 1683826581272 (W)
+     | 1683826581272 Writing back bytes
+     | 1683826581272 Wrote [8186] bytes to the client
+     | 1683826581272 (W)
+     | 1683826581272 Writing back bytes
+     | 1683826581272 Wrote [5] bytes to the client
+     | 1683826581272 (W)
+     | 1683826581272 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581272 (WKA)
+     | 1683826581272 Read [336] bytes from client
+     | 1683826581272 (R)
+     | 1683826581272 (RP)
+     | 1683826581273 Preamble successfully parsed
+     | 1683826581273 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581273 (RWo)
+     | 1683826581273 (RC)
+     | 1683826581273 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581273 Preamble is [198] bytes long
+     | 1683826581273 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581273 Still writing preamble
+     | 1683826581273 Wrote [198] bytes to the client
+     | 1683826581273 (W)
+     | 1683826581273 Writing back bytes
+     | 1683826581273 Wrote [16392] bytes to the client
+     | 1683826581273 (W)
+     | 1683826581273 Writing back bytes
+     | 1683826581273 Wrote [8285] bytes to the client
+     | 1683826581273 (W)
+     | 1683826581273 Writing back bytes
+     | 1683826581273 Wrote [5] bytes to the client
+     | 1683826581273 (W)
+     | 1683826581273 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581273 (WKA)
+     | 1683826581274 Read [336] bytes from client
+     | 1683826581274 (R)
+     | 1683826581274 (RP)
+     | 1683826581274 Preamble successfully parsed
+     | 1683826581274 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581274 (RWo)
+     | 1683826581274 (RC)
+     | 1683826581275 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581275 Preamble is [198] bytes long
+     | 1683826581275 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581275 Still writing preamble
+     | 1683826581275 Wrote [198] bytes to the client
+     | 1683826581275 (W)
+     | 1683826581275 Writing back bytes
+     | 1683826581275 Wrote [16392] bytes to the client
+     | 1683826581275 (W)
+     | 1683826581275 Writing back bytes
+     | 1683826581275 Wrote [8384] bytes to the client
+     | 1683826581275 (W)
+     | 1683826581275 Writing back bytes
+     | 1683826581275 Wrote [5] bytes to the client
+     | 1683826581275 (W)
+     | 1683826581275 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581275 (WKA)
+     | 1683826581275 Read [336] bytes from client
+     | 1683826581275 (R)
+     | 1683826581275 (RP)
+     | 1683826581275 Preamble successfully parsed
+     | 1683826581275 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581275 (RWo)
+     | 1683826581275 (RC)
+     | 1683826581276 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581276 Preamble is [198] bytes long
+     | 1683826581276 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581276 Still writing preamble
+     | 1683826581276 Wrote [198] bytes to the client
+     | 1683826581276 (W)
+     | 1683826581276 Writing back bytes
+     | 1683826581276 Wrote [16392] bytes to the client
+     | 1683826581276 (W)
+     | 1683826581276 Writing back bytes
+     | 1683826581276 Wrote [8483] bytes to the client
+     | 1683826581276 (W)
+     | 1683826581276 Writing back bytes
+     | 1683826581276 Wrote [5] bytes to the client
+     | 1683826581276 (W)
+     | 1683826581276 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581276 (WKA)
+     | 1683826581277 Read [336] bytes from client
+     | 1683826581277 (R)
+     | 1683826581277 (RP)
+     | 1683826581277 Preamble successfully parsed
+     | 1683826581277 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581277 (RWo)
+     | 1683826581277 (RC)
+     | 1683826581277 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581277 Preamble is [198] bytes long
+     | 1683826581277 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581277 Still writing preamble
+     | 1683826581277 Wrote [198] bytes to the client
+     | 1683826581277 (W)
+     | 1683826581277 Writing back bytes
+     | 1683826581277 Wrote [16392] bytes to the client
+     | 1683826581277 (W)
+     | 1683826581277 Writing back bytes
+     | 1683826581277 Wrote [8582] bytes to the client
+     | 1683826581277 (W)
+     | 1683826581277 Writing back bytes
+     | 1683826581277 Wrote [5] bytes to the client
+     | 1683826581277 (W)
+     | 1683826581277 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581277 (WKA)
+     | 1683826581278 Read [336] bytes from client
+     | 1683826581278 (R)
+     | 1683826581278 (RP)
+     | 1683826581278 Preamble successfully parsed
+     | 1683826581278 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581278 (RWo)
+     | 1683826581278 (RC)
+     | 1683826581279 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581279 Preamble is [198] bytes long
+     | 1683826581279 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581279 Still writing preamble
+     | 1683826581279 Wrote [198] bytes to the client
+     | 1683826581279 (W)
+     | 1683826581279 Writing back bytes
+     | 1683826581279 Wrote [16392] bytes to the client
+     | 1683826581279 (W)
+     | 1683826581279 Writing back bytes
+     | 1683826581279 Wrote [8681] bytes to the client
+     | 1683826581279 (W)
+     | 1683826581279 Writing back bytes
+     | 1683826581279 Wrote [5] bytes to the client
+     | 1683826581279 (W)
+     | 1683826581279 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581279 (WKA)
+     | 1683826581279 Read [336] bytes from client
+     | 1683826581279 (R)
+     | 1683826581279 (RP)
+     | 1683826581279 Preamble successfully parsed
+     | 1683826581279 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581279 (RWo)
+     | 1683826581279 (RC)
+     | 1683826581280 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581280 Preamble is [198] bytes long
+     | 1683826581280 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581280 Still writing preamble
+     | 1683826581280 Wrote [198] bytes to the client
+     | 1683826581280 (W)
+     | 1683826581280 Writing back bytes
+     | 1683826581280 Wrote [16392] bytes to the client
+     | 1683826581280 (W)
+     | 1683826581280 Writing back bytes
+     | 1683826581280 Wrote [8780] bytes to the client
+     | 1683826581280 (W)
+     | 1683826581280 Writing back bytes
+     | 1683826581280 Wrote [5] bytes to the client
+     | 1683826581280 (W)
+     | 1683826581280 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581280 (WKA)
+     | 1683826581280 Read [336] bytes from client
+     | 1683826581280 (R)
+     | 1683826581280 (RP)
+     | 1683826581280 Preamble successfully parsed
+     | 1683826581280 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581280 (RWo)
+     | 1683826581280 (RC)
+     | 1683826581281 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581281 Preamble is [198] bytes long
+     | 1683826581281 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581281 Still writing preamble
+     | 1683826581281 Wrote [198] bytes to the client
+     | 1683826581281 (W)
+     | 1683826581281 Writing back bytes
+     | 1683826581281 Wrote [16392] bytes to the client
+     | 1683826581281 (W)
+     | 1683826581281 Writing back bytes
+     | 1683826581281 Wrote [8879] bytes to the client
+     | 1683826581281 (W)
+     | 1683826581281 Writing back bytes
+     | 1683826581281 Wrote [5] bytes to the client
+     | 1683826581281 (W)
+     | 1683826581281 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581281 (WKA)
+     | 1683826581281 Read [336] bytes from client
+     | 1683826581281 (R)
+     | 1683826581281 (RP)
+     | 1683826581281 Preamble successfully parsed
+     | 1683826581281 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581281 (RWo)
+     | 1683826581281 (RC)
+     | 1683826581282 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581282 Preamble is [198] bytes long
+     | 1683826581282 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581282 Still writing preamble
+     | 1683826581282 Wrote [198] bytes to the client
+     | 1683826581282 (W)
+     | 1683826581282 Writing back bytes
+     | 1683826581282 Wrote [16392] bytes to the client
+     | 1683826581282 (W)
+     | 1683826581282 Writing back bytes
+     | 1683826581282 Wrote [8978] bytes to the client
+     | 1683826581282 (W)
+     | 1683826581282 Writing back bytes
+     | 1683826581282 Wrote [5] bytes to the client
+     | 1683826581282 (W)
+     | 1683826581282 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581282 (WKA)
+     | 1683826581283 Read [336] bytes from client
+     | 1683826581283 (R)
+     | 1683826581283 (RP)
+     | 1683826581283 Preamble successfully parsed
+     | 1683826581283 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581283 (RWo)
+     | 1683826581283 (RC)
+     | 1683826581284 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581284 Preamble is [198] bytes long
+     | 1683826581284 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581284 Still writing preamble
+     | 1683826581284 Wrote [198] bytes to the client
+     | 1683826581284 (W)
+     | 1683826581284 Writing back bytes
+     | 1683826581284 Wrote [16392] bytes to the client
+     | 1683826581284 (W)
+     | 1683826581284 Writing back bytes
+     | 1683826581284 Wrote [9077] bytes to the client
+     | 1683826581284 (W)
+     | 1683826581284 Writing back bytes
+     | 1683826581284 Wrote [5] bytes to the client
+     | 1683826581284 (W)
+     | 1683826581284 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581284 (WKA)
+     | 1683826581284 Read [336] bytes from client
+     | 1683826581284 (R)
+     | 1683826581284 (RP)
+     | 1683826581284 Preamble successfully parsed
+     | 1683826581284 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581284 (RWo)
+     | 1683826581284 (RC)
+     | 1683826581285 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581285 Preamble is [198] bytes long
+     | 1683826581285 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581285 Still writing preamble
+     | 1683826581285 Wrote [198] bytes to the client
+     | 1683826581285 (W)
+     | 1683826581285 Writing back bytes
+     | 1683826581285 Wrote [16392] bytes to the client
+     | 1683826581285 (W)
+     | 1683826581285 Writing back bytes
+     | 1683826581285 Wrote [9176] bytes to the client
+     | 1683826581285 (W)
+     | 1683826581285 Writing back bytes
+     | 1683826581285 Wrote [5] bytes to the client
+     | 1683826581285 (W)
+     | 1683826581285 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581285 (WKA)
+     | 1683826581285 Read [336] bytes from client
+     | 1683826581285 (R)
+     | 1683826581285 (RP)
+     | 1683826581285 Preamble successfully parsed
+     | 1683826581285 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581285 (RWo)
+     | 1683826581285 (RC)
+     | 1683826581286 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581286 Preamble is [198] bytes long
+     | 1683826581286 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581286 Still writing preamble
+     | 1683826581286 Wrote [198] bytes to the client
+     | 1683826581286 (W)
+     | 1683826581286 Writing back bytes
+     | 1683826581286 Wrote [16392] bytes to the client
+     | 1683826581286 (W)
+     | 1683826581286 Writing back bytes
+     | 1683826581286 Wrote [9275] bytes to the client
+     | 1683826581286 (W)
+     | 1683826581286 Writing back bytes
+     | 1683826581286 Wrote [5] bytes to the client
+     | 1683826581286 (W)
+     | 1683826581286 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581286 (WKA)
+     | 1683826581287 Read [336] bytes from client
+     | 1683826581287 (R)
+     | 1683826581287 (RP)
+     | 1683826581287 Preamble successfully parsed
+     | 1683826581287 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581287 (RWo)
+     | 1683826581287 (RC)
+     | 1683826581287 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581287 Preamble is [198] bytes long
+     | 1683826581287 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581287 Still writing preamble
+     | 1683826581287 Wrote [198] bytes to the client
+     | 1683826581287 (W)
+     | 1683826581287 Writing back bytes
+     | 1683826581287 Wrote [16392] bytes to the client
+     | 1683826581287 (W)
+     | 1683826581287 Writing back bytes
+     | 1683826581287 Wrote [9374] bytes to the client
+     | 1683826581287 (W)
+     | 1683826581287 Writing back bytes
+     | 1683826581287 Wrote [5] bytes to the client
+     | 1683826581287 (W)
+     | 1683826581287 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581287 (WKA)
+     | 1683826581288 Read [336] bytes from client
+     | 1683826581288 (R)
+     | 1683826581288 (RP)
+     | 1683826581288 Preamble successfully parsed
+     | 1683826581288 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581288 (RWo)
+     | 1683826581288 (RC)
+     | 1683826581289 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581289 Preamble is [198] bytes long
+     | 1683826581289 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581289 Still writing preamble
+     | 1683826581289 Wrote [198] bytes to the client
+     | 1683826581289 (W)
+     | 1683826581289 Writing back bytes
+     | 1683826581289 Wrote [16392] bytes to the client
+     | 1683826581289 (W)
+     | 1683826581289 Writing back bytes
+     | 1683826581289 Wrote [9473] bytes to the client
+     | 1683826581289 (W)
+     | 1683826581289 Writing back bytes
+     | 1683826581289 Wrote [5] bytes to the client
+     | 1683826581289 (W)
+     | 1683826581289 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581289 (WKA)
+     | 1683826581289 Read [336] bytes from client
+     | 1683826581289 (R)
+     | 1683826581289 (RP)
+     | 1683826581289 Preamble successfully parsed
+     | 1683826581289 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581289 (RWo)
+     | 1683826581289 (RC)
+     | 1683826581290 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581290 Preamble is [198] bytes long
+     | 1683826581290 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581290 Still writing preamble
+     | 1683826581290 Wrote [198] bytes to the client
+     | 1683826581290 (W)
+     | 1683826581290 Writing back bytes
+     | 1683826581290 Wrote [16392] bytes to the client
+     | 1683826581290 (W)
+     | 1683826581290 Writing back bytes
+     | 1683826581290 Wrote [9572] bytes to the client
+     | 1683826581290 (W)
+     | 1683826581290 Writing back bytes
+     | 1683826581290 Wrote [5] bytes to the client
+     | 1683826581290 (W)
+     | 1683826581290 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581290 (WKA)
+     | 1683826581290 Read [336] bytes from client
+     | 1683826581290 (R)
+     | 1683826581290 (RP)
+     | 1683826581290 Preamble successfully parsed
+     | 1683826581290 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581290 (RWo)
+     | 1683826581290 (RC)
+     | 1683826581291 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581291 Preamble is [198] bytes long
+     | 1683826581291 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581291 Still writing preamble
+     | 1683826581291 Wrote [198] bytes to the client
+     | 1683826581291 (W)
+     | 1683826581291 Writing back bytes
+     | 1683826581291 Wrote [16392] bytes to the client
+     | 1683826581291 (W)
+     | 1683826581291 Writing back bytes
+     | 1683826581291 Wrote [9671] bytes to the client
+     | 1683826581291 (W)
+     | 1683826581291 Writing back bytes
+     | 1683826581291 Wrote [5] bytes to the client
+     | 1683826581291 (W)
+     | 1683826581291 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581291 (WKA)
+     | 1683826581291 Read [336] bytes from client
+     | 1683826581291 (R)
+     | 1683826581291 (RP)
+     | 1683826581291 Preamble successfully parsed
+     | 1683826581291 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581291 (RWo)
+     | 1683826581291 (RC)
+     | 1683826581292 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581292 Preamble is [198] bytes long
+     | 1683826581292 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581292 Still writing preamble
+     | 1683826581292 Wrote [198] bytes to the client
+     | 1683826581292 (W)
+     | 1683826581292 Writing back bytes
+     | 1683826581292 Wrote [16392] bytes to the client
+     | 1683826581292 (W)
+     | 1683826581292 Writing back bytes
+     | 1683826581292 Wrote [9770] bytes to the client
+     | 1683826581292 (W)
+     | 1683826581292 Writing back bytes
+     | 1683826581292 Wrote [5] bytes to the client
+     | 1683826581292 (W)
+     | 1683826581292 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581292 (WKA)
+     | 1683826581293 Read [336] bytes from client
+     | 1683826581293 (R)
+     | 1683826581293 (RP)
+     | 1683826581293 Preamble successfully parsed
+     | 1683826581293 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581293 (RWo)
+     | 1683826581293 (RC)
+     | 1683826581294 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581294 Preamble is [198] bytes long
+     | 1683826581294 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581294 Still writing preamble
+     | 1683826581294 Wrote [198] bytes to the client
+     | 1683826581294 (W)
+     | 1683826581294 Writing back bytes
+     | 1683826581294 Wrote [16392] bytes to the client
+     | 1683826581294 (W)
+     | 1683826581294 Writing back bytes
+     | 1683826581294 Wrote [9869] bytes to the client
+     | 1683826581294 (W)
+     | 1683826581294 Writing back bytes
+     | 1683826581294 Wrote [5] bytes to the client
+     | 1683826581294 (W)
+     | 1683826581294 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581294 (WKA)
+     | 1683826581294 Read [336] bytes from client
+     | 1683826581294 (R)
+     | 1683826581294 (RP)
+     | 1683826581294 Preamble successfully parsed
+     | 1683826581294 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581294 (RWo)
+     | 1683826581294 (RC)
+     | 1683826581295 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581295 Preamble is [198] bytes long
+     | 1683826581295 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581295 Still writing preamble
+     | 1683826581295 Wrote [198] bytes to the client
+     | 1683826581295 (W)
+     | 1683826581295 Writing back bytes
+     | 1683826581295 Wrote [16392] bytes to the client
+     | 1683826581295 (W)
+     | 1683826581295 Writing back bytes
+     | 1683826581295 Wrote [9968] bytes to the client
+     | 1683826581295 (W)
+     | 1683826581295 Writing back bytes
+     | 1683826581295 Wrote [5] bytes to the client
+     | 1683826581295 (W)
+     | 1683826581295 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581295 (WKA)
+     | 1683826581295 Read [336] bytes from client
+     | 1683826581295 (R)
+     | 1683826581295 (RP)
+     | 1683826581295 Preamble successfully parsed
+     | 1683826581295 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581295 (RWo)
+     | 1683826581295 (RC)
+     | 1683826581296 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581296 Preamble is [198] bytes long
+     | 1683826581296 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581296 Still writing preamble
+     | 1683826581296 Wrote [198] bytes to the client
+     | 1683826581296 (W)
+     | 1683826581296 Writing back bytes
+     | 1683826581296 Wrote [16392] bytes to the client
+     | 1683826581296 (W)
+     | 1683826581296 Writing back bytes
+     | 1683826581296 Wrote [10067] bytes to the client
+     | 1683826581296 (W)
+     | 1683826581296 Writing back bytes
+     | 1683826581296 Wrote [5] bytes to the client
+     | 1683826581296 (W)
+     | 1683826581296 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581296 (WKA)
+     | 1683826581297 Read [336] bytes from client
+     | 1683826581297 (R)
+     | 1683826581297 (RP)
+     | 1683826581297 Preamble successfully parsed
+     | 1683826581297 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581297 (RWo)
+     | 1683826581297 (RC)
+     | 1683826581298 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581298 Preamble is [198] bytes long
+     | 1683826581298 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581298 Still writing preamble
+     | 1683826581298 Wrote [198] bytes to the client
+     | 1683826581298 (W)
+     | 1683826581298 Writing back bytes
+     | 1683826581298 Wrote [16392] bytes to the client
+     | 1683826581298 (W)
+     | 1683826581298 Writing back bytes
+     | 1683826581298 Wrote [10166] bytes to the client
+     | 1683826581298 (W)
+     | 1683826581298 Writing back bytes
+     | 1683826581298 Wrote [5] bytes to the client
+     | 1683826581298 (W)
+     | 1683826581298 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581298 (WKA)
+     | 1683826581298 Read [336] bytes from client
+     | 1683826581298 (R)
+     | 1683826581298 (RP)
+     | 1683826581298 Preamble successfully parsed
+     | 1683826581298 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581298 (RWo)
+     | 1683826581298 (RC)
+     | 1683826581299 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581299 Preamble is [198] bytes long
+     | 1683826581299 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581299 Still writing preamble
+     | 1683826581299 Wrote [198] bytes to the client
+     | 1683826581299 (W)
+     | 1683826581299 Writing back bytes
+     | 1683826581299 Wrote [16392] bytes to the client
+     | 1683826581299 (W)
+     | 1683826581299 Writing back bytes
+     | 1683826581299 Wrote [10265] bytes to the client
+     | 1683826581299 (W)
+     | 1683826581299 Writing back bytes
+     | 1683826581299 Wrote [5] bytes to the client
+     | 1683826581299 (W)
+     | 1683826581299 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581299 (WKA)
+     | 1683826581300 Read [336] bytes from client
+     | 1683826581300 (R)
+     | 1683826581300 (RP)
+     | 1683826581300 Preamble successfully parsed
+     | 1683826581300 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581300 (RWo)
+     | 1683826581300 (RC)
+     | 1683826581301 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581301 Preamble is [198] bytes long
+     | 1683826581301 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581301 Still writing preamble
+     | 1683826581301 Wrote [198] bytes to the client
+     | 1683826581301 (W)
+     | 1683826581301 Writing back bytes
+     | 1683826581301 Wrote [16392] bytes to the client
+     | 1683826581301 (W)
+     | 1683826581301 Writing back bytes
+     | 1683826581301 Wrote [10364] bytes to the client
+     | 1683826581301 (W)
+     | 1683826581301 Writing back bytes
+     | 1683826581301 Wrote [5] bytes to the client
+     | 1683826581301 (W)
+     | 1683826581301 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581301 (WKA)
+     | 1683826581301 Read [336] bytes from client
+     | 1683826581301 (R)
+     | 1683826581301 (RP)
+     | 1683826581301 Preamble successfully parsed
+     | 1683826581301 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581301 (RWo)
+     | 1683826581301 (RC)
+     | 1683826581302 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581302 Preamble is [198] bytes long
+     | 1683826581302 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581302 Still writing preamble
+     | 1683826581302 Wrote [198] bytes to the client
+     | 1683826581302 (W)
+     | 1683826581302 Writing back bytes
+     | 1683826581302 Wrote [16392] bytes to the client
+     | 1683826581302 (W)
+     | 1683826581302 Writing back bytes
+     | 1683826581302 Wrote [10463] bytes to the client
+     | 1683826581302 (W)
+     | 1683826581302 Writing back bytes
+     | 1683826581302 Wrote [5] bytes to the client
+     | 1683826581302 (W)
+     | 1683826581302 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581302 (WKA)
+     | 1683826581302 Read [336] bytes from client
+     | 1683826581302 (R)
+     | 1683826581302 (RP)
+     | 1683826581302 Preamble successfully parsed
+     | 1683826581302 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581302 (RWo)
+     | 1683826581302 (RC)
+     | 1683826581303 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581303 Preamble is [198] bytes long
+     | 1683826581303 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581303 Still writing preamble
+     | 1683826581303 Wrote [198] bytes to the client
+     | 1683826581303 (W)
+     | 1683826581303 Writing back bytes
+     | 1683826581303 Wrote [16392] bytes to the client
+     | 1683826581303 (W)
+     | 1683826581303 Writing back bytes
+     | 1683826581303 Wrote [10562] bytes to the client
+     | 1683826581303 (W)
+     | 1683826581303 Writing back bytes
+     | 1683826581303 Wrote [5] bytes to the client
+     | 1683826581303 (W)
+     | 1683826581303 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581303 (WKA)
+     | 1683826581304 Read [336] bytes from client
+     | 1683826581304 (R)
+     | 1683826581304 (RP)
+     | 1683826581304 Preamble successfully parsed
+     | 1683826581304 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581304 (RWo)
+     | 1683826581304 (RC)
+     | 1683826581305 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581305 Preamble is [198] bytes long
+     | 1683826581305 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581305 Still writing preamble
+     | 1683826581305 Wrote [198] bytes to the client
+     | 1683826581305 (W)
+     | 1683826581305 Writing back bytes
+     | 1683826581305 Wrote [16392] bytes to the client
+     | 1683826581305 (W)
+     | 1683826581305 Writing back bytes
+     | 1683826581305 Wrote [10661] bytes to the client
+     | 1683826581305 (W)
+     | 1683826581305 Writing back bytes
+     | 1683826581305 Wrote [5] bytes to the client
+     | 1683826581305 (W)
+     | 1683826581305 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581305 (WKA)
+     | 1683826581305 Read [336] bytes from client
+     | 1683826581305 (R)
+     | 1683826581305 (RP)
+     | 1683826581305 Preamble successfully parsed
+     | 1683826581305 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581305 (RWo)
+     | 1683826581305 (RC)
+     | 1683826581306 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581306 Preamble is [198] bytes long
+     | 1683826581306 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581306 Still writing preamble
+     | 1683826581306 Wrote [198] bytes to the client
+     | 1683826581306 (W)
+     | 1683826581306 Writing back bytes
+     | 1683826581306 Wrote [16392] bytes to the client
+     | 1683826581306 (W)
+     | 1683826581306 Writing back bytes
+     | 1683826581306 Wrote [10760] bytes to the client
+     | 1683826581306 (W)
+     | 1683826581306 Writing back bytes
+     | 1683826581306 Wrote [5] bytes to the client
+     | 1683826581306 (W)
+     | 1683826581306 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581306 (WKA)
+     | 1683826581307 Read [336] bytes from client
+     | 1683826581307 (R)
+     | 1683826581307 (RP)
+     | 1683826581307 Preamble successfully parsed
+     | 1683826581307 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581307 (RWo)
+     | 1683826581307 (RC)
+     | 1683826581307 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581307 Preamble is [198] bytes long
+     | 1683826581307 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581307 Still writing preamble
+     | 1683826581307 Wrote [198] bytes to the client
+     | 1683826581307 (W)
+     | 1683826581307 Writing back bytes
+     | 1683826581307 Wrote [16392] bytes to the client
+     | 1683826581307 (W)
+     | 1683826581307 Writing back bytes
+     | 1683826581307 Wrote [10859] bytes to the client
+     | 1683826581307 (W)
+     | 1683826581307 Writing back bytes
+     | 1683826581307 Wrote [5] bytes to the client
+     | 1683826581307 (W)
+     | 1683826581307 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581307 (WKA)
+     | 1683826581308 Read [336] bytes from client
+     | 1683826581308 (R)
+     | 1683826581308 (RP)
+     | 1683826581308 Preamble successfully parsed
+     | 1683826581308 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581308 (RWo)
+     | 1683826581308 (RC)
+     | 1683826581309 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581309 Preamble is [198] bytes long
+     | 1683826581309 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581309 Still writing preamble
+     | 1683826581309 Wrote [198] bytes to the client
+     | 1683826581309 (W)
+     | 1683826581309 Writing back bytes
+     | 1683826581309 Wrote [16392] bytes to the client
+     | 1683826581309 (W)
+     | 1683826581309 Writing back bytes
+     | 1683826581309 Wrote [10958] bytes to the client
+     | 1683826581309 (W)
+     | 1683826581309 Writing back bytes
+     | 1683826581309 Wrote [5] bytes to the client
+     | 1683826581309 (W)
+     | 1683826581309 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581309 (WKA)
+     | 1683826581309 Read [336] bytes from client
+     | 1683826581309 (R)
+     | 1683826581309 (RP)
+     | 1683826581309 Preamble successfully parsed
+     | 1683826581309 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581309 (RWo)
+     | 1683826581309 (RC)
+     | 1683826581310 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581310 Preamble is [198] bytes long
+     | 1683826581310 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581310 Still writing preamble
+     | 1683826581310 Wrote [198] bytes to the client
+     | 1683826581310 (W)
+     | 1683826581310 Writing back bytes
+     | 1683826581310 Wrote [16392] bytes to the client
+     | 1683826581310 (W)
+     | 1683826581310 Writing back bytes
+     | 1683826581310 Wrote [11057] bytes to the client
+     | 1683826581310 (W)
+     | 1683826581310 Writing back bytes
+     | 1683826581310 Wrote [5] bytes to the client
+     | 1683826581310 (W)
+     | 1683826581310 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581310 (WKA)
+     | 1683826581310 Read [336] bytes from client
+     | 1683826581310 (R)
+     | 1683826581310 (RP)
+     | 1683826581311 Preamble successfully parsed
+     | 1683826581311 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581311 (RWo)
+     | 1683826581311 (RC)
+     | 1683826581311 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581311 Preamble is [198] bytes long
+     | 1683826581311 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581311 Still writing preamble
+     | 1683826581311 Wrote [198] bytes to the client
+     | 1683826581311 (W)
+     | 1683826581311 Writing back bytes
+     | 1683826581311 Wrote [16392] bytes to the client
+     | 1683826581311 (W)
+     | 1683826581311 Writing back bytes
+     | 1683826581311 Wrote [11156] bytes to the client
+     | 1683826581311 (W)
+     | 1683826581311 Writing back bytes
+     | 1683826581311 Wrote [5] bytes to the client
+     | 1683826581311 (W)
+     | 1683826581311 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581311 (WKA)
+     | 1683826581312 Read [336] bytes from client
+     | 1683826581312 (R)
+     | 1683826581312 (RP)
+     | 1683826581312 Preamble successfully parsed
+     | 1683826581312 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581312 (RWo)
+     | 1683826581312 (RC)
+     | 1683826581312 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581313 Preamble is [198] bytes long
+     | 1683826581313 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581313 Still writing preamble
+     | 1683826581313 Wrote [198] bytes to the client
+     | 1683826581313 (W)
+     | 1683826581313 Writing back bytes
+     | 1683826581313 Wrote [16392] bytes to the client
+     | 1683826581313 (W)
+     | 1683826581313 Writing back bytes
+     | 1683826581313 Wrote [11255] bytes to the client
+     | 1683826581313 (W)
+     | 1683826581313 Writing back bytes
+     | 1683826581313 Wrote [5] bytes to the client
+     | 1683826581313 (W)
+     | 1683826581313 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581313 (WKA)
+     | 1683826581313 Read [336] bytes from client
+     | 1683826581313 (R)
+     | 1683826581313 (RP)
+     | 1683826581313 Preamble successfully parsed
+     | 1683826581313 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581313 (RWo)
+     | 1683826581313 (RC)
+     | 1683826581314 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581314 Preamble is [198] bytes long
+     | 1683826581314 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581314 Still writing preamble
+     | 1683826581314 Wrote [198] bytes to the client
+     | 1683826581314 (W)
+     | 1683826581314 Writing back bytes
+     | 1683826581314 Wrote [16392] bytes to the client
+     | 1683826581314 (W)
+     | 1683826581314 Writing back bytes
+     | 1683826581314 Wrote [11354] bytes to the client
+     | 1683826581314 (W)
+     | 1683826581314 Writing back bytes
+     | 1683826581314 Wrote [5] bytes to the client
+     | 1683826581314 (W)
+     | 1683826581314 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581314 (WKA)
+     | 1683826581314 Read [336] bytes from client
+     | 1683826581314 (R)
+     | 1683826581314 (RP)
+     | 1683826581314 Preamble successfully parsed
+     | 1683826581314 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581314 (RWo)
+     | 1683826581314 (RC)
+     | 1683826581315 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581315 Preamble is [198] bytes long
+     | 1683826581315 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581315 Still writing preamble
+     | 1683826581315 Wrote [198] bytes to the client
+     | 1683826581315 (W)
+     | 1683826581315 Writing back bytes
+     | 1683826581315 Wrote [16392] bytes to the client
+     | 1683826581315 (W)
+     | 1683826581315 Writing back bytes
+     | 1683826581315 Wrote [11453] bytes to the client
+     | 1683826581315 (W)
+     | 1683826581315 Writing back bytes
+     | 1683826581315 Wrote [5] bytes to the client
+     | 1683826581315 (W)
+     | 1683826581315 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581315 (WKA)
+     | 1683826581315 Read [336] bytes from client
+     | 1683826581315 (R)
+     | 1683826581315 (RP)
+     | 1683826581316 Preamble successfully parsed
+     | 1683826581316 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581316 (RWo)
+     | 1683826581316 (RC)
+     | 1683826581316 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581316 Preamble is [198] bytes long
+     | 1683826581316 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581316 Still writing preamble
+     | 1683826581317 Wrote [198] bytes to the client
+     | 1683826581317 (W)
+     | 1683826581317 Writing back bytes
+     | 1683826581317 Wrote [16392] bytes to the client
+     | 1683826581317 (W)
+     | 1683826581317 Writing back bytes
+     | 1683826581317 Wrote [11552] bytes to the client
+     | 1683826581317 (W)
+     | 1683826581317 Writing back bytes
+     | 1683826581317 Wrote [5] bytes to the client
+     | 1683826581317 (W)
+     | 1683826581317 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581317 (WKA)
+     | 1683826581317 Read [336] bytes from client
+     | 1683826581317 (R)
+     | 1683826581317 (RP)
+     | 1683826581317 Preamble successfully parsed
+     | 1683826581317 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581317 (RWo)
+     | 1683826581317 (RC)
+     | 1683826581318 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581318 Preamble is [198] bytes long
+     | 1683826581318 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581318 Still writing preamble
+     | 1683826581318 Wrote [198] bytes to the client
+     | 1683826581318 (W)
+     | 1683826581318 Writing back bytes
+     | 1683826581318 Wrote [16392] bytes to the client
+     | 1683826581318 (W)
+     | 1683826581318 Writing back bytes
+     | 1683826581318 Wrote [11651] bytes to the client
+     | 1683826581318 (W)
+     | 1683826581318 Writing back bytes
+     | 1683826581318 Wrote [5] bytes to the client
+     | 1683826581318 (W)
+     | 1683826581318 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581318 (WKA)
+     | 1683826581318 Read [336] bytes from client
+     | 1683826581318 (R)
+     | 1683826581318 (RP)
+     | 1683826581318 Preamble successfully parsed
+     | 1683826581318 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581318 (RWo)
+     | 1683826581318 (RC)
+     | 1683826581319 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581319 Preamble is [198] bytes long
+     | 1683826581319 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581319 Still writing preamble
+     | 1683826581319 Wrote [198] bytes to the client
+     | 1683826581319 (W)
+     | 1683826581319 Writing back bytes
+     | 1683826581319 Wrote [16392] bytes to the client
+     | 1683826581319 (W)
+     | 1683826581319 Writing back bytes
+     | 1683826581319 Wrote [11750] bytes to the client
+     | 1683826581319 (W)
+     | 1683826581319 Writing back bytes
+     | 1683826581319 Wrote [5] bytes to the client
+     | 1683826581319 (W)
+     | 1683826581319 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581319 (WKA)
+     | 1683826581319 Read [336] bytes from client
+     | 1683826581319 (R)
+     | 1683826581319 (RP)
+     | 1683826581319 Preamble successfully parsed
+     | 1683826581319 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581319 (RWo)
+     | 1683826581319 (RC)
+     | 1683826581320 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581320 Preamble is [198] bytes long
+     | 1683826581320 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581320 Still writing preamble
+     | 1683826581320 Wrote [198] bytes to the client
+     | 1683826581320 (W)
+     | 1683826581320 Writing back bytes
+     | 1683826581320 Wrote [16392] bytes to the client
+     | 1683826581320 (W)
+     | 1683826581320 Writing back bytes
+     | 1683826581320 Wrote [11849] bytes to the client
+     | 1683826581320 (W)
+     | 1683826581320 Writing back bytes
+     | 1683826581320 Wrote [5] bytes to the client
+     | 1683826581320 (W)
+     | 1683826581320 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581320 (WKA)
+     | 1683826581321 Read [336] bytes from client
+     | 1683826581321 (R)
+     | 1683826581321 (RP)
+     | 1683826581321 Preamble successfully parsed
+     | 1683826581321 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581321 (RWo)
+     | 1683826581321 (RC)
+     | 1683826581322 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581322 Preamble is [198] bytes long
+     | 1683826581322 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581322 Still writing preamble
+     | 1683826581322 Wrote [198] bytes to the client
+     | 1683826581322 (W)
+     | 1683826581322 Writing back bytes
+     | 1683826581322 Wrote [16392] bytes to the client
+     | 1683826581322 (W)
+     | 1683826581322 Writing back bytes
+     | 1683826581322 Wrote [11948] bytes to the client
+     | 1683826581322 (W)
+     | 1683826581322 Writing back bytes
+     | 1683826581322 Wrote [5] bytes to the client
+     | 1683826581322 (W)
+     | 1683826581322 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581322 (WKA)
+     | 1683826581322 Read [336] bytes from client
+     | 1683826581322 (R)
+     | 1683826581322 (RP)
+     | 1683826581322 Preamble successfully parsed
+     | 1683826581322 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581322 (RWo)
+     | 1683826581322 (RC)
+     | 1683826581323 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581323 Preamble is [198] bytes long
+     | 1683826581323 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581323 Still writing preamble
+     | 1683826581323 Wrote [198] bytes to the client
+     | 1683826581323 (W)
+     | 1683826581323 Writing back bytes
+     | 1683826581323 Wrote [16392] bytes to the client
+     | 1683826581323 (W)
+     | 1683826581323 Writing back bytes
+     | 1683826581323 Wrote [12047] bytes to the client
+     | 1683826581323 (W)
+     | 1683826581323 Writing back bytes
+     | 1683826581323 Wrote [5] bytes to the client
+     | 1683826581323 (W)
+     | 1683826581323 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581323 (WKA)
+     | 1683826581323 Read [336] bytes from client
+     | 1683826581323 (R)
+     | 1683826581323 (RP)
+     | 1683826581324 Preamble successfully parsed
+     | 1683826581324 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581324 (RWo)
+     | 1683826581324 (RC)
+     | 1683826581324 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581324 Preamble is [198] bytes long
+     | 1683826581324 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581324 Still writing preamble
+     | 1683826581324 Wrote [198] bytes to the client
+     | 1683826581324 (W)
+     | 1683826581324 Writing back bytes
+     | 1683826581324 Wrote [16392] bytes to the client
+     | 1683826581324 (W)
+     | 1683826581324 Writing back bytes
+     | 1683826581324 Wrote [12146] bytes to the client
+     | 1683826581324 (W)
+     | 1683826581324 Writing back bytes
+     | 1683826581324 Wrote [5] bytes to the client
+     | 1683826581324 (W)
+     | 1683826581324 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581324 (WKA)
+     | 1683826581325 Read [336] bytes from client
+     | 1683826581325 (R)
+     | 1683826581325 (RP)
+     | 1683826581325 Preamble successfully parsed
+     | 1683826581325 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581325 (RWo)
+     | 1683826581325 (RC)
+     | 1683826581325 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581325 Preamble is [198] bytes long
+     | 1683826581325 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581325 Still writing preamble
+     | 1683826581325 Wrote [198] bytes to the client
+     | 1683826581325 (W)
+     | 1683826581325 Writing back bytes
+     | 1683826581325 Wrote [16392] bytes to the client
+     | 1683826581325 (W)
+     | 1683826581325 Writing back bytes
+     | 1683826581325 Wrote [12245] bytes to the client
+     | 1683826581325 (W)
+     | 1683826581325 Writing back bytes
+     | 1683826581325 Wrote [5] bytes to the client
+     | 1683826581325 (W)
+     | 1683826581325 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581325 (WKA)
+     | 1683826581326 Read [336] bytes from client
+     | 1683826581326 (R)
+     | 1683826581326 (RP)
+     | 1683826581326 Preamble successfully parsed
+     | 1683826581326 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581326 (RWo)
+     | 1683826581326 (RC)
+     | 1683826581326 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581326 Preamble is [198] bytes long
+     | 1683826581326 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581326 Still writing preamble
+     | 1683826581326 Wrote [198] bytes to the client
+     | 1683826581326 (W)
+     | 1683826581326 Writing back bytes
+     | 1683826581326 Wrote [16392] bytes to the client
+     | 1683826581326 (W)
+     | 1683826581326 Writing back bytes
+     | 1683826581326 Wrote [12344] bytes to the client
+     | 1683826581326 (W)
+     | 1683826581326 Writing back bytes
+     | 1683826581326 Wrote [5] bytes to the client
+     | 1683826581326 (W)
+     | 1683826581326 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581326 (WKA)
+     | 1683826581327 Read [336] bytes from client
+     | 1683826581327 (R)
+     | 1683826581327 (RP)
+     | 1683826581327 Preamble successfully parsed
+     | 1683826581327 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581327 (RWo)
+     | 1683826581327 (RC)
+     | 1683826581327 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581327 Preamble is [198] bytes long
+     | 1683826581327 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581327 Still writing preamble
+     | 1683826581327 Wrote [198] bytes to the client
+     | 1683826581327 (W)
+     | 1683826581327 Writing back bytes
+     | 1683826581327 Wrote [16392] bytes to the client
+     | 1683826581327 (W)
+     | 1683826581327 Writing back bytes
+     | 1683826581327 Wrote [12443] bytes to the client
+     | 1683826581327 (W)
+     | 1683826581327 Writing back bytes
+     | 1683826581327 Wrote [5] bytes to the client
+     | 1683826581327 (W)
+     | 1683826581327 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581327 (WKA)
+     | 1683826581328 Read [336] bytes from client
+     | 1683826581328 (R)
+     | 1683826581328 (RP)
+     | 1683826581328 Preamble successfully parsed
+     | 1683826581328 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581328 (RWo)
+     | 1683826581328 (RC)
+     | 1683826581329 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581329 Preamble is [198] bytes long
+     | 1683826581329 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581329 Still writing preamble
+     | 1683826581329 Wrote [198] bytes to the client
+     | 1683826581329 (W)
+     | 1683826581329 Writing back bytes
+     | 1683826581329 Wrote [16392] bytes to the client
+     | 1683826581329 (W)
+     | 1683826581329 Writing back bytes
+     | 1683826581329 Wrote [12542] bytes to the client
+     | 1683826581329 (W)
+     | 1683826581329 Writing back bytes
+     | 1683826581329 Wrote [5] bytes to the client
+     | 1683826581329 (W)
+     | 1683826581329 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581329 (WKA)
+     | 1683826581329 Read [336] bytes from client
+     | 1683826581329 (R)
+     | 1683826581329 (RP)
+     | 1683826581329 Preamble successfully parsed
+     | 1683826581329 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581329 (RWo)
+     | 1683826581329 (RC)
+     | 1683826581330 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581330 Preamble is [198] bytes long
+     | 1683826581330 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581330 Still writing preamble
+     | 1683826581330 Wrote [198] bytes to the client
+     | 1683826581330 (W)
+     | 1683826581330 Writing back bytes
+     | 1683826581330 Wrote [16392] bytes to the client
+     | 1683826581330 (W)
+     | 1683826581330 Writing back bytes
+     | 1683826581330 Wrote [12641] bytes to the client
+     | 1683826581330 (W)
+     | 1683826581330 Writing back bytes
+     | 1683826581330 Wrote [5] bytes to the client
+     | 1683826581330 (W)
+     | 1683826581330 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581330 (WKA)
+     | 1683826581330 Read [336] bytes from client
+     | 1683826581330 (R)
+     | 1683826581330 (RP)
+     | 1683826581330 Preamble successfully parsed
+     | 1683826581330 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581330 (RWo)
+     | 1683826581330 (RC)
+     | 1683826581331 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581331 Preamble is [198] bytes long
+     | 1683826581331 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581331 Still writing preamble
+     | 1683826581331 Wrote [198] bytes to the client
+     | 1683826581331 (W)
+     | 1683826581331 Writing back bytes
+     | 1683826581331 Wrote [16392] bytes to the client
+     | 1683826581331 (W)
+     | 1683826581331 Writing back bytes
+     | 1683826581331 Wrote [12740] bytes to the client
+     | 1683826581331 (W)
+     | 1683826581331 Writing back bytes
+     | 1683826581331 Wrote [5] bytes to the client
+     | 1683826581331 (W)
+     | 1683826581331 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581331 (WKA)
+     | 1683826581331 Read [336] bytes from client
+     | 1683826581331 (R)
+     | 1683826581331 (RP)
+     | 1683826581331 Preamble successfully parsed
+     | 1683826581331 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581331 (RWo)
+     | 1683826581331 (RC)
+     | 1683826581332 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581332 Preamble is [198] bytes long
+     | 1683826581332 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581332 Still writing preamble
+     | 1683826581332 Wrote [198] bytes to the client
+     | 1683826581332 (W)
+     | 1683826581332 Writing back bytes
+     | 1683826581332 Wrote [16392] bytes to the client
+     | 1683826581332 (W)
+     | 1683826581332 Writing back bytes
+     | 1683826581332 Wrote [12839] bytes to the client
+     | 1683826581332 (W)
+     | 1683826581332 Writing back bytes
+     | 1683826581332 Wrote [5] bytes to the client
+     | 1683826581332 (W)
+     | 1683826581332 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581332 (WKA)
+     | 1683826581332 Read [336] bytes from client
+     | 1683826581332 (R)
+     | 1683826581332 (RP)
+     | 1683826581332 Preamble successfully parsed
+     | 1683826581332 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581332 (RWo)
+     | 1683826581332 (RC)
+     | 1683826581333 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581333 Preamble is [198] bytes long
+     | 1683826581333 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581333 Still writing preamble
+     | 1683826581333 Wrote [198] bytes to the client
+     | 1683826581333 (W)
+     | 1683826581333 Writing back bytes
+     | 1683826581333 Wrote [16392] bytes to the client
+     | 1683826581333 (W)
+     | 1683826581333 Writing back bytes
+     | 1683826581333 Wrote [12938] bytes to the client
+     | 1683826581333 (W)
+     | 1683826581333 Writing back bytes
+     | 1683826581333 Wrote [5] bytes to the client
+     | 1683826581333 (W)
+     | 1683826581333 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581333 (WKA)
+     | 1683826581333 Read [336] bytes from client
+     | 1683826581333 (R)
+     | 1683826581333 (RP)
+     | 1683826581333 Preamble successfully parsed
+     | 1683826581333 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581333 (RWo)
+     | 1683826581333 (RC)
+     | 1683826581334 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581334 Preamble is [198] bytes long
+     | 1683826581334 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581334 Still writing preamble
+     | 1683826581334 Wrote [198] bytes to the client
+     | 1683826581334 (W)
+     | 1683826581334 Writing back bytes
+     | 1683826581334 Wrote [16392] bytes to the client
+     | 1683826581334 (W)
+     | 1683826581334 Writing back bytes
+     | 1683826581334 Wrote [13037] bytes to the client
+     | 1683826581334 (W)
+     | 1683826581334 Writing back bytes
+     | 1683826581334 Wrote [5] bytes to the client
+     | 1683826581334 (W)
+     | 1683826581334 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581334 (WKA)
+     | 1683826581334 Read [336] bytes from client
+     | 1683826581334 (R)
+     | 1683826581334 (RP)
+     | 1683826581334 Preamble successfully parsed
+     | 1683826581334 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581334 (RWo)
+     | 1683826581334 (RC)
+     | 1683826581335 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581335 Preamble is [198] bytes long
+     | 1683826581335 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581335 Still writing preamble
+     | 1683826581335 Wrote [198] bytes to the client
+     | 1683826581335 (W)
+     | 1683826581335 Writing back bytes
+     | 1683826581335 Wrote [16392] bytes to the client
+     | 1683826581335 (W)
+     | 1683826581335 Writing back bytes
+     | 1683826581335 Wrote [13136] bytes to the client
+     | 1683826581335 (W)
+     | 1683826581335 Writing back bytes
+     | 1683826581335 Wrote [5] bytes to the client
+     | 1683826581335 (W)
+     | 1683826581335 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581335 (WKA)
+     | 1683826581336 Read [336] bytes from client
+     | 1683826581336 (R)
+     | 1683826581336 (RP)
+     | 1683826581336 Preamble successfully parsed
+     | 1683826581336 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581336 (RWo)
+     | 1683826581336 (RC)
+     | 1683826581337 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581337 Preamble is [198] bytes long
+     | 1683826581337 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581337 Still writing preamble
+     | 1683826581337 Wrote [198] bytes to the client
+     | 1683826581337 (W)
+     | 1683826581337 Writing back bytes
+     | 1683826581337 Wrote [16392] bytes to the client
+     | 1683826581337 (W)
+     | 1683826581337 Writing back bytes
+     | 1683826581337 Wrote [13235] bytes to the client
+     | 1683826581337 (W)
+     | 1683826581337 Writing back bytes
+     | 1683826581337 Wrote [5] bytes to the client
+     | 1683826581337 (W)
+     | 1683826581337 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581337 (WKA)
+     | 1683826581337 Read [336] bytes from client
+     | 1683826581337 (R)
+     | 1683826581337 (RP)
+     | 1683826581337 Preamble successfully parsed
+     | 1683826581337 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581337 (RWo)
+     | 1683826581337 (RC)
+     | 1683826581338 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581338 Preamble is [198] bytes long
+     | 1683826581338 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581338 Still writing preamble
+     | 1683826581338 Wrote [198] bytes to the client
+     | 1683826581338 (W)
+     | 1683826581338 Writing back bytes
+     | 1683826581338 Wrote [16392] bytes to the client
+     | 1683826581338 (W)
+     | 1683826581338 Writing back bytes
+     | 1683826581338 Wrote [13334] bytes to the client
+     | 1683826581338 (W)
+     | 1683826581338 Writing back bytes
+     | 1683826581338 Wrote [5] bytes to the client
+     | 1683826581338 (W)
+     | 1683826581338 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581338 (WKA)
+     | 1683826581338 Read [336] bytes from client
+     | 1683826581338 (R)
+     | 1683826581338 (RP)
+     | 1683826581338 Preamble successfully parsed
+     | 1683826581338 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581338 (RWo)
+     | 1683826581338 (RC)
+     | 1683826581339 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581339 Preamble is [198] bytes long
+     | 1683826581339 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581339 Still writing preamble
+     | 1683826581339 Wrote [198] bytes to the client
+     | 1683826581339 (W)
+     | 1683826581339 Writing back bytes
+     | 1683826581339 Wrote [16392] bytes to the client
+     | 1683826581339 (W)
+     | 1683826581339 Writing back bytes
+     | 1683826581339 Wrote [13433] bytes to the client
+     | 1683826581339 (W)
+     | 1683826581339 Writing back bytes
+     | 1683826581339 Wrote [5] bytes to the client
+     | 1683826581339 (W)
+     | 1683826581339 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581339 (WKA)
+     | 1683826581340 Read [336] bytes from client
+     | 1683826581340 (R)
+     | 1683826581340 (RP)
+     | 1683826581340 Preamble successfully parsed
+     | 1683826581340 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581340 (RWo)
+     | 1683826581340 (RC)
+     | 1683826581340 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581340 Preamble is [198] bytes long
+     | 1683826581340 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581340 Still writing preamble
+     | 1683826581340 Wrote [198] bytes to the client
+     | 1683826581340 (W)
+     | 1683826581340 Writing back bytes
+     | 1683826581340 Wrote [16392] bytes to the client
+     | 1683826581340 (W)
+     | 1683826581340 Writing back bytes
+     | 1683826581340 Wrote [13532] bytes to the client
+     | 1683826581340 (W)
+     | 1683826581340 Writing back bytes
+     | 1683826581340 Wrote [5] bytes to the client
+     | 1683826581340 (W)
+     | 1683826581340 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581340 (WKA)
+     | 1683826581341 Read [336] bytes from client
+     | 1683826581341 (R)
+     | 1683826581341 (RP)
+     | 1683826581341 Preamble successfully parsed
+     | 1683826581341 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581341 (RWo)
+     | 1683826581341 (RC)
+     | 1683826581342 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581342 Preamble is [198] bytes long
+     | 1683826581342 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581342 Still writing preamble
+     | 1683826581342 Wrote [198] bytes to the client
+     | 1683826581342 (W)
+     | 1683826581342 Writing back bytes
+     | 1683826581342 Wrote [16392] bytes to the client
+     | 1683826581342 (W)
+     | 1683826581342 Writing back bytes
+     | 1683826581342 Wrote [13631] bytes to the client
+     | 1683826581342 (W)
+     | 1683826581342 Writing back bytes
+     | 1683826581342 Wrote [5] bytes to the client
+     | 1683826581342 (W)
+     | 1683826581342 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581342 (WKA)
+     | 1683826581342 Read [336] bytes from client
+     | 1683826581342 (R)
+     | 1683826581342 (RP)
+     | 1683826581342 Preamble successfully parsed
+     | 1683826581342 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581342 (RWo)
+     | 1683826581342 (RC)
+     | 1683826581343 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581343 Preamble is [198] bytes long
+     | 1683826581343 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581343 Still writing preamble
+     | 1683826581343 Wrote [198] bytes to the client
+     | 1683826581343 (W)
+     | 1683826581343 Writing back bytes
+     | 1683826581343 Wrote [16392] bytes to the client
+     | 1683826581343 (W)
+     | 1683826581343 Writing back bytes
+     | 1683826581343 Wrote [13730] bytes to the client
+     | 1683826581343 (W)
+     | 1683826581343 Writing back bytes
+     | 1683826581343 Wrote [5] bytes to the client
+     | 1683826581343 (W)
+     | 1683826581343 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581343 (WKA)
+     | 1683826581343 Read [336] bytes from client
+     | 1683826581343 (R)
+     | 1683826581343 (RP)
+     | 1683826581343 Preamble successfully parsed
+     | 1683826581343 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581343 (RWo)
+     | 1683826581343 (RC)
+     | 1683826581344 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581344 Preamble is [198] bytes long
+     | 1683826581344 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581344 Still writing preamble
+     | 1683826581344 Wrote [198] bytes to the client
+     | 1683826581344 (W)
+     | 1683826581344 Writing back bytes
+     | 1683826581344 Wrote [16392] bytes to the client
+     | 1683826581344 (W)
+     | 1683826581344 Writing back bytes
+     | 1683826581344 Wrote [13829] bytes to the client
+     | 1683826581344 (W)
+     | 1683826581344 Writing back bytes
+     | 1683826581344 Wrote [5] bytes to the client
+     | 1683826581344 (W)
+     | 1683826581344 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581344 (WKA)
+     | 1683826581345 Read [336] bytes from client
+     | 1683826581345 (R)
+     | 1683826581345 (RP)
+     | 1683826581345 Preamble successfully parsed
+     | 1683826581345 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581345 (RWo)
+     | 1683826581345 (RC)
+     | 1683826581345 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581345 Preamble is [198] bytes long
+     | 1683826581345 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581345 Still writing preamble
+     | 1683826581346 Wrote [198] bytes to the client
+     | 1683826581346 (W)
+     | 1683826581346 Writing back bytes
+     | 1683826581346 Wrote [16392] bytes to the client
+     | 1683826581346 (W)
+     | 1683826581346 Writing back bytes
+     | 1683826581346 Wrote [13928] bytes to the client
+     | 1683826581346 (W)
+     | 1683826581346 Writing back bytes
+     | 1683826581346 Wrote [5] bytes to the client
+     | 1683826581346 (W)
+     | 1683826581346 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581346 (WKA)
+     | 1683826581346 Read [336] bytes from client
+     | 1683826581346 (R)
+     | 1683826581346 (RP)
+     | 1683826581346 Preamble successfully parsed
+     | 1683826581346 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581346 (RWo)
+     | 1683826581346 (RC)
+     | 1683826581347 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581347 Preamble is [198] bytes long
+     | 1683826581347 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581347 Still writing preamble
+     | 1683826581347 Wrote [198] bytes to the client
+     | 1683826581347 (W)
+     | 1683826581347 Writing back bytes
+     | 1683826581347 Wrote [16392] bytes to the client
+     | 1683826581347 (W)
+     | 1683826581347 Writing back bytes
+     | 1683826581347 Wrote [14027] bytes to the client
+     | 1683826581347 (W)
+     | 1683826581347 Writing back bytes
+     | 1683826581347 Wrote [5] bytes to the client
+     | 1683826581347 (W)
+     | 1683826581347 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581347 (WKA)
+     | 1683826581347 Read [336] bytes from client
+     | 1683826581347 (R)
+     | 1683826581347 (RP)
+     | 1683826581347 Preamble successfully parsed
+     | 1683826581347 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581347 (RWo)
+     | 1683826581347 (RC)
+     | 1683826581348 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581348 Preamble is [198] bytes long
+     | 1683826581348 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581348 Still writing preamble
+     | 1683826581348 Wrote [198] bytes to the client
+     | 1683826581348 (W)
+     | 1683826581348 Writing back bytes
+     | 1683826581348 Wrote [16392] bytes to the client
+     | 1683826581348 (W)
+     | 1683826581348 Writing back bytes
+     | 1683826581348 Wrote [14126] bytes to the client
+     | 1683826581348 (W)
+     | 1683826581348 Writing back bytes
+     | 1683826581348 Wrote [5] bytes to the client
+     | 1683826581348 (W)
+     | 1683826581348 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581348 (WKA)
+     | 1683826581348 Read [336] bytes from client
+     | 1683826581348 (R)
+     | 1683826581348 (RP)
+     | 1683826581349 Preamble successfully parsed
+     | 1683826581349 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581349 (RWo)
+     | 1683826581349 (RC)
+     | 1683826581349 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581349 Preamble is [198] bytes long
+     | 1683826581349 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581349 Still writing preamble
+     | 1683826581349 Wrote [198] bytes to the client
+     | 1683826581349 (W)
+     | 1683826581349 Writing back bytes
+     | 1683826581349 Wrote [16392] bytes to the client
+     | 1683826581349 (W)
+     | 1683826581349 Writing back bytes
+     | 1683826581349 Wrote [14225] bytes to the client
+     | 1683826581349 (W)
+     | 1683826581349 Writing back bytes
+     | 1683826581349 Wrote [5] bytes to the client
+     | 1683826581349 (W)
+     | 1683826581349 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581349 (WKA)
+     | 1683826581350 Read [336] bytes from client
+     | 1683826581350 (R)
+     | 1683826581350 (RP)
+     | 1683826581350 Preamble successfully parsed
+     | 1683826581350 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581350 (RWo)
+     | 1683826581350 (RC)
+     | 1683826581350 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581351 Preamble is [198] bytes long
+     | 1683826581351 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581351 Still writing preamble
+     | 1683826581351 Wrote [198] bytes to the client
+     | 1683826581351 (W)
+     | 1683826581351 Writing back bytes
+     | 1683826581351 Wrote [16392] bytes to the client
+     | 1683826581351 (W)
+     | 1683826581351 Writing back bytes
+     | 1683826581351 Wrote [14324] bytes to the client
+     | 1683826581351 (W)
+     | 1683826581351 Writing back bytes
+     | 1683826581351 Wrote [5] bytes to the client
+     | 1683826581351 (W)
+     | 1683826581351 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581351 (WKA)
+     | 1683826581351 Read [336] bytes from client
+     | 1683826581351 (R)
+     | 1683826581351 (RP)
+     | 1683826581351 Preamble successfully parsed
+     | 1683826581351 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581351 (RWo)
+     | 1683826581351 (RC)
+     | 1683826581352 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581352 Preamble is [198] bytes long
+     | 1683826581352 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581352 Still writing preamble
+     | 1683826581352 Wrote [198] bytes to the client
+     | 1683826581352 (W)
+     | 1683826581352 Writing back bytes
+     | 1683826581352 Wrote [16392] bytes to the client
+     | 1683826581352 (W)
+     | 1683826581352 Writing back bytes
+     | 1683826581352 Wrote [14423] bytes to the client
+     | 1683826581352 (W)
+     | 1683826581352 Writing back bytes
+     | 1683826581352 Wrote [5] bytes to the client
+     | 1683826581352 (W)
+     | 1683826581352 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581352 (WKA)
+     | 1683826581352 Read [336] bytes from client
+     | 1683826581352 (R)
+     | 1683826581352 (RP)
+     | 1683826581352 Preamble successfully parsed
+     | 1683826581352 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581352 (RWo)
+     | 1683826581352 (RC)
+     | 1683826581353 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581353 Preamble is [198] bytes long
+     | 1683826581353 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581353 Still writing preamble
+     | 1683826581353 Wrote [198] bytes to the client
+     | 1683826581353 (W)
+     | 1683826581353 Writing back bytes
+     | 1683826581353 Wrote [16392] bytes to the client
+     | 1683826581353 (W)
+     | 1683826581353 Writing back bytes
+     | 1683826581353 Wrote [14522] bytes to the client
+     | 1683826581353 (W)
+     | 1683826581353 Writing back bytes
+     | 1683826581353 Wrote [5] bytes to the client
+     | 1683826581353 (W)
+     | 1683826581353 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581353 (WKA)
+     | 1683826581353 Read [336] bytes from client
+     | 1683826581353 (R)
+     | 1683826581353 (RP)
+     | 1683826581353 Preamble successfully parsed
+     | 1683826581353 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581353 (RWo)
+     | 1683826581353 (RC)
+     | 1683826581354 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581354 Preamble is [198] bytes long
+     | 1683826581354 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581354 Still writing preamble
+     | 1683826581354 Wrote [198] bytes to the client
+     | 1683826581354 (W)
+     | 1683826581354 Writing back bytes
+     | 1683826581354 Wrote [16392] bytes to the client
+     | 1683826581354 (W)
+     | 1683826581354 Writing back bytes
+     | 1683826581354 Wrote [14621] bytes to the client
+     | 1683826581354 (W)
+     | 1683826581354 Writing back bytes
+     | 1683826581354 Wrote [5] bytes to the client
+     | 1683826581354 (W)
+     | 1683826581354 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581354 (WKA)
+     | 1683826581355 Read [336] bytes from client
+     | 1683826581355 (R)
+     | 1683826581355 (RP)
+     | 1683826581355 Preamble successfully parsed
+     | 1683826581355 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581355 (RWo)
+     | 1683826581355 (RC)
+     | 1683826581355 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581355 Preamble is [198] bytes long
+     | 1683826581355 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581355 Still writing preamble
+     | 1683826581355 Wrote [198] bytes to the client
+     | 1683826581355 (W)
+     | 1683826581355 Writing back bytes
+     | 1683826581355 Wrote [16392] bytes to the client
+     | 1683826581355 (W)
+     | 1683826581355 Writing back bytes
+     | 1683826581355 Wrote [14720] bytes to the client
+     | 1683826581355 (W)
+     | 1683826581355 Writing back bytes
+     | 1683826581355 Wrote [5] bytes to the client
+     | 1683826581355 (W)
+     | 1683826581355 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581355 (WKA)
+     | 1683826581356 Read [336] bytes from client
+     | 1683826581356 (R)
+     | 1683826581356 (RP)
+     | 1683826581356 Preamble successfully parsed
+     | 1683826581356 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581356 (RWo)
+     | 1683826581356 (RC)
+     | 1683826581357 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581357 Preamble is [198] bytes long
+     | 1683826581357 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581357 Still writing preamble
+     | 1683826581357 Wrote [198] bytes to the client
+     | 1683826581357 (W)
+     | 1683826581357 Writing back bytes
+     | 1683826581357 Wrote [16392] bytes to the client
+     | 1683826581357 (W)
+     | 1683826581357 Writing back bytes
+     | 1683826581357 Wrote [14819] bytes to the client
+     | 1683826581357 (W)
+     | 1683826581357 Writing back bytes
+     | 1683826581357 Wrote [5] bytes to the client
+     | 1683826581357 (W)
+     | 1683826581357 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581357 (WKA)
+     | 1683826581358 Read [336] bytes from client
+     | 1683826581358 (R)
+     | 1683826581358 (RP)
+     | 1683826581358 Preamble successfully parsed
+     | 1683826581358 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581358 (RWo)
+     | 1683826581358 (RC)
+     | 1683826581358 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581358 Preamble is [198] bytes long
+     | 1683826581358 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581358 Still writing preamble
+     | 1683826581358 Wrote [198] bytes to the client
+     | 1683826581358 (W)
+     | 1683826581358 Writing back bytes
+     | 1683826581358 Wrote [16392] bytes to the client
+     | 1683826581358 (W)
+     | 1683826581358 Writing back bytes
+     | 1683826581358 Wrote [14918] bytes to the client
+     | 1683826581358 (W)
+     | 1683826581358 Writing back bytes
+     | 1683826581358 Wrote [5] bytes to the client
+     | 1683826581358 (W)
+     | 1683826581358 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581358 (WKA)
+     | 1683826581359 Read [336] bytes from client
+     | 1683826581359 (R)
+     | 1683826581359 (RP)
+     | 1683826581359 Preamble successfully parsed
+     | 1683826581359 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581359 (RWo)
+     | 1683826581359 (RC)
+     | 1683826581360 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581360 Preamble is [198] bytes long
+     | 1683826581360 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581360 Still writing preamble
+     | 1683826581360 Wrote [198] bytes to the client
+     | 1683826581360 (W)
+     | 1683826581360 Writing back bytes
+     | 1683826581360 Wrote [16392] bytes to the client
+     | 1683826581360 (W)
+     | 1683826581360 Writing back bytes
+     | 1683826581360 Wrote [15017] bytes to the client
+     | 1683826581360 (W)
+     | 1683826581360 Writing back bytes
+     | 1683826581360 Wrote [5] bytes to the client
+     | 1683826581360 (W)
+     | 1683826581360 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581360 (WKA)
+     | 1683826581360 Read [336] bytes from client
+     | 1683826581360 (R)
+     | 1683826581360 (RP)
+     | 1683826581360 Preamble successfully parsed
+     | 1683826581360 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581360 (RWo)
+     | 1683826581360 (RC)
+     | 1683826581361 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581361 Preamble is [198] bytes long
+     | 1683826581361 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581361 Still writing preamble
+     | 1683826581361 Wrote [198] bytes to the client
+     | 1683826581361 (W)
+     | 1683826581361 Writing back bytes
+     | 1683826581361 Wrote [16392] bytes to the client
+     | 1683826581361 (W)
+     | 1683826581361 Writing back bytes
+     | 1683826581361 Wrote [15116] bytes to the client
+     | 1683826581361 (W)
+     | 1683826581361 Writing back bytes
+     | 1683826581361 Wrote [5] bytes to the client
+     | 1683826581361 (W)
+     | 1683826581361 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581361 (WKA)
+     | 1683826581361 Read [336] bytes from client
+     | 1683826581361 (R)
+     | 1683826581361 (RP)
+     | 1683826581361 Preamble successfully parsed
+     | 1683826581361 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581361 (RWo)
+     | 1683826581361 (RC)
+     | 1683826581362 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581362 Preamble is [198] bytes long
+     | 1683826581362 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581362 Still writing preamble
+     | 1683826581362 Wrote [198] bytes to the client
+     | 1683826581362 (W)
+     | 1683826581362 Writing back bytes
+     | 1683826581362 Wrote [16392] bytes to the client
+     | 1683826581362 (W)
+     | 1683826581362 Writing back bytes
+     | 1683826581362 Wrote [15215] bytes to the client
+     | 1683826581362 (W)
+     | 1683826581362 Writing back bytes
+     | 1683826581362 Wrote [5] bytes to the client
+     | 1683826581362 (W)
+     | 1683826581362 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581362 (WKA)
+     | 1683826581363 Read [336] bytes from client
+     | 1683826581363 (R)
+     | 1683826581363 (RP)
+     | 1683826581363 Preamble successfully parsed
+     | 1683826581363 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581363 (RWo)
+     | 1683826581363 (RC)
+     | 1683826581364 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581364 Preamble is [198] bytes long
+     | 1683826581364 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581364 Still writing preamble
+     | 1683826581364 Wrote [198] bytes to the client
+     | 1683826581364 (W)
+     | 1683826581364 Writing back bytes
+     | 1683826581364 Wrote [16392] bytes to the client
+     | 1683826581364 (W)
+     | 1683826581364 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581364 Writing back bytes
+     | 1683826581364 Wrote [15314] bytes to the client
+     | 1683826581364 (W)
+     | 1683826581364 Writing back bytes
+     | 1683826581364 Wrote [5] bytes to the client
+     | 1683826581364 (W)
+     | 1683826581364 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581364 (WKA)
+     | 1683826581364 Read [336] bytes from client
+     | 1683826581364 (R)
+     | 1683826581364 (RP)
+     | 1683826581364 Preamble successfully parsed
+     | 1683826581364 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581364 (RWo)
+     | 1683826581364 (RC)
+     | 1683826581365 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581365 Preamble is [198] bytes long
+     | 1683826581365 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581365 Still writing preamble
+     | 1683826581365 Wrote [198] bytes to the client
+     | 1683826581365 (W)
+     | 1683826581365 Writing back bytes
+     | 1683826581365 Wrote [16392] bytes to the client
+     | 1683826581365 (W)
+     | 1683826581365 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581365 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581365 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581365 Writing back bytes
+     | 1683826581365 Wrote [15413] bytes to the client
+     | 1683826581365 (W)
+     | 1683826581365 Writing back bytes
+     | 1683826581365 Wrote [5] bytes to the client
+     | 1683826581365 (W)
+     | 1683826581365 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581365 (WKA)
+     | 1683826581366 Read [336] bytes from client
+     | 1683826581366 (R)
+     | 1683826581366 (RP)
+     | 1683826581366 Preamble successfully parsed
+     | 1683826581366 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581366 (RWo)
+     | 1683826581366 (RC)
+     | 1683826581367 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581367 Preamble is [198] bytes long
+     | 1683826581367 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581367 Still writing preamble
+     | 1683826581367 Wrote [198] bytes to the client
+     | 1683826581367 (W)
+     | 1683826581367 Writing back bytes
+     | 1683826581367 Wrote [16392] bytes to the client
+     | 1683826581367 (W)
+     | 1683826581367 Writing back bytes
+     | 1683826581367 Wrote [15512] bytes to the client
+     | 1683826581367 (W)
+     | 1683826581367 Writing back bytes
+     | 1683826581367 Wrote [5] bytes to the client
+     | 1683826581367 (W)
+     | 1683826581367 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581367 (WKA)
+     | 1683826581367 Read [336] bytes from client
+     | 1683826581367 (R)
+     | 1683826581367 (RP)
+     | 1683826581367 Preamble successfully parsed
+     | 1683826581367 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581367 (RWo)
+     | 1683826581367 (RC)
+     | 1683826581368 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581369 Preamble is [198] bytes long
+     | 1683826581369 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581369 Still writing preamble
+     | 1683826581369 Wrote [198] bytes to the client
+     | 1683826581369 (W)
+     | 1683826581369 Writing back bytes
+     | 1683826581369 Wrote [16392] bytes to the client
+     | 1683826581369 (W)
+     | 1683826581369 Writing back bytes
+     | 1683826581369 Wrote [15611] bytes to the client
+     | 1683826581369 (W)
+     | 1683826581369 Writing back bytes
+     | 1683826581369 Wrote [5] bytes to the client
+     | 1683826581369 (W)
+     | 1683826581369 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581369 (WKA)
+     | 1683826581369 Read [336] bytes from client
+     | 1683826581369 (R)
+     | 1683826581369 (RP)
+     | 1683826581369 Preamble successfully parsed
+     | 1683826581369 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581369 (RWo)
+     | 1683826581369 (RC)
+     | 1683826581370 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581370 Preamble is [198] bytes long
+     | 1683826581370 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581370 Still writing preamble
+     | 1683826581370 Wrote [198] bytes to the client
+     | 1683826581370 (W)
+     | 1683826581370 Writing back bytes
+     | 1683826581370 Wrote [16392] bytes to the client
+     | 1683826581370 (W)
+     | 1683826581370 Writing back bytes
+     | 1683826581370 Wrote [15710] bytes to the client
+     | 1683826581370 (W)
+     | 1683826581370 Writing back bytes
+     | 1683826581370 Wrote [5] bytes to the client
+     | 1683826581370 (W)
+     | 1683826581370 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581370 (WKA)
+     | 1683826581371 Read [336] bytes from client
+     | 1683826581371 (R)
+     | 1683826581371 (RP)
+     | 1683826581371 Preamble successfully parsed
+     | 1683826581371 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581371 (RWo)
+     | 1683826581371 (RC)
+     | 1683826581371 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581372 Preamble is [198] bytes long
+     | 1683826581372 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581372 Still writing preamble
+     | 1683826581372 Wrote [198] bytes to the client
+     | 1683826581372 (W)
+     | 1683826581372 Writing back bytes
+     | 1683826581372 Wrote [16392] bytes to the client
+     | 1683826581372 (W)
+     | 1683826581372 Writing back bytes
+     | 1683826581372 Wrote [15809] bytes to the client
+     | 1683826581372 (W)
+     | 1683826581372 Writing back bytes
+     | 1683826581372 Wrote [5] bytes to the client
+     | 1683826581372 (W)
+     | 1683826581372 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581372 (WKA)
+     | 1683826581372 Read [336] bytes from client
+     | 1683826581372 (R)
+     | 1683826581372 (RP)
+     | 1683826581372 Preamble successfully parsed
+     | 1683826581372 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581372 (RWo)
+     | 1683826581372 (RC)
+     | 1683826581373 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581373 Preamble is [198] bytes long
+     | 1683826581373 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581373 Still writing preamble
+     | 1683826581373 Wrote [198] bytes to the client
+     | 1683826581373 (W)
+     | 1683826581373 Writing back bytes
+     | 1683826581373 Wrote [16392] bytes to the client
+     | 1683826581373 (W)
+     | 1683826581373 Writing back bytes
+     | 1683826581373 Wrote [15908] bytes to the client
+     | 1683826581373 (W)
+     | 1683826581373 Writing back bytes
+     | 1683826581373 Wrote [5] bytes to the client
+     | 1683826581373 (W)
+     | 1683826581373 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581373 (WKA)
+     | 1683826581373 Read [336] bytes from client
+     | 1683826581373 (R)
+     | 1683826581373 (RP)
+     | 1683826581373 Preamble successfully parsed
+     | 1683826581373 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581373 (RWo)
+     | 1683826581373 (RC)
+     | 1683826581374 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581374 Preamble is [198] bytes long
+     | 1683826581374 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581374 Still writing preamble
+     | 1683826581374 Wrote [198] bytes to the client
+     | 1683826581374 (W)
+     | 1683826581374 Writing back bytes
+     | 1683826581374 Wrote [16392] bytes to the client
+     | 1683826581374 (W)
+     | 1683826581374 Writing back bytes
+     | 1683826581374 Wrote [16007] bytes to the client
+     | 1683826581374 (W)
+     | 1683826581374 Writing back bytes
+     | 1683826581374 Wrote [5] bytes to the client
+     | 1683826581374 (W)
+     | 1683826581374 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581374 (WKA)
+     | 1683826581374 Read [336] bytes from client
+     | 1683826581374 (R)
+     | 1683826581374 (RP)
+     | 1683826581374 Preamble successfully parsed
+     | 1683826581374 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581374 (RWo)
+     | 1683826581374 (RC)
+     | 1683826581375 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581375 Preamble is [198] bytes long
+     | 1683826581375 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581375 Still writing preamble
+     | 1683826581375 Wrote [198] bytes to the client
+     | 1683826581375 (W)
+     | 1683826581375 Writing back bytes
+     | 1683826581375 Wrote [16392] bytes to the client
+     | 1683826581375 (W)
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581375 Writing back bytes
+     | 1683826581375 Wrote [16106] bytes to the client
+     | 1683826581375 (W)
+     | 1683826581375 Writing back bytes
+     | 1683826581375 Wrote [5] bytes to the client
+     | 1683826581375 (W)
+     | 1683826581375 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581375 (WKA)
+     | 1683826581376 Read [336] bytes from client
+     | 1683826581376 (R)
+     | 1683826581376 (RP)
+     | 1683826581376 Preamble successfully parsed
+     | 1683826581376 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581376 (RWo)
+     | 1683826581376 (RC)
+     | 1683826581376 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581376 Preamble is [198] bytes long
+     | 1683826581377 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581377 Still writing preamble
+     | 1683826581377 Wrote [198] bytes to the client
+     | 1683826581377 (W)
+     | 1683826581377 Writing back bytes
+     | 1683826581377 Wrote [16392] bytes to the client
+     | 1683826581377 (W)
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581377 Writing back bytes
+     | 1683826581377 Wrote [16205] bytes to the client
+     | 1683826581377 (W)
+     | 1683826581377 Writing back bytes
+     | 1683826581377 Wrote [5] bytes to the client
+     | 1683826581377 (W)
+     | 1683826581377 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581377 (WKA)
+     | 1683826581377 Read [336] bytes from client
+     | 1683826581377 (R)
+     | 1683826581377 (RP)
+     | 1683826581377 Preamble successfully parsed
+     | 1683826581377 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581377 (RWo)
+     | 1683826581377 (RC)
+     | 1683826581378 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581378 Preamble is [198] bytes long
+     | 1683826581378 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581378 Still writing preamble
+     | 1683826581378 Wrote [198] bytes to the client
+     | 1683826581378 (W)
+     | 1683826581378 Writing back bytes
+     | 1683826581378 Wrote [16392] bytes to the client
+     | 1683826581378 (W)
+     | 1683826581378 Writing back bytes
+     | 1683826581378 Wrote [16304] bytes to the client
+     | 1683826581378 (W)
+     | 1683826581378 Writing back bytes
+     | 1683826581378 Wrote [5] bytes to the client
+     | 1683826581378 (W)
+     | 1683826581378 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581378 (WKA)
+     | 1683826581378 Read [336] bytes from client
+     | 1683826581378 (R)
+     | 1683826581378 (RP)
+     | 1683826581378 Preamble successfully parsed
+     | 1683826581378 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581378 (RWo)
+     | 1683826581378 (RC)
+     | 1683826581379 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581379 Preamble is [198] bytes long
+     | 1683826581379 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581379 Still writing preamble
+     | 1683826581379 Wrote [198] bytes to the client
+     | 1683826581379 (W)
+     | 1683826581379 Writing back bytes
+     | 1683826581379 Wrote [16392] bytes to the client
+     | 1683826581379 (W)
+     | 1683826581379 Writing back bytes
+     | 1683826581379 Wrote [16392] bytes to the client
+     | 1683826581379 (W)
+     | 1683826581379 Writing back bytes
+     | 1683826581379 Wrote [16] bytes to the client
+     | 1683826581379 (W)
+     | 1683826581379 Writing back bytes
+     | 1683826581379 Wrote [5] bytes to the client
+     | 1683826581379 (W)
+     | 1683826581379 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581379 (WKA)
+     | 1683826581380 Read [336] bytes from client
+     | 1683826581380 (R)
+     | 1683826581380 (RP)
+     | 1683826581380 Preamble successfully parsed
+     | 1683826581380 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581380 (RWo)
+     | 1683826581380 (RC)
+     | 1683826581381 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581381 Preamble is [198] bytes long
+     | 1683826581381 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581381 Still writing preamble
+     | 1683826581381 Wrote [198] bytes to the client
+     | 1683826581381 (W)
+     | 1683826581381 Writing back bytes
+     | 1683826581381 Wrote [16392] bytes to the client
+     | 1683826581381 (W)
+     | 1683826581381 Writing back bytes
+     | 1683826581381 Wrote [16392] bytes to the client
+     | 1683826581381 (W)
+     | 1683826581381 Writing back bytes
+     | 1683826581381 Wrote [116] bytes to the client
+     | 1683826581381 (W)
+     | 1683826581381 Writing back bytes
+     | 1683826581381 Wrote [5] bytes to the client
+     | 1683826581381 (W)
+     | 1683826581381 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581381 (WKA)
+     | 1683826581381 Read [336] bytes from client
+     | 1683826581381 (R)
+     | 1683826581381 (RP)
+     | 1683826581381 Preamble successfully parsed
+     | 1683826581381 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581381 (RWo)
+     | 1683826581381 (RC)
+     | 1683826581382 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581382 Preamble is [198] bytes long
+     | 1683826581382 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581382 Still writing preamble
+     | 1683826581382 Wrote [198] bytes to the client
+     | 1683826581382 (W)
+     | 1683826581382 Writing back bytes
+     | 1683826581382 Wrote [16392] bytes to the client
+     | 1683826581382 (W)
+     | 1683826581382 Writing back bytes
+     | 1683826581382 Wrote [16392] bytes to the client
+     | 1683826581382 (W)
+     | 1683826581382 Writing back bytes
+     | 1683826581382 Wrote [215] bytes to the client
+     | 1683826581382 (W)
+     | 1683826581382 Writing back bytes
+     | 1683826581382 Wrote [5] bytes to the client
+     | 1683826581382 (W)
+     | 1683826581382 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581382 (WKA)
+     | 1683826581383 Read [336] bytes from client
+     | 1683826581383 (R)
+     | 1683826581383 (RP)
+     | 1683826581383 Preamble successfully parsed
+     | 1683826581383 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581383 (RWo)
+     | 1683826581383 (RC)
+     | 1683826581383 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581383 Preamble is [198] bytes long
+     | 1683826581383 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581383 Still writing preamble
+     | 1683826581383 Wrote [198] bytes to the client
+     | 1683826581383 (W)
+     | 1683826581383 Writing back bytes
+     | 1683826581383 Wrote [16392] bytes to the client
+     | 1683826581383 (W)
+     | 1683826581383 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581383 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581383 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581383 Writing back bytes
+     | 1683826581384 Wrote [16392] bytes to the client
+     | 1683826581384 (W)
+     | 1683826581384 Writing back bytes
+     | 1683826581384 Wrote [315] bytes to the client
+     | 1683826581384 (W)
+     | 1683826581384 Writing back bytes
+     | 1683826581384 Wrote [5] bytes to the client
+     | 1683826581384 (W)
+     | 1683826581384 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581384 (WKA)
+     | 1683826581384 Read [336] bytes from client
+     | 1683826581384 (R)
+     | 1683826581384 (RP)
+     | 1683826581384 Preamble successfully parsed
+     | 1683826581384 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581384 (RWo)
+     | 1683826581384 (RC)
+     | 1683826581385 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581385 Preamble is [198] bytes long
+     | 1683826581385 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581385 Still writing preamble
+     | 1683826581385 Wrote [198] bytes to the client
+     | 1683826581385 (W)
+     | 1683826581385 Writing back bytes
+     | 1683826581385 Wrote [16392] bytes to the client
+     | 1683826581385 (W)
+     | 1683826581385 Writing back bytes
+     | 1683826581385 Wrote [16392] bytes to the client
+     | 1683826581385 (W)
+     | 1683826581385 Writing back bytes
+     | 1683826581385 Wrote [414] bytes to the client
+     | 1683826581385 (W)
+     | 1683826581385 Writing back bytes
+     | 1683826581385 Wrote [5] bytes to the client
+     | 1683826581385 (W)
+     | 1683826581385 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581385 (WKA)
+     | 1683826581385 Read [336] bytes from client
+     | 1683826581385 (R)
+     | 1683826581385 (RP)
+     | 1683826581385 Preamble successfully parsed
+     | 1683826581385 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581385 (RWo)
+     | 1683826581385 (RC)
+     | 1683826581386 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581386 Preamble is [198] bytes long
+     | 1683826581386 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581386 Still writing preamble
+     | 1683826581386 Wrote [198] bytes to the client
+     | 1683826581386 (W)
+     | 1683826581386 Writing back bytes
+     | 1683826581386 Wrote [16392] bytes to the client
+     | 1683826581386 (W)
+     | 1683826581386 Writing back bytes
+     | 1683826581386 Wrote [16392] bytes to the client
+     | 1683826581386 (W)
+     | 1683826581386 Writing back bytes
+     | 1683826581386 Wrote [513] bytes to the client
+     | 1683826581386 (W)
+     | 1683826581386 Writing back bytes
+     | 1683826581386 Wrote [5] bytes to the client
+     | 1683826581386 (W)
+     | 1683826581386 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581386 (WKA)
+     | 1683826581387 Read [336] bytes from client
+     | 1683826581387 (R)
+     | 1683826581387 (RP)
+     | 1683826581387 Preamble successfully parsed
+     | 1683826581387 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581387 (RWo)
+     | 1683826581387 (RC)
+     | 1683826581387 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581387 Preamble is [198] bytes long
+     | 1683826581387 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581387 Still writing preamble
+     | 1683826581387 Wrote [198] bytes to the client
+     | 1683826581387 (W)
+     | 1683826581387 Writing back bytes
+     | 1683826581387 Wrote [16392] bytes to the client
+     | 1683826581387 (W)
+     | 1683826581387 Writing back bytes
+     | 1683826581387 Wrote [16392] bytes to the client
+     | 1683826581387 (W)
+     | 1683826581387 Writing back bytes
+     | 1683826581387 Wrote [612] bytes to the client
+     | 1683826581387 (W)
+     | 1683826581387 Writing back bytes
+     | 1683826581387 Wrote [5] bytes to the client
+     | 1683826581387 (W)
+     | 1683826581387 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581387 (WKA)
+     | 1683826581388 Read [336] bytes from client
+     | 1683826581388 (R)
+     | 1683826581388 (RP)
+     | 1683826581388 Preamble successfully parsed
+     | 1683826581388 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581388 (RWo)
+     | 1683826581388 (RC)
+     | 1683826581389 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581389 Preamble is [198] bytes long
+     | 1683826581389 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581389 Still writing preamble
+     | 1683826581389 Wrote [198] bytes to the client
+     | 1683826581389 (W)
+     | 1683826581389 Writing back bytes
+     | 1683826581389 Wrote [16392] bytes to the client
+     | 1683826581389 (W)
+     | 1683826581389 Writing back bytes
+     | 1683826581389 Wrote [16392] bytes to the client
+     | 1683826581389 (W)
+     | 1683826581389 Writing back bytes
+     | 1683826581389 Wrote [711] bytes to the client
+     | 1683826581389 (W)
+     | 1683826581389 Writing back bytes
+     | 1683826581389 Wrote [5] bytes to the client
+     | 1683826581389 (W)
+     | 1683826581389 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581389 (WKA)
+     | 1683826581389 Read [336] bytes from client
+     | 1683826581389 (R)
+     | 1683826581389 (RP)
+     | 1683826581389 Preamble successfully parsed
+     | 1683826581389 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581389 (RWo)
+     | 1683826581389 (RC)
+     | 1683826581390 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581390 Preamble is [198] bytes long
+     | 1683826581390 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581390 Still writing preamble
+     | 1683826581390 Wrote [198] bytes to the client
+     | 1683826581390 (W)
+     | 1683826581390 Writing back bytes
+     | 1683826581390 Wrote [16392] bytes to the client
+     | 1683826581390 (W)
+     | 1683826581390 Writing back bytes
+     | 1683826581390 Wrote [16392] bytes to the client
+     | 1683826581390 (W)
+     | 1683826581390 Writing back bytes
+     | 1683826581390 Wrote [810] bytes to the client
+     | 1683826581390 (W)
+     | 1683826581390 Writing back bytes
+     | 1683826581390 Wrote [5] bytes to the client
+     | 1683826581390 (W)
+     | 1683826581390 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581390 (WKA)
+     | 1683826581391 Read [336] bytes from client
+     | 1683826581391 (R)
+     | 1683826581391 (RP)
+     | 1683826581391 Preamble successfully parsed
+     | 1683826581391 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581391 (RWo)
+     | 1683826581391 (RC)
+     | 1683826581392 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581392 Preamble is [198] bytes long
+     | 1683826581392 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581392 Still writing preamble
+     | 1683826581392 Wrote [198] bytes to the client
+     | 1683826581392 (W)
+     | 1683826581392 Writing back bytes
+     | 1683826581392 Wrote [16392] bytes to the client
+     | 1683826581392 (W)
+     | 1683826581392 Writing back bytes
+     | 1683826581392 Wrote [16392] bytes to the client
+     | 1683826581392 (W)
+     | 1683826581392 Writing back bytes
+     | 1683826581392 Wrote [909] bytes to the client
+     | 1683826581392 (W)
+     | 1683826581392 Writing back bytes
+     | 1683826581392 Wrote [5] bytes to the client
+     | 1683826581392 (W)
+     | 1683826581392 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581392 (WKA)
+     | 1683826581392 Read [336] bytes from client
+     | 1683826581392 (R)
+     | 1683826581392 (RP)
+     | 1683826581392 Preamble successfully parsed
+     | 1683826581392 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581392 (RWo)
+     | 1683826581392 (RC)
+     | 1683826581393 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581393 Preamble is [198] bytes long
+     | 1683826581393 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581393 Still writing preamble
+     | 1683826581393 Wrote [198] bytes to the client
+     | 1683826581393 (W)
+     | 1683826581393 Writing back bytes
+     | 1683826581393 Wrote [16392] bytes to the client
+     | 1683826581393 (W)
+     | 1683826581393 Writing back bytes
+     | 1683826581393 Wrote [16392] bytes to the client
+     | 1683826581393 (W)
+     | 1683826581393 Writing back bytes
+     | 1683826581393 Wrote [1008] bytes to the client
+     | 1683826581393 (W)
+     | 1683826581393 Writing back bytes
+     | 1683826581393 Wrote [5] bytes to the client
+     | 1683826581393 (W)
+     | 1683826581393 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581393 (WKA)
+     | 1683826581394 Read [336] bytes from client
+     | 1683826581394 (R)
+     | 1683826581394 (RP)
+     | 1683826581394 Preamble successfully parsed
+     | 1683826581394 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581394 (RWo)
+     | 1683826581394 (RC)
+     | 1683826581394 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581394 Preamble is [198] bytes long
+     | 1683826581394 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581394 Still writing preamble
+     | 1683826581394 Wrote [198] bytes to the client
+     | 1683826581394 (W)
+     | 1683826581394 Writing back bytes
+     | 1683826581394 Wrote [16392] bytes to the client
+     | 1683826581394 (W)
+     | 1683826581394 Writing back bytes
+     | 1683826581394 Wrote [16392] bytes to the client
+     | 1683826581394 (W)
+     | 1683826581394 Writing back bytes
+     | 1683826581394 Wrote [1107] bytes to the client
+     | 1683826581394 (W)
+     | 1683826581394 Writing back bytes
+     | 1683826581394 Wrote [5] bytes to the client
+     | 1683826581394 (W)
+     | 1683826581394 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581394 (WKA)
+     | 1683826581395 Read [336] bytes from client
+     | 1683826581395 (R)
+     | 1683826581395 (RP)
+     | 1683826581395 Preamble successfully parsed
+     | 1683826581395 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581395 (RWo)
+     | 1683826581395 (RC)
+     | 1683826581395 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581395 Preamble is [198] bytes long
+     | 1683826581395 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581395 Still writing preamble
+     | 1683826581395 Wrote [198] bytes to the client
+     | 1683826581395 (W)
+     | 1683826581395 Writing back bytes
+     | 1683826581396 Wrote [16392] bytes to the client
+     | 1683826581396 (W)
+     | 1683826581396 Writing back bytes
+     | 1683826581396 Wrote [16392] bytes to the client
+     | 1683826581396 (W)
+     | 1683826581396 Writing back bytes
+     | 1683826581396 Wrote [1206] bytes to the client
+     | 1683826581396 (W)
+     | 1683826581396 Writing back bytes
+     | 1683826581396 Wrote [5] bytes to the client
+     | 1683826581396 (W)
+     | 1683826581396 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581396 (WKA)
+     | 1683826581396 Read [336] bytes from client
+     | 1683826581396 (R)
+     | 1683826581396 (RP)
+     | 1683826581396 Preamble successfully parsed
+     | 1683826581396 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581396 (RWo)
+     | 1683826581396 (RC)
+     | 1683826581397 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581397 Preamble is [198] bytes long
+     | 1683826581397 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581397 Still writing preamble
+     | 1683826581397 Wrote [198] bytes to the client
+     | 1683826581397 (W)
+     | 1683826581397 Writing back bytes
+     | 1683826581397 Wrote [16392] bytes to the client
+     | 1683826581397 (W)
+     | 1683826581397 Writing back bytes
+     | 1683826581397 Wrote [16392] bytes to the client
+     | 1683826581397 (W)
+     | 1683826581397 Writing back bytes
+     | 1683826581397 Wrote [1305] bytes to the client
+     | 1683826581397 (W)
+     | 1683826581397 Writing back bytes
+     | 1683826581397 Wrote [5] bytes to the client
+     | 1683826581397 (W)
+     | 1683826581397 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581397 (WKA)
+     | 1683826581397 Read [336] bytes from client
+     | 1683826581397 (R)
+     | 1683826581397 (RP)
+     | 1683826581397 Preamble successfully parsed
+     | 1683826581397 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581397 (RWo)
+     | 1683826581397 (RC)
+     | 1683826581398 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581398 Preamble is [198] bytes long
+     | 1683826581398 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581398 Still writing preamble
+     | 1683826581398 Wrote [198] bytes to the client
+     | 1683826581398 (W)
+     | 1683826581398 Writing back bytes
+     | 1683826581398 Wrote [16392] bytes to the client
+     | 1683826581398 (W)
+     | 1683826581398 Writing back bytes
+     | 1683826581398 Wrote [16392] bytes to the client
+     | 1683826581398 (W)
+     | 1683826581398 Writing back bytes
+     | 1683826581398 Wrote [1404] bytes to the client
+     | 1683826581398 (W)
+     | 1683826581398 Writing back bytes
+     | 1683826581398 Wrote [5] bytes to the client
+     | 1683826581398 (W)
+     | 1683826581398 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581398 (WKA)
+     | 1683826581399 Read [336] bytes from client
+     | 1683826581399 (R)
+     | 1683826581399 (RP)
+     | 1683826581399 Preamble successfully parsed
+     | 1683826581399 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581399 (RWo)
+     | 1683826581399 (RC)
+     | 1683826581400 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581400 Preamble is [198] bytes long
+     | 1683826581400 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581400 Still writing preamble
+     | 1683826581400 Wrote [198] bytes to the client
+     | 1683826581400 (W)
+     | 1683826581400 Writing back bytes
+     | 1683826581400 Wrote [16392] bytes to the client
+     | 1683826581400 (W)
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581400 Writing back bytes
+     | 1683826581400 Wrote [16392] bytes to the client
+     | 1683826581400 (W)
+     | 1683826581400 Writing back bytes
+     | 1683826581400 Wrote [1503] bytes to the client
+     | 1683826581400 (W)
+     | 1683826581400 Writing back bytes
+     | 1683826581400 Wrote [5] bytes to the client
+     | 1683826581400 (W)
+     | 1683826581400 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581400 (WKA)
+     | 1683826581400 Read [336] bytes from client
+     | 1683826581400 (R)
+     | 1683826581400 (RP)
+     | 1683826581400 Preamble successfully parsed
+     | 1683826581400 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581400 (RWo)
+     | 1683826581400 (RC)
+     | 1683826581401 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581401 Preamble is [198] bytes long
+     | 1683826581401 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581401 Still writing preamble
+     | 1683826581401 Wrote [198] bytes to the client
+     | 1683826581401 (W)
+     | 1683826581401 Writing back bytes
+     | 1683826581401 Wrote [16392] bytes to the client
+     | 1683826581401 (W)
+     | 1683826581401 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581401 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581401 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581401 Writing back bytes
+     | 1683826581401 Wrote [16392] bytes to the client
+     | 1683826581401 (W)
+     | 1683826581401 Writing back bytes
+     | 1683826581401 Wrote [1602] bytes to the client
+     | 1683826581401 (W)
+     | 1683826581401 Writing back bytes
+     | 1683826581401 Wrote [5] bytes to the client
+     | 1683826581401 (W)
+     | 1683826581401 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581401 (WKA)
+     | 1683826581401 Read [336] bytes from client
+     | 1683826581401 (R)
+     | 1683826581401 (RP)
+     | 1683826581401 Preamble successfully parsed
+     | 1683826581401 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581401 (RWo)
+     | 1683826581401 (RC)
+     | 1683826581402 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581402 Preamble is [198] bytes long
+     | 1683826581402 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581402 Still writing preamble
+     | 1683826581402 Wrote [198] bytes to the client
+     | 1683826581402 (W)
+     | 1683826581402 Writing back bytes
+     | 1683826581402 Wrote [16392] bytes to the client
+     | 1683826581402 (W)
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581402 Writing back bytes
+     | 1683826581402 Wrote [16392] bytes to the client
+     | 1683826581402 (W)
+     | 1683826581402 Writing back bytes
+     | 1683826581402 Wrote [1701] bytes to the client
+     | 1683826581402 (W)
+     | 1683826581402 Writing back bytes
+     | 1683826581402 Wrote [5] bytes to the client
+     | 1683826581402 (W)
+     | 1683826581402 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581402 (WKA)
+     | 1683826581402 Read [336] bytes from client
+     | 1683826581402 (R)
+     | 1683826581402 (RP)
+     | 1683826581402 Preamble successfully parsed
+     | 1683826581402 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581402 (RWo)
+     | 1683826581402 (RC)
+     | 1683826581403 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581403 Preamble is [198] bytes long
+     | 1683826581403 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581403 Still writing preamble
+     | 1683826581403 Wrote [198] bytes to the client
+     | 1683826581403 (W)
+     | 1683826581403 Writing back bytes
+     | 1683826581403 Wrote [16392] bytes to the client
+     | 1683826581403 (W)
+     | 1683826581403 Writing back bytes
+     | 1683826581403 Wrote [16392] bytes to the client
+     | 1683826581403 (W)
+     | 1683826581403 Writing back bytes
+     | 1683826581403 Wrote [1800] bytes to the client
+     | 1683826581403 (W)
+     | 1683826581403 Writing back bytes
+     | 1683826581403 Wrote [5] bytes to the client
+     | 1683826581403 (W)
+     | 1683826581403 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581403 (WKA)
+     | 1683826581403 Read [336] bytes from client
+     | 1683826581403 (R)
+     | 1683826581403 (RP)
+     | 1683826581403 Preamble successfully parsed
+     | 1683826581403 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581403 (RWo)
+     | 1683826581403 (RC)
+     | 1683826581404 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581404 Preamble is [198] bytes long
+     | 1683826581404 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581404 Still writing preamble
+     | 1683826581404 Wrote [198] bytes to the client
+     | 1683826581404 (W)
+     | 1683826581404 Writing back bytes
+     | 1683826581404 Wrote [16392] bytes to the client
+     | 1683826581404 (W)
+     | 1683826581404 Writing back bytes
+     | 1683826581404 Wrote [16392] bytes to the client
+     | 1683826581404 (W)
+     | 1683826581404 Writing back bytes
+     | 1683826581404 Wrote [1899] bytes to the client
+     | 1683826581404 (W)
+     | 1683826581404 Writing back bytes
+     | 1683826581404 Wrote [5] bytes to the client
+     | 1683826581404 (W)
+     | 1683826581404 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581404 (WKA)
+     | 1683826581405 Read [336] bytes from client
+     | 1683826581405 (R)
+     | 1683826581405 (RP)
+     | 1683826581405 Preamble successfully parsed
+     | 1683826581405 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581405 (RWo)
+     | 1683826581405 (RC)
+     | 1683826581405 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581405 Preamble is [198] bytes long
+     | 1683826581405 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581405 Still writing preamble
+     | 1683826581405 Wrote [198] bytes to the client
+     | 1683826581405 (W)
+     | 1683826581405 Writing back bytes
+     | 1683826581405 Wrote [16392] bytes to the client
+     | 1683826581405 (W)
+     | 1683826581405 Writing back bytes
+     | 1683826581405 Wrote [16392] bytes to the client
+     | 1683826581405 (W)
+     | 1683826581405 Writing back bytes
+     | 1683826581405 Wrote [1998] bytes to the client
+     | 1683826581405 (W)
+     | 1683826581405 Writing back bytes
+     | 1683826581405 Wrote [5] bytes to the client
+     | 1683826581405 (W)
+     | 1683826581405 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581405 (WKA)
+     | 1683826581406 Read [336] bytes from client
+     | 1683826581406 (R)
+     | 1683826581406 (RP)
+     | 1683826581406 Preamble successfully parsed
+     | 1683826581406 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581406 (RWo)
+     | 1683826581406 (RC)
+     | 1683826581406 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581407 Preamble is [198] bytes long
+     | 1683826581407 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581407 Still writing preamble
+     | 1683826581407 Wrote [198] bytes to the client
+     | 1683826581407 (W)
+     | 1683826581407 Writing back bytes
+     | 1683826581407 Wrote [16392] bytes to the client
+     | 1683826581407 (W)
+     | 1683826581407 Writing back bytes
+     | 1683826581407 Wrote [16392] bytes to the client
+     | 1683826581407 (W)
+     | 1683826581407 Writing back bytes
+     | 1683826581407 Wrote [2097] bytes to the client
+     | 1683826581407 (W)
+     | 1683826581407 Writing back bytes
+     | 1683826581407 Wrote [5] bytes to the client
+     | 1683826581407 (W)
+     | 1683826581407 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581407 (WKA)
+     | 1683826581407 Read [336] bytes from client
+     | 1683826581407 (R)
+     | 1683826581407 (RP)
+     | 1683826581407 Preamble successfully parsed
+     | 1683826581407 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581407 (RWo)
+     | 1683826581407 (RC)
+     | 1683826581408 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581408 Preamble is [198] bytes long
+     | 1683826581408 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581408 Still writing preamble
+     | 1683826581408 Wrote [198] bytes to the client
+     | 1683826581408 (W)
+     | 1683826581408 Writing back bytes
+     | 1683826581408 Wrote [16392] bytes to the client
+     | 1683826581408 (W)
+     | 1683826581408 Writing back bytes
+     | 1683826581408 Wrote [16392] bytes to the client
+     | 1683826581408 (W)
+     | 1683826581408 Writing back bytes
+     | 1683826581408 Wrote [2196] bytes to the client
+     | 1683826581408 (W)
+     | 1683826581408 Writing back bytes
+     | 1683826581408 Wrote [5] bytes to the client
+     | 1683826581408 (W)
+     | 1683826581408 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581408 (WKA)
+     | 1683826581408 Read [336] bytes from client
+     | 1683826581408 (R)
+     | 1683826581408 (RP)
+     | 1683826581408 Preamble successfully parsed
+     | 1683826581408 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581408 (RWo)
+     | 1683826581408 (RC)
+     | 1683826581409 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581409 Preamble is [198] bytes long
+     | 1683826581409 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581409 Still writing preamble
+     | 1683826581409 Wrote [198] bytes to the client
+     | 1683826581409 (W)
+     | 1683826581409 Writing back bytes
+     | 1683826581409 Wrote [16392] bytes to the client
+     | 1683826581409 (W)
+     | 1683826581409 Writing back bytes
+     | 1683826581409 Wrote [16392] bytes to the client
+     | 1683826581409 (W)
+     | 1683826581409 Writing back bytes
+     | 1683826581409 Wrote [2295] bytes to the client
+     | 1683826581409 (W)
+     | 1683826581409 Writing back bytes
+     | 1683826581409 Wrote [5] bytes to the client
+     | 1683826581409 (W)
+     | 1683826581409 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581409 (WKA)
+     | 1683826581410 Read [336] bytes from client
+     | 1683826581410 (R)
+     | 1683826581410 (RP)
+     | 1683826581410 Preamble successfully parsed
+     | 1683826581410 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581410 (RWo)
+     | 1683826581410 (RC)
+     | 1683826581410 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581410 Preamble is [198] bytes long
+     | 1683826581410 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581410 Still writing preamble
+     | 1683826581410 Wrote [198] bytes to the client
+     | 1683826581410 (W)
+     | 1683826581410 Writing back bytes
+     | 1683826581410 Wrote [16392] bytes to the client
+     | 1683826581410 (W)
+     | 1683826581410 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581410 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581410 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581410 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581410 Writing back bytes
+     | 1683826581410 Wrote [16392] bytes to the client
+     | 1683826581410 (W)
+     | 1683826581410 Writing back bytes
+     | 1683826581410 Wrote [2394] bytes to the client
+     | 1683826581410 (W)
+     | 1683826581410 Writing back bytes
+     | 1683826581410 Wrote [5] bytes to the client
+     | 1683826581410 (W)
+     | 1683826581410 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581410 (WKA)
+     | 1683826581411 Read [336] bytes from client
+     | 1683826581411 (R)
+     | 1683826581411 (RP)
+     | 1683826581411 Preamble successfully parsed
+     | 1683826581411 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581411 (RWo)
+     | 1683826581411 (RC)
+     | 1683826581411 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581411 Preamble is [198] bytes long
+     | 1683826581411 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581411 Still writing preamble
+     | 1683826581411 Wrote [198] bytes to the client
+     | 1683826581411 (W)
+     | 1683826581411 Writing back bytes
+     | 1683826581411 Wrote [16392] bytes to the client
+     | 1683826581411 (W)
+     | 1683826581411 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581411 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581411 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581411 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581411 Writing back bytes
+     | 1683826581411 Wrote [16392] bytes to the client
+     | 1683826581411 (W)
+     | 1683826581411 Writing back bytes
+     | 1683826581412 Wrote [2493] bytes to the client
+     | 1683826581412 (W)
+     | 1683826581412 Writing back bytes
+     | 1683826581412 Wrote [5] bytes to the client
+     | 1683826581412 (W)
+     | 1683826581412 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581412 (WKA)
+     | 1683826581412 Read [336] bytes from client
+     | 1683826581412 (R)
+     | 1683826581412 (RP)
+     | 1683826581412 Preamble successfully parsed
+     | 1683826581412 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581412 (RWo)
+     | 1683826581412 (RC)
+     | 1683826581413 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581413 Preamble is [198] bytes long
+     | 1683826581413 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581413 Still writing preamble
+     | 1683826581413 Wrote [198] bytes to the client
+     | 1683826581413 (W)
+     | 1683826581413 Writing back bytes
+     | 1683826581413 Wrote [16392] bytes to the client
+     | 1683826581413 (W)
+     | 1683826581413 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581413 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581413 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581413 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581413 Writing back bytes
+     | 1683826581413 Wrote [16392] bytes to the client
+     | 1683826581413 (W)
+     | 1683826581413 Writing back bytes
+     | 1683826581413 Wrote [2592] bytes to the client
+     | 1683826581413 (W)
+     | 1683826581413 Writing back bytes
+     | 1683826581413 Wrote [5] bytes to the client
+     | 1683826581413 (W)
+     | 1683826581413 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581413 (WKA)
+     | 1683826581413 Read [336] bytes from client
+     | 1683826581413 (R)
+     | 1683826581413 (RP)
+     | 1683826581413 Preamble successfully parsed
+     | 1683826581413 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581413 (RWo)
+     | 1683826581413 (RC)
+     | 1683826581414 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581414 Preamble is [198] bytes long
+     | 1683826581414 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581414 Still writing preamble
+     | 1683826581414 Wrote [198] bytes to the client
+     | 1683826581414 (W)
+     | 1683826581414 Writing back bytes
+     | 1683826581414 Wrote [16392] bytes to the client
+     | 1683826581414 (W)
+     | 1683826581414 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581414 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581414 Writing back bytes
+     | 1683826581414 Wrote [16392] bytes to the client
+     | 1683826581414 (W)
+     | 1683826581414 Writing back bytes
+     | 1683826581414 Wrote [2691] bytes to the client
+     | 1683826581414 (W)
+     | 1683826581414 Writing back bytes
+     | 1683826581414 Wrote [5] bytes to the client
+     | 1683826581414 (W)
+     | 1683826581414 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581414 (WKA)
+     | 1683826581414 Read [336] bytes from client
+     | 1683826581414 (R)
+     | 1683826581414 (RP)
+     | 1683826581414 Preamble successfully parsed
+     | 1683826581414 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581414 (RWo)
+     | 1683826581414 (RC)
+     | 1683826581415 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581415 Preamble is [198] bytes long
+     | 1683826581415 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581415 Still writing preamble
+     | 1683826581415 Wrote [198] bytes to the client
+     | 1683826581415 (W)
+     | 1683826581415 Writing back bytes
+     | 1683826581415 Wrote [16392] bytes to the client
+     | 1683826581415 (W)
+     | 1683826581415 Writing back bytes
+     | 1683826581415 Wrote [16392] bytes to the client
+     | 1683826581415 (W)
+     | 1683826581415 Writing back bytes
+     | 1683826581415 Wrote [2790] bytes to the client
+     | 1683826581415 (W)
+     | 1683826581415 Writing back bytes
+     | 1683826581415 Wrote [5] bytes to the client
+     | 1683826581415 (W)
+     | 1683826581415 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581415 (WKA)
+     | 1683826581416 Read [336] bytes from client
+     | 1683826581416 (R)
+     | 1683826581416 (RP)
+     | 1683826581416 Preamble successfully parsed
+     | 1683826581416 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581416 (RWo)
+     | 1683826581416 (RC)
+     | 1683826581417 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581417 Preamble is [198] bytes long
+     | 1683826581417 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581417 Still writing preamble
+     | 1683826581417 Wrote [198] bytes to the client
+     | 1683826581417 (W)
+     | 1683826581417 Writing back bytes
+     | 1683826581417 Wrote [16392] bytes to the client
+     | 1683826581417 (W)
+     | 1683826581417 Writing back bytes
+     | 1683826581417 Wrote [16392] bytes to the client
+     | 1683826581417 (W)
+     | 1683826581417 Writing back bytes
+     | 1683826581417 Wrote [2889] bytes to the client
+     | 1683826581417 (W)
+     | 1683826581417 Writing back bytes
+     | 1683826581417 Wrote [5] bytes to the client
+     | 1683826581417 (W)
+     | 1683826581417 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581417 (WKA)
+     | 1683826581417 Read [336] bytes from client
+     | 1683826581417 (R)
+     | 1683826581417 (RP)
+     | 1683826581417 Preamble successfully parsed
+     | 1683826581417 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581417 (RWo)
+     | 1683826581417 (RC)
+     | 1683826581418 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581418 Preamble is [198] bytes long
+     | 1683826581418 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581418 Still writing preamble
+     | 1683826581418 Wrote [198] bytes to the client
+     | 1683826581418 (W)
+     | 1683826581418 Writing back bytes
+     | 1683826581418 Wrote [16392] bytes to the client
+     | 1683826581418 (W)
+     | 1683826581418 Writing back bytes
+     | 1683826581418 Wrote [16392] bytes to the client
+     | 1683826581418 (W)
+     | 1683826581418 Writing back bytes
+     | 1683826581418 Wrote [2988] bytes to the client
+     | 1683826581418 (W)
+     | 1683826581418 Writing back bytes
+     | 1683826581418 Wrote [5] bytes to the client
+     | 1683826581418 (W)
+     | 1683826581418 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581418 (WKA)
+     | 1683826581418 Read [336] bytes from client
+     | 1683826581418 (R)
+     | 1683826581418 (RP)
+     | 1683826581418 Preamble successfully parsed
+     | 1683826581418 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581418 (RWo)
+     | 1683826581418 (RC)
+     | 1683826581419 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581419 Preamble is [198] bytes long
+     | 1683826581419 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581419 Still writing preamble
+     | 1683826581419 Wrote [198] bytes to the client
+     | 1683826581419 (W)
+     | 1683826581419 Writing back bytes
+     | 1683826581419 Wrote [16392] bytes to the client
+     | 1683826581419 (W)
+     | 1683826581419 Writing back bytes
+     | 1683826581419 Wrote [16392] bytes to the client
+     | 1683826581419 (W)
+     | 1683826581419 Writing back bytes
+     | 1683826581419 Wrote [3087] bytes to the client
+     | 1683826581419 (W)
+     | 1683826581419 Writing back bytes
+     | 1683826581419 Wrote [5] bytes to the client
+     | 1683826581419 (W)
+     | 1683826581419 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581419 (WKA)
+     | 1683826581420 Read [336] bytes from client
+     | 1683826581420 (R)
+     | 1683826581420 (RP)
+     | 1683826581420 Preamble successfully parsed
+     | 1683826581420 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581420 (RWo)
+     | 1683826581420 (RC)
+     | 1683826581420 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581420 Preamble is [198] bytes long
+     | 1683826581420 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581420 Still writing preamble
+     | 1683826581420 Wrote [198] bytes to the client
+     | 1683826581420 (W)
+     | 1683826581420 Writing back bytes
+     | 1683826581420 Wrote [16392] bytes to the client
+     | 1683826581420 (W)
+     | 1683826581420 Writing back bytes
+     | 1683826581420 Wrote [16392] bytes to the client
+     | 1683826581420 (W)
+     | 1683826581420 Writing back bytes
+     | 1683826581421 Wrote [3186] bytes to the client
+     | 1683826581421 (W)
+     | 1683826581421 Writing back bytes
+     | 1683826581421 Wrote [5] bytes to the client
+     | 1683826581421 (W)
+     | 1683826581421 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581421 (WKA)
+     | 1683826581421 Read [336] bytes from client
+     | 1683826581421 (R)
+     | 1683826581421 (RP)
+     | 1683826581421 Preamble successfully parsed
+     | 1683826581421 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581421 (RWo)
+     | 1683826581421 (RC)
+     | 1683826581422 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581422 Preamble is [198] bytes long
+     | 1683826581422 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581422 Still writing preamble
+     | 1683826581422 Wrote [198] bytes to the client
+     | 1683826581422 (W)
+     | 1683826581422 Writing back bytes
+     | 1683826581422 Wrote [16392] bytes to the client
+     | 1683826581422 (W)
+     | 1683826581422 Writing back bytes
+     | 1683826581422 Wrote [16392] bytes to the client
+     | 1683826581422 (W)
+     | 1683826581422 Writing back bytes
+     | 1683826581422 Wrote [3285] bytes to the client
+     | 1683826581422 (W)
+     | 1683826581422 Writing back bytes
+     | 1683826581422 Wrote [5] bytes to the client
+     | 1683826581422 (W)
+     | 1683826581422 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581422 (WKA)
+     | 1683826581422 Read [336] bytes from client
+     | 1683826581422 (R)
+     | 1683826581422 (RP)
+     | 1683826581422 Preamble successfully parsed
+     | 1683826581422 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581422 (RWo)
+     | 1683826581422 (RC)
+     | 1683826581425 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581425 Preamble is [198] bytes long
+     | 1683826581425 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581425 Still writing preamble
+     | 1683826581426 Wrote [198] bytes to the client
+     | 1683826581426 (W)
+     | 1683826581426 Writing back bytes
+     | 1683826581426 Wrote [16392] bytes to the client
+     | 1683826581426 (W)
+     | 1683826581426 Writing back bytes
+     | 1683826581426 Wrote [16392] bytes to the client
+     | 1683826581426 (W)
+     | 1683826581426 Writing back bytes
+     | 1683826581426 Wrote [3384] bytes to the client
+     | 1683826581426 (W)
+     | 1683826581426 Writing back bytes
+     | 1683826581426 Wrote [5] bytes to the client
+     | 1683826581426 (W)
+     | 1683826581426 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581426 (WKA)
+     | 1683826581426 Read [336] bytes from client
+     | 1683826581426 (R)
+     | 1683826581426 (RP)
+     | 1683826581426 Preamble successfully parsed
+     | 1683826581426 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581426 (RWo)
+     | 1683826581426 (RC)
+     | 1683826581427 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581427 Preamble is [198] bytes long
+     | 1683826581427 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581427 Still writing preamble
+     | 1683826581427 Wrote [198] bytes to the client
+     | 1683826581427 (W)
+     | 1683826581427 Writing back bytes
+     | 1683826581427 Wrote [16392] bytes to the client
+     | 1683826581427 (W)
+     | 1683826581427 Writing back bytes
+     | 1683826581427 Wrote [16392] bytes to the client
+     | 1683826581427 (W)
+     | 1683826581427 Writing back bytes
+     | 1683826581427 Wrote [3483] bytes to the client
+     | 1683826581427 (W)
+     | 1683826581427 Writing back bytes
+     | 1683826581427 Wrote [5] bytes to the client
+     | 1683826581427 (W)
+     | 1683826581427 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581427 (WKA)
+     | 1683826581427 Read [336] bytes from client
+     | 1683826581427 (R)
+     | 1683826581427 (RP)
+     | 1683826581427 Preamble successfully parsed
+     | 1683826581427 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581427 (RWo)
+     | 1683826581427 (RC)
+     | 1683826581428 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581428 Preamble is [198] bytes long
+     | 1683826581428 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581428 Still writing preamble
+     | 1683826581428 Wrote [198] bytes to the client
+     | 1683826581428 (W)
+     | 1683826581428 Writing back bytes
+     | 1683826581428 Wrote [16392] bytes to the client
+     | 1683826581428 (W)
+     | 1683826581428 Writing back bytes
+     | 1683826581428 Wrote [16392] bytes to the client
+     | 1683826581428 (W)
+     | 1683826581428 Writing back bytes
+     | 1683826581428 Wrote [3582] bytes to the client
+     | 1683826581428 (W)
+     | 1683826581428 Writing back bytes
+     | 1683826581428 Wrote [5] bytes to the client
+     | 1683826581428 (W)
+     | 1683826581428 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581428 (WKA)
+     | 1683826581429 Read [336] bytes from client
+     | 1683826581429 (R)
+     | 1683826581429 (RP)
+     | 1683826581429 Preamble successfully parsed
+     | 1683826581429 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581429 (RWo)
+     | 1683826581429 (RC)
+     | 1683826581430 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581430 Preamble is [198] bytes long
+     | 1683826581430 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581430 Still writing preamble
+     | 1683826581430 Wrote [198] bytes to the client
+     | 1683826581430 (W)
+     | 1683826581430 Writing back bytes
+     | 1683826581430 Wrote [16392] bytes to the client
+     | 1683826581430 (W)
+     | 1683826581430 Writing back bytes
+     | 1683826581430 Wrote [16392] bytes to the client
+     | 1683826581430 (W)
+     | 1683826581430 Writing back bytes
+     | 1683826581430 Wrote [3681] bytes to the client
+     | 1683826581430 (W)
+     | 1683826581430 Writing back bytes
+     | 1683826581430 Wrote [5] bytes to the client
+     | 1683826581430 (W)
+     | 1683826581430 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581430 (WKA)
+     | 1683826581430 Read [336] bytes from client
+     | 1683826581430 (R)
+     | 1683826581430 (RP)
+     | 1683826581430 Preamble successfully parsed
+     | 1683826581430 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581430 (RWo)
+     | 1683826581430 (RC)
+     | 1683826581431 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581431 Preamble is [198] bytes long
+     | 1683826581431 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581431 Still writing preamble
+     | 1683826581431 Wrote [198] bytes to the client
+     | 1683826581431 (W)
+     | 1683826581431 Writing back bytes
+     | 1683826581431 Wrote [16392] bytes to the client
+     | 1683826581431 (W)
+     | 1683826581431 Writing back bytes
+     | 1683826581431 Wrote [16392] bytes to the client
+     | 1683826581431 (W)
+     | 1683826581431 Writing back bytes
+     | 1683826581431 Wrote [3780] bytes to the client
+     | 1683826581431 (W)
+     | 1683826581431 Writing back bytes
+     | 1683826581431 Wrote [5] bytes to the client
+     | 1683826581431 (W)
+     | 1683826581431 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581431 (WKA)
+     | 1683826581432 Read [336] bytes from client
+     | 1683826581432 (R)
+     | 1683826581432 (RP)
+     | 1683826581432 Preamble successfully parsed
+     | 1683826581432 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581432 (RWo)
+     | 1683826581432 (RC)
+     | 1683826581432 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581432 Preamble is [198] bytes long
+     | 1683826581432 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581432 Still writing preamble
+     | 1683826581432 Wrote [198] bytes to the client
+     | 1683826581432 (W)
+     | 1683826581432 Writing back bytes
+     | 1683826581432 Wrote [16392] bytes to the client
+     | 1683826581432 (W)
+     | 1683826581432 Writing back bytes
+     | 1683826581432 Wrote [16392] bytes to the client
+     | 1683826581432 (W)
+     | 1683826581432 Writing back bytes
+     | 1683826581433 Wrote [3879] bytes to the client
+     | 1683826581433 (W)
+     | 1683826581433 Writing back bytes
+     | 1683826581433 Wrote [5] bytes to the client
+     | 1683826581433 (W)
+     | 1683826581433 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581433 (WKA)
+     | 1683826581433 Read [336] bytes from client
+     | 1683826581433 (R)
+     | 1683826581433 (RP)
+     | 1683826581433 Preamble successfully parsed
+     | 1683826581433 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581433 (RWo)
+     | 1683826581433 (RC)
+     | 1683826581434 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581434 Preamble is [198] bytes long
+     | 1683826581434 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581434 Still writing preamble
+     | 1683826581434 Wrote [198] bytes to the client
+     | 1683826581434 (W)
+     | 1683826581434 Writing back bytes
+     | 1683826581434 Wrote [16392] bytes to the client
+     | 1683826581434 (W)
+     | 1683826581434 Writing back bytes
+     | 1683826581434 Wrote [16392] bytes to the client
+     | 1683826581434 (W)
+     | 1683826581434 Writing back bytes
+     | 1683826581434 Wrote [3978] bytes to the client
+     | 1683826581434 (W)
+     | 1683826581434 Writing back bytes
+     | 1683826581434 Wrote [5] bytes to the client
+     | 1683826581434 (W)
+     | 1683826581434 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581434 (WKA)
+     | 1683826581434 Read [336] bytes from client
+     | 1683826581434 (R)
+     | 1683826581434 (RP)
+     | 1683826581434 Preamble successfully parsed
+     | 1683826581434 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581434 (RWo)
+     | 1683826581434 (RC)
+     | 1683826581435 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581435 Preamble is [198] bytes long
+     | 1683826581435 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581435 Still writing preamble
+     | 1683826581435 Wrote [198] bytes to the client
+     | 1683826581435 (W)
+     | 1683826581435 Writing back bytes
+     | 1683826581435 Wrote [16392] bytes to the client
+     | 1683826581435 (W)
+     | 1683826581435 Writing back bytes
+     | 1683826581435 Wrote [16392] bytes to the client
+     | 1683826581435 (W)
+     | 1683826581435 Writing back bytes
+     | 1683826581435 Wrote [4077] bytes to the client
+     | 1683826581435 (W)
+     | 1683826581435 Writing back bytes
+     | 1683826581435 Wrote [5] bytes to the client
+     | 1683826581435 (W)
+     | 1683826581435 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581435 (WKA)
+     | 1683826581436 Read [336] bytes from client
+     | 1683826581436 (R)
+     | 1683826581436 (RP)
+     | 1683826581436 Preamble successfully parsed
+     | 1683826581436 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581436 (RWo)
+     | 1683826581436 (RC)
+     | 1683826581436 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581436 Preamble is [198] bytes long
+     | 1683826581436 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581436 Still writing preamble
+     | 1683826581436 Wrote [198] bytes to the client
+     | 1683826581436 (W)
+     | 1683826581436 Writing back bytes
+     | 1683826581437 Wrote [16392] bytes to the client
+     | 1683826581437 (W)
+     | 1683826581437 Writing back bytes
+     | 1683826581437 Wrote [16392] bytes to the client
+     | 1683826581437 (W)
+     | 1683826581437 Writing back bytes
+     | 1683826581437 Wrote [4177] bytes to the client
+     | 1683826581437 (W)
+     | 1683826581437 Writing back bytes
+     | 1683826581437 Wrote [5] bytes to the client
+     | 1683826581437 (W)
+     | 1683826581437 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581437 (WKA)
+     | 1683826581437 Read [336] bytes from client
+     | 1683826581437 (R)
+     | 1683826581437 (RP)
+     | 1683826581437 Preamble successfully parsed
+     | 1683826581437 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581437 (RWo)
+     | 1683826581437 (RC)
+     | 1683826581438 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581438 Preamble is [198] bytes long
+     | 1683826581438 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581438 Still writing preamble
+     | 1683826581438 Wrote [198] bytes to the client
+     | 1683826581438 (W)
+     | 1683826581438 Writing back bytes
+     | 1683826581438 Wrote [16392] bytes to the client
+     | 1683826581438 (W)
+     | 1683826581438 Writing back bytes
+     | 1683826581438 Wrote [16392] bytes to the client
+     | 1683826581438 (W)
+     | 1683826581438 Writing back bytes
+     | 1683826581438 Wrote [4276] bytes to the client
+     | 1683826581438 (W)
+     | 1683826581438 Writing back bytes
+     | 1683826581438 Wrote [5] bytes to the client
+     | 1683826581438 (W)
+     | 1683826581438 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581438 (WKA)
+     | 1683826581438 Read [336] bytes from client
+     | 1683826581438 (R)
+     | 1683826581438 (RP)
+     | 1683826581438 Preamble successfully parsed
+     | 1683826581438 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581438 (RWo)
+     | 1683826581438 (RC)
+     | 1683826581439 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581439 Preamble is [198] bytes long
+     | 1683826581439 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581439 Still writing preamble
+     | 1683826581439 Wrote [198] bytes to the client
+     | 1683826581439 (W)
+     | 1683826581439 Writing back bytes
+     | 1683826581439 Wrote [16392] bytes to the client
+     | 1683826581439 (W)
+     | 1683826581439 Writing back bytes
+     | 1683826581439 Wrote [16392] bytes to the client
+     | 1683826581439 (W)
+     | 1683826581439 Writing back bytes
+     | 1683826581439 Wrote [4375] bytes to the client
+     | 1683826581439 (W)
+     | 1683826581439 Writing back bytes
+     | 1683826581439 Wrote [5] bytes to the client
+     | 1683826581439 (W)
+     | 1683826581439 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581439 (WKA)
+     | 1683826581440 Read [336] bytes from client
+     | 1683826581440 (R)
+     | 1683826581440 (RP)
+     | 1683826581440 Preamble successfully parsed
+     | 1683826581440 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581440 (RWo)
+     | 1683826581440 (RC)
+     | 1683826581440 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581440 Preamble is [198] bytes long
+     | 1683826581440 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581440 Still writing preamble
+     | 1683826581441 Wrote [198] bytes to the client
+     | 1683826581441 (W)
+     | 1683826581441 Writing back bytes
+     | 1683826581441 Wrote [16392] bytes to the client
+     | 1683826581441 (W)
+     | 1683826581441 Writing back bytes
+     | 1683826581441 Wrote [16392] bytes to the client
+     | 1683826581441 (W)
+     | 1683826581441 Writing back bytes
+     | 1683826581441 Wrote [4474] bytes to the client
+     | 1683826581441 (W)
+     | 1683826581441 Writing back bytes
+     | 1683826581441 Wrote [5] bytes to the client
+     | 1683826581441 (W)
+     | 1683826581441 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581441 (WKA)
+     | 1683826581441 Read [336] bytes from client
+     | 1683826581441 (R)
+     | 1683826581441 (RP)
+     | 1683826581441 Preamble successfully parsed
+     | 1683826581441 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581441 (RWo)
+     | 1683826581441 (RC)
+     | 1683826581442 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581442 Preamble is [198] bytes long
+     | 1683826581442 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581442 Still writing preamble
+     | 1683826581442 Wrote [198] bytes to the client
+     | 1683826581442 (W)
+     | 1683826581442 Writing back bytes
+     | 1683826581442 Wrote [16392] bytes to the client
+     | 1683826581442 (W)
+     | 1683826581442 Writing back bytes
+     | 1683826581442 Wrote [16392] bytes to the client
+     | 1683826581442 (W)
+     | 1683826581442 Writing back bytes
+     | 1683826581442 Wrote [4573] bytes to the client
+     | 1683826581442 (W)
+     | 1683826581442 Writing back bytes
+     | 1683826581442 Wrote [5] bytes to the client
+     | 1683826581442 (W)
+     | 1683826581442 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581442 (WKA)
+     | 1683826581442 Read [336] bytes from client
+     | 1683826581442 (R)
+     | 1683826581442 (RP)
+     | 1683826581442 Preamble successfully parsed
+     | 1683826581442 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581442 (RWo)
+     | 1683826581442 (RC)
+     | 1683826581443 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581443 Preamble is [198] bytes long
+     | 1683826581443 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581443 Still writing preamble
+     | 1683826581443 Wrote [198] bytes to the client
+     | 1683826581443 (W)
+     | 1683826581443 Writing back bytes
+     | 1683826581443 Wrote [16392] bytes to the client
+     | 1683826581443 (W)
+     | 1683826581443 Writing back bytes
+     | 1683826581443 Wrote [16392] bytes to the client
+     | 1683826581443 (W)
+     | 1683826581443 Writing back bytes
+     | 1683826581443 Wrote [4672] bytes to the client
+     | 1683826581443 (W)
+     | 1683826581443 Writing back bytes
+     | 1683826581443 Wrote [5] bytes to the client
+     | 1683826581443 (W)
+     | 1683826581443 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581443 (WKA)
+     | 1683826581444 Read [336] bytes from client
+     | 1683826581444 (R)
+     | 1683826581444 (RP)
+     | 1683826581444 Preamble successfully parsed
+     | 1683826581444 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581444 (RWo)
+     | 1683826581444 (RC)
+     | 1683826581445 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581445 Preamble is [198] bytes long
+     | 1683826581445 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581445 Still writing preamble
+     | 1683826581446 Wrote [198] bytes to the client
+     | 1683826581446 (W)
+     | 1683826581446 Writing back bytes
+     | 1683826581446 Wrote [16392] bytes to the client
+     | 1683826581446 (W)
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581446 Writing back bytes
+     | 1683826581446 Wrote [16392] bytes to the client
+     | 1683826581446 (W)
+     | 1683826581446 Writing back bytes
+     | 1683826581446 Wrote [4771] bytes to the client
+     | 1683826581446 (W)
+     | 1683826581446 Writing back bytes
+     | 1683826581446 Wrote [5] bytes to the client
+     | 1683826581446 (W)
+     | 1683826581446 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581446 (WKA)
+     | 1683826581446 Read [336] bytes from client
+     | 1683826581446 (R)
+     | 1683826581446 (RP)
+     | 1683826581446 Preamble successfully parsed
+     | 1683826581446 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581446 (RWo)
+     | 1683826581446 (RC)
+     | 1683826581447 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581447 Preamble is [198] bytes long
+     | 1683826581447 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581447 Still writing preamble
+     | 1683826581447 Wrote [198] bytes to the client
+     | 1683826581447 (W)
+     | 1683826581447 Writing back bytes
+     | 1683826581447 Wrote [16392] bytes to the client
+     | 1683826581447 (W)
+     | 1683826581447 Writing back bytes
+     | 1683826581447 Wrote [16392] bytes to the client
+     | 1683826581447 (W)
+     | 1683826581447 Writing back bytes
+     | 1683826581447 Wrote [4870] bytes to the client
+     | 1683826581447 (W)
+     | 1683826581447 Writing back bytes
+     | 1683826581447 Wrote [5] bytes to the client
+     | 1683826581447 (W)
+     | 1683826581447 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581447 (WKA)
+     | 1683826581447 Read [336] bytes from client
+     | 1683826581447 (R)
+     | 1683826581447 (RP)
+     | 1683826581447 Preamble successfully parsed
+     | 1683826581447 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581447 (RWo)
+     | 1683826581447 (RC)
+     | 1683826581448 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581448 Preamble is [198] bytes long
+     | 1683826581448 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581448 Still writing preamble
+     | 1683826581448 Wrote [198] bytes to the client
+     | 1683826581448 (W)
+     | 1683826581448 Writing back bytes
+     | 1683826581448 Wrote [16392] bytes to the client
+     | 1683826581448 (W)
+     | 1683826581448 Writing back bytes
+     | 1683826581448 Wrote [16392] bytes to the client
+     | 1683826581448 (W)
+     | 1683826581448 Writing back bytes
+     | 1683826581448 Wrote [4969] bytes to the client
+     | 1683826581448 (W)
+     | 1683826581448 Writing back bytes
+     | 1683826581448 Wrote [5] bytes to the client
+     | 1683826581448 (W)
+     | 1683826581448 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581448 (WKA)
+     | 1683826581449 Read [336] bytes from client
+     | 1683826581449 (R)
+     | 1683826581449 (RP)
+     | 1683826581449 Preamble successfully parsed
+     | 1683826581449 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581449 (RWo)
+     | 1683826581449 (RC)
+     | 1683826581450 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581450 Preamble is [198] bytes long
+     | 1683826581450 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581450 Still writing preamble
+     | 1683826581450 Wrote [198] bytes to the client
+     | 1683826581450 (W)
+     | 1683826581450 Writing back bytes
+     | 1683826581450 Wrote [16392] bytes to the client
+     | 1683826581450 (W)
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581450 Writing back bytes
+     | 1683826581450 Wrote [16392] bytes to the client
+     | 1683826581450 (W)
+     | 1683826581450 Writing back bytes
+     | 1683826581450 Wrote [5068] bytes to the client
+     | 1683826581450 (W)
+     | 1683826581450 Writing back bytes
+     | 1683826581450 Wrote [5] bytes to the client
+     | 1683826581450 (W)
+     | 1683826581450 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581450 (WKA)
+     | 1683826581450 Read [336] bytes from client
+     | 1683826581450 (R)
+     | 1683826581450 (RP)
+     | 1683826581450 Preamble successfully parsed
+     | 1683826581450 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581450 (RWo)
+     | 1683826581450 (RC)
+     | 1683826581451 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581451 Preamble is [198] bytes long
+     | 1683826581451 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581451 Still writing preamble
+     | 1683826581451 Wrote [198] bytes to the client
+     | 1683826581451 (W)
+     | 1683826581451 Writing back bytes
+     | 1683826581451 Wrote [16392] bytes to the client
+     | 1683826581451 (W)
+     | 1683826581451 Writing back bytes
+     | 1683826581451 Wrote [16392] bytes to the client
+     | 1683826581451 (W)
+     | 1683826581451 Writing back bytes
+     | 1683826581451 Wrote [5167] bytes to the client
+     | 1683826581451 (W)
+     | 1683826581451 Writing back bytes
+     | 1683826581451 Wrote [5] bytes to the client
+     | 1683826581451 (W)
+     | 1683826581451 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581451 (WKA)
+     | 1683826581451 Read [336] bytes from client
+     | 1683826581451 (R)
+     | 1683826581451 (RP)
+     | 1683826581451 Preamble successfully parsed
+     | 1683826581451 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581451 (RWo)
+     | 1683826581451 (RC)
+     | 1683826581452 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581452 Preamble is [198] bytes long
+     | 1683826581452 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581452 Still writing preamble
+     | 1683826581452 Wrote [198] bytes to the client
+     | 1683826581452 (W)
+     | 1683826581452 Writing back bytes
+     | 1683826581452 Wrote [16392] bytes to the client
+     | 1683826581452 (W)
+     | 1683826581452 Writing back bytes
+     | 1683826581452 Wrote [16392] bytes to the client
+     | 1683826581452 (W)
+     | 1683826581452 Writing back bytes
+     | 1683826581452 Wrote [5266] bytes to the client
+     | 1683826581452 (W)
+     | 1683826581452 Writing back bytes
+     | 1683826581452 Wrote [5] bytes to the client
+     | 1683826581452 (W)
+     | 1683826581452 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581452 (WKA)
+     | 1683826581453 Read [336] bytes from client
+     | 1683826581453 (R)
+     | 1683826581453 (RP)
+     | 1683826581453 Preamble successfully parsed
+     | 1683826581453 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581453 (RWo)
+     | 1683826581453 (RC)
+     | 1683826581453 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581454 Preamble is [198] bytes long
+     | 1683826581454 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581454 Still writing preamble
+     | 1683826581454 Wrote [198] bytes to the client
+     | 1683826581454 (W)
+     | 1683826581454 Writing back bytes
+     | 1683826581454 Wrote [16392] bytes to the client
+     | 1683826581454 (W)
+     | 1683826581454 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581454 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581454 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581454 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581454 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581454 Writing back bytes
+     | 1683826581454 Wrote [16392] bytes to the client
+     | 1683826581454 (W)
+     | 1683826581454 Writing back bytes
+     | 1683826581454 Wrote [5365] bytes to the client
+     | 1683826581454 (W)
+     | 1683826581454 Writing back bytes
+     | 1683826581454 Wrote [5] bytes to the client
+     | 1683826581454 (W)
+     | 1683826581454 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581454 (WKA)
+     | 1683826581454 Read [336] bytes from client
+     | 1683826581454 (R)
+     | 1683826581454 (RP)
+     | 1683826581454 Preamble successfully parsed
+     | 1683826581454 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581454 (RWo)
+     | 1683826581454 (RC)
+     | 1683826581455 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581455 Preamble is [198] bytes long
+     | 1683826581455 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581455 Still writing preamble
+     | 1683826581455 Wrote [198] bytes to the client
+     | 1683826581455 (W)
+     | 1683826581455 Writing back bytes
+     | 1683826581455 Wrote [16392] bytes to the client
+     | 1683826581455 (W)
+     | 1683826581455 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581455 Writing back bytes
+     | 1683826581455 Wrote [16392] bytes to the client
+     | 1683826581455 (W)
+     | 1683826581455 Writing back bytes
+     | 1683826581455 Wrote [5464] bytes to the client
+     | 1683826581455 (W)
+     | 1683826581455 Writing back bytes
+     | 1683826581455 Wrote [5] bytes to the client
+     | 1683826581455 (W)
+     | 1683826581455 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581455 (WKA)
+     | 1683826581455 Read [336] bytes from client
+     | 1683826581455 (R)
+     | 1683826581455 (RP)
+     | 1683826581455 Preamble successfully parsed
+     | 1683826581455 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581455 (RWo)
+     | 1683826581455 (RC)
+     | 1683826581456 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581456 Preamble is [198] bytes long
+     | 1683826581456 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581456 Still writing preamble
+     | 1683826581456 Wrote [198] bytes to the client
+     | 1683826581456 (W)
+     | 1683826581456 Writing back bytes
+     | 1683826581456 Wrote [16392] bytes to the client
+     | 1683826581456 (W)
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581456 Writing back bytes
+     | 1683826581456 Wrote [16392] bytes to the client
+     | 1683826581456 (W)
+     | 1683826581456 Writing back bytes
+     | 1683826581456 Wrote [5563] bytes to the client
+     | 1683826581456 (W)
+     | 1683826581456 Writing back bytes
+     | 1683826581456 Wrote [5] bytes to the client
+     | 1683826581456 (W)
+     | 1683826581456 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581456 (WKA)
+     | 1683826581456 Read [336] bytes from client
+     | 1683826581456 (R)
+     | 1683826581456 (RP)
+     | 1683826581457 Preamble successfully parsed
+     | 1683826581457 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581457 (RWo)
+     | 1683826581457 (RC)
+     | 1683826581457 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581457 Preamble is [198] bytes long
+     | 1683826581457 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581457 Still writing preamble
+     | 1683826581457 Wrote [198] bytes to the client
+     | 1683826581457 (W)
+     | 1683826581457 Writing back bytes
+     | 1683826581457 Wrote [16392] bytes to the client
+     | 1683826581457 (W)
+     | 1683826581457 Writing back bytes
+     | 1683826581457 Wrote [16392] bytes to the client
+     | 1683826581457 (W)
+     | 1683826581457 Writing back bytes
+     | 1683826581457 Wrote [5662] bytes to the client
+     | 1683826581457 (W)
+     | 1683826581457 Writing back bytes
+     | 1683826581457 Wrote [5] bytes to the client
+     | 1683826581457 (W)
+     | 1683826581457 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581457 (WKA)
+     | 1683826581457 Flipping a SelectionKey to Read because it wasn't in the right state
+     | 1683826581458 Read [336] bytes from client
+     | 1683826581458 (R)
+     | 1683826581458 (RP)
+     | 1683826581458 Preamble successfully parsed
+     | 1683826581458 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581458 (RWo)
+     | 1683826581458 (RC)
+     | 1683826581459 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581459 Preamble is [198] bytes long
+     | 1683826581459 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581459 Still writing preamble
+     | 1683826581459 Wrote [198] bytes to the client
+     | 1683826581459 (W)
+     | 1683826581459 Writing back bytes
+     | 1683826581459 Wrote [16392] bytes to the client
+     | 1683826581459 (W)
+     | 1683826581459 Writing back bytes
+     | 1683826581459 Wrote [16392] bytes to the client
+     | 1683826581459 (W)
+     | 1683826581459 Writing back bytes
+     | 1683826581459 Wrote [5761] bytes to the client
+     | 1683826581459 (W)
+     | 1683826581459 Writing back bytes
+     | 1683826581459 Wrote [5] bytes to the client
+     | 1683826581459 (W)
+     | 1683826581459 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581459 (WKA)
+     | 1683826581459 Read [336] bytes from client
+     | 1683826581459 (R)
+     | 1683826581459 (RP)
+     | 1683826581459 Preamble successfully parsed
+     | 1683826581459 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581459 (RWo)
+     | 1683826581459 (RC)
+     | 1683826581460 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581460 Preamble is [198] bytes long
+     | 1683826581460 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581460 Still writing preamble
+     | 1683826581460 Wrote [198] bytes to the client
+     | 1683826581460 (W)
+     | 1683826581460 Writing back bytes
+     | 1683826581460 Wrote [16392] bytes to the client
+     | 1683826581460 (W)
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581460 Writing back bytes
+     | 1683826581460 Wrote [16392] bytes to the client
+     | 1683826581460 (W)
+     | 1683826581460 Writing back bytes
+     | 1683826581460 Wrote [5860] bytes to the client
+     | 1683826581460 (W)
+     | 1683826581460 Writing back bytes
+     | 1683826581460 Wrote [5] bytes to the client
+     | 1683826581460 (W)
+     | 1683826581460 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581460 (WKA)
+     | 1683826581460 Read [336] bytes from client
+     | 1683826581460 (R)
+     | 1683826581460 (RP)
+     | 1683826581460 Preamble successfully parsed
+     | 1683826581460 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581460 (RWo)
+     | 1683826581460 (RC)
+     | 1683826581461 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581461 Preamble is [198] bytes long
+     | 1683826581461 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581461 Still writing preamble
+     | 1683826581461 Wrote [198] bytes to the client
+     | 1683826581461 (W)
+     | 1683826581461 Writing back bytes
+     | 1683826581461 Wrote [16392] bytes to the client
+     | 1683826581461 (W)
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581461 Writing back bytes
+     | 1683826581461 Wrote [16392] bytes to the client
+     | 1683826581461 (W)
+     | 1683826581461 Writing back bytes
+     | 1683826581461 Wrote [5959] bytes to the client
+     | 1683826581461 (W)
+     | 1683826581461 Writing back bytes
+     | 1683826581461 Wrote [5] bytes to the client
+     | 1683826581461 (W)
+     | 1683826581461 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581461 (WKA)
+     | 1683826581461 Read [336] bytes from client
+     | 1683826581461 (R)
+     | 1683826581461 (RP)
+     | 1683826581461 Preamble successfully parsed
+     | 1683826581461 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581461 (RWo)
+     | 1683826581461 (RC)
+     | 1683826581462 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581462 Preamble is [198] bytes long
+     | 1683826581462 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581462 Still writing preamble
+     | 1683826581462 Wrote [198] bytes to the client
+     | 1683826581462 (W)
+     | 1683826581462 Writing back bytes
+     | 1683826581462 Wrote [16392] bytes to the client
+     | 1683826581462 (W)
+     | 1683826581462 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581462 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581462 Writing back bytes
+     | 1683826581462 Wrote [16392] bytes to the client
+     | 1683826581462 (W)
+     | 1683826581462 Writing back bytes
+     | 1683826581462 Wrote [6058] bytes to the client
+     | 1683826581462 (W)
+     | 1683826581462 Writing back bytes
+     | 1683826581462 Wrote [5] bytes to the client
+     | 1683826581462 (W)
+     | 1683826581462 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581462 (WKA)
+     | 1683826581463 Read [336] bytes from client
+     | 1683826581463 (R)
+     | 1683826581463 (RP)
+     | 1683826581463 Preamble successfully parsed
+     | 1683826581463 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581463 (RWo)
+     | 1683826581463 (RC)
+     | 1683826581463 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581463 Preamble is [198] bytes long
+     | 1683826581463 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581463 Still writing preamble
+     | 1683826581463 Wrote [198] bytes to the client
+     | 1683826581463 (W)
+     | 1683826581463 Writing back bytes
+     | 1683826581463 Wrote [16392] bytes to the client
+     | 1683826581463 (W)
+     | 1683826581463 Writing back bytes
+     | 1683826581463 Wrote [16392] bytes to the client
+     | 1683826581463 (W)
+     | 1683826581463 Writing back bytes
+     | 1683826581463 Wrote [6157] bytes to the client
+     | 1683826581463 (W)
+     | 1683826581463 Writing back bytes
+     | 1683826581463 Wrote [5] bytes to the client
+     | 1683826581463 (W)
+     | 1683826581463 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581463 (WKA)
+     | 1683826581464 Read [336] bytes from client
+     | 1683826581464 (R)
+     | 1683826581464 (RP)
+     | 1683826581464 Preamble successfully parsed
+     | 1683826581464 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581464 (RWo)
+     | 1683826581464 (RC)
+     | 1683826581465 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581465 Preamble is [198] bytes long
+     | 1683826581465 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581465 Still writing preamble
+     | 1683826581465 Wrote [198] bytes to the client
+     | 1683826581465 (W)
+     | 1683826581465 Writing back bytes
+     | 1683826581465 Wrote [16392] bytes to the client
+     | 1683826581465 (W)
+     | 1683826581465 Writing back bytes
+     | 1683826581465 Wrote [16392] bytes to the client
+     | 1683826581465 (W)
+     | 1683826581465 Writing back bytes
+     | 1683826581465 Wrote [6256] bytes to the client
+     | 1683826581465 (W)
+     | 1683826581465 Writing back bytes
+     | 1683826581465 Wrote [5] bytes to the client
+     | 1683826581465 (W)
+     | 1683826581465 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581465 (WKA)
+     | 1683826581465 Read [336] bytes from client
+     | 1683826581465 (R)
+     | 1683826581465 (RP)
+     | 1683826581465 Preamble successfully parsed
+     | 1683826581465 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581465 (RWo)
+     | 1683826581465 (RC)
+     | 1683826581466 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581466 Preamble is [198] bytes long
+     | 1683826581466 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581466 Still writing preamble
+     | 1683826581466 Wrote [198] bytes to the client
+     | 1683826581466 (W)
+     | 1683826581466 Writing back bytes
+     | 1683826581466 Wrote [16392] bytes to the client
+     | 1683826581466 (W)
+     | 1683826581466 Writing back bytes
+     | 1683826581466 Wrote [16392] bytes to the client
+     | 1683826581466 (W)
+     | 1683826581466 Writing back bytes
+     | 1683826581466 Wrote [6355] bytes to the client
+     | 1683826581466 (W)
+     | 1683826581466 Writing back bytes
+     | 1683826581466 Wrote [5] bytes to the client
+     | 1683826581466 (W)
+     | 1683826581466 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581466 (WKA)
+     | 1683826581466 Read [336] bytes from client
+     | 1683826581466 (R)
+     | 1683826581466 (RP)
+     | 1683826581466 Preamble successfully parsed
+     | 1683826581466 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581466 (RWo)
+     | 1683826581467 (RC)
+     | 1683826581467 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581467 Preamble is [198] bytes long
+     | 1683826581467 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581467 Still writing preamble
+     | 1683826581467 Wrote [198] bytes to the client
+     | 1683826581467 (W)
+     | 1683826581467 Writing back bytes
+     | 1683826581467 Wrote [16392] bytes to the client
+     | 1683826581467 (W)
+     | 1683826581467 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581467 Writing back bytes
+     | 1683826581467 Wrote [16392] bytes to the client
+     | 1683826581467 (W)
+     | 1683826581467 Writing back bytes
+     | 1683826581467 Wrote [6454] bytes to the client
+     | 1683826581467 (W)
+     | 1683826581467 Writing back bytes
+     | 1683826581467 Wrote [5] bytes to the client
+     | 1683826581467 (W)
+     | 1683826581467 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581467 (WKA)
+     | 1683826581468 Read [336] bytes from client
+     | 1683826581468 (R)
+     | 1683826581468 (RP)
+     | 1683826581468 Preamble successfully parsed
+     | 1683826581468 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581468 (RWo)
+     | 1683826581468 (RC)
+     | 1683826581469 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581469 Preamble is [198] bytes long
+     | 1683826581469 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581469 Still writing preamble
+     | 1683826581469 Wrote [198] bytes to the client
+     | 1683826581469 (W)
+     | 1683826581469 Writing back bytes
+     | 1683826581469 Wrote [16392] bytes to the client
+     | 1683826581469 (W)
+     | 1683826581469 Writing back bytes
+     | 1683826581469 Wrote [16392] bytes to the client
+     | 1683826581469 (W)
+     | 1683826581469 Writing back bytes
+     | 1683826581469 Wrote [6553] bytes to the client
+     | 1683826581469 (W)
+     | 1683826581469 Writing back bytes
+     | 1683826581469 Wrote [5] bytes to the client
+     | 1683826581469 (W)
+     | 1683826581469 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581469 (WKA)
+     | 1683826581469 Read [336] bytes from client
+     | 1683826581469 (R)
+     | 1683826581469 (RP)
+     | 1683826581469 Preamble successfully parsed
+     | 1683826581469 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581469 (RWo)
+     | 1683826581469 (RC)
+     | 1683826581470 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581470 Preamble is [198] bytes long
+     | 1683826581470 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581470 Still writing preamble
+     | 1683826581470 Wrote [198] bytes to the client
+     | 1683826581470 (W)
+     | 1683826581470 Writing back bytes
+     | 1683826581470 Wrote [16392] bytes to the client
+     | 1683826581470 (W)
+     | 1683826581470 Writing back bytes
+     | 1683826581470 Wrote [16392] bytes to the client
+     | 1683826581470 (W)
+     | 1683826581470 Writing back bytes
+     | 1683826581470 Wrote [6652] bytes to the client
+     | 1683826581470 (W)
+     | 1683826581470 Writing back bytes
+     | 1683826581470 Wrote [5] bytes to the client
+     | 1683826581470 (W)
+     | 1683826581470 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581470 (WKA)
+     | 1683826581470 Read [336] bytes from client
+     | 1683826581470 (R)
+     | 1683826581470 (RP)
+     | 1683826581470 Preamble successfully parsed
+     | 1683826581470 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581470 (RWo)
+     | 1683826581470 (RC)
+     | 1683826581471 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581471 Preamble is [198] bytes long
+     | 1683826581471 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581471 Still writing preamble
+     | 1683826581471 Wrote [198] bytes to the client
+     | 1683826581471 (W)
+     | 1683826581471 Writing back bytes
+     | 1683826581471 Wrote [16392] bytes to the client
+     | 1683826581471 (W)
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581471 Writing back bytes
+     | 1683826581471 Wrote [16392] bytes to the client
+     | 1683826581471 (W)
+     | 1683826581471 Writing back bytes
+     | 1683826581471 Wrote [6751] bytes to the client
+     | 1683826581471 (W)
+     | 1683826581471 Writing back bytes
+     | 1683826581471 Wrote [5] bytes to the client
+     | 1683826581471 (W)
+     | 1683826581471 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581471 (WKA)
+     | 1683826581471 Read [336] bytes from client
+     | 1683826581471 (R)
+     | 1683826581471 (RP)
+     | 1683826581471 Preamble successfully parsed
+     | 1683826581471 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581471 (RWo)
+     | 1683826581472 (RC)
+     | 1683826581472 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581472 Preamble is [198] bytes long
+     | 1683826581472 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581472 Still writing preamble
+     | 1683826581472 Wrote [198] bytes to the client
+     | 1683826581472 (W)
+     | 1683826581472 Writing back bytes
+     | 1683826581472 Wrote [16392] bytes to the client
+     | 1683826581472 (W)
+     | 1683826581472 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581472 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581472 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581472 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581472 Writing back bytes
+     | 1683826581472 Wrote [16392] bytes to the client
+     | 1683826581472 (W)
+     | 1683826581472 Writing back bytes
+     | 1683826581472 Wrote [6850] bytes to the client
+     | 1683826581472 (W)
+     | 1683826581472 Writing back bytes
+     | 1683826581472 Wrote [5] bytes to the client
+     | 1683826581472 (W)
+     | 1683826581472 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581472 (WKA)
+     | 1683826581473 Read [336] bytes from client
+     | 1683826581473 (R)
+     | 1683826581473 (RP)
+     | 1683826581473 Preamble successfully parsed
+     | 1683826581473 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581473 (RWo)
+     | 1683826581473 (RC)
+     | 1683826581474 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581474 Preamble is [198] bytes long
+     | 1683826581474 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581474 Still writing preamble
+     | 1683826581474 Wrote [198] bytes to the client
+     | 1683826581474 (W)
+     | 1683826581474 Writing back bytes
+     | 1683826581474 Wrote [16392] bytes to the client
+     | 1683826581474 (W)
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581474 Writing back bytes
+     | 1683826581474 Wrote [16392] bytes to the client
+     | 1683826581474 (W)
+     | 1683826581474 Writing back bytes
+     | 1683826581474 Wrote [6949] bytes to the client
+     | 1683826581474 (W)
+     | 1683826581474 Writing back bytes
+     | 1683826581474 Wrote [5] bytes to the client
+     | 1683826581474 (W)
+     | 1683826581474 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581474 (WKA)
+     | 1683826581474 Read [336] bytes from client
+     | 1683826581474 (R)
+     | 1683826581474 (RP)
+     | 1683826581474 Preamble successfully parsed
+     | 1683826581474 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581474 (RWo)
+     | 1683826581474 (RC)
+     | 1683826581475 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581475 Preamble is [198] bytes long
+     | 1683826581475 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581475 Still writing preamble
+     | 1683826581475 Wrote [198] bytes to the client
+     | 1683826581475 (W)
+     | 1683826581475 Writing back bytes
+     | 1683826581475 Wrote [16392] bytes to the client
+     | 1683826581475 (W)
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581475 Writing back bytes
+     | 1683826581475 Wrote [16392] bytes to the client
+     | 1683826581475 (W)
+     | 1683826581475 Writing back bytes
+     | 1683826581475 Wrote [7048] bytes to the client
+     | 1683826581475 (W)
+     | 1683826581475 Writing back bytes
+     | 1683826581475 Wrote [5] bytes to the client
+     | 1683826581475 (W)
+     | 1683826581475 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581475 (WKA)
+     | 1683826581475 Read [336] bytes from client
+     | 1683826581475 (R)
+     | 1683826581475 (RP)
+     | 1683826581475 Preamble successfully parsed
+     | 1683826581475 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581475 (RWo)
+     | 1683826581475 (RC)
+     | 1683826581476 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581476 Preamble is [198] bytes long
+     | 1683826581476 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581476 Still writing preamble
+     | 1683826581476 Wrote [198] bytes to the client
+     | 1683826581476 (W)
+     | 1683826581476 Writing back bytes
+     | 1683826581476 Wrote [16392] bytes to the client
+     | 1683826581476 (W)
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581476 Writing back bytes
+     | 1683826581476 Wrote [16392] bytes to the client
+     | 1683826581476 (W)
+     | 1683826581476 Writing back bytes
+     | 1683826581476 Wrote [7147] bytes to the client
+     | 1683826581476 (W)
+     | 1683826581476 Writing back bytes
+     | 1683826581476 Wrote [5] bytes to the client
+     | 1683826581476 (W)
+     | 1683826581476 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581476 (WKA)
+     | 1683826581477 Read [336] bytes from client
+     | 1683826581477 (R)
+     | 1683826581477 (RP)
+     | 1683826581477 Preamble successfully parsed
+     | 1683826581477 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581477 (RWo)
+     | 1683826581477 (RC)
+     | 1683826581477 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581477 Preamble is [198] bytes long
+     | 1683826581477 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581477 Still writing preamble
+     | 1683826581477 Wrote [198] bytes to the client
+     | 1683826581477 (W)
+     | 1683826581477 Writing back bytes
+     | 1683826581477 Wrote [16392] bytes to the client
+     | 1683826581477 (W)
+     | 1683826581477 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581477 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581477 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581477 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581477 Writing back bytes
+     | 1683826581477 Wrote [16392] bytes to the client
+     | 1683826581477 (W)
+     | 1683826581477 Writing back bytes
+     | 1683826581477 Wrote [7246] bytes to the client
+     | 1683826581477 (W)
+     | 1683826581477 Writing back bytes
+     | 1683826581477 Wrote [5] bytes to the client
+     | 1683826581477 (W)
+     | 1683826581477 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581477 (WKA)
+     | 1683826581478 Read [336] bytes from client
+     | 1683826581478 (R)
+     | 1683826581478 (RP)
+     | 1683826581478 Preamble successfully parsed
+     | 1683826581478 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581478 (RWo)
+     | 1683826581478 (RC)
+     | 1683826581479 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581479 Preamble is [198] bytes long
+     | 1683826581479 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581479 Still writing preamble
+     | 1683826581479 Wrote [198] bytes to the client
+     | 1683826581479 (W)
+     | 1683826581479 Writing back bytes
+     | 1683826581479 Wrote [16392] bytes to the client
+     | 1683826581479 (W)
+     | 1683826581479 Writing back bytes
+     | 1683826581479 Wrote [16392] bytes to the client
+     | 1683826581479 (W)
+     | 1683826581479 Writing back bytes
+     | 1683826581479 Wrote [7345] bytes to the client
+     | 1683826581479 (W)
+     | 1683826581479 Writing back bytes
+     | 1683826581479 Wrote [5] bytes to the client
+     | 1683826581479 (W)
+     | 1683826581479 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581479 (WKA)
+     | 1683826581479 Read [336] bytes from client
+     | 1683826581479 (R)
+     | 1683826581479 (RP)
+     | 1683826581479 Preamble successfully parsed
+     | 1683826581479 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581479 (RWo)
+     | 1683826581479 (RC)
+     | 1683826581480 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581480 Preamble is [198] bytes long
+     | 1683826581480 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581480 Still writing preamble
+     | 1683826581480 Wrote [198] bytes to the client
+     | 1683826581480 (W)
+     | 1683826581480 Writing back bytes
+     | 1683826581480 Wrote [16392] bytes to the client
+     | 1683826581480 (W)
+     | 1683826581480 Writing back bytes
+     | 1683826581480 Wrote [16392] bytes to the client
+     | 1683826581480 (W)
+     | 1683826581480 Writing back bytes
+     | 1683826581480 Wrote [7444] bytes to the client
+     | 1683826581480 (W)
+     | 1683826581480 Writing back bytes
+     | 1683826581480 Wrote [5] bytes to the client
+     | 1683826581480 (W)
+     | 1683826581480 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581480 (WKA)
+     | 1683826581481 Read [336] bytes from client
+     | 1683826581481 (R)
+     | 1683826581481 (RP)
+     | 1683826581481 Preamble successfully parsed
+     | 1683826581481 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581481 (RWo)
+     | 1683826581481 (RC)
+     | 1683826581481 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581481 Preamble is [198] bytes long
+     | 1683826581481 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581481 Still writing preamble
+     | 1683826581481 Wrote [198] bytes to the client
+     | 1683826581481 (W)
+     | 1683826581481 Writing back bytes
+     | 1683826581481 Wrote [16392] bytes to the client
+     | 1683826581481 (W)
+     | 1683826581481 Writing back bytes
+     | 1683826581481 Wrote [16392] bytes to the client
+     | 1683826581481 (W)
+     | 1683826581481 Writing back bytes
+     | 1683826581481 Wrote [7543] bytes to the client
+     | 1683826581481 (W)
+     | 1683826581481 Writing back bytes
+     | 1683826581481 Wrote [5] bytes to the client
+     | 1683826581481 (W)
+     | 1683826581481 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581481 (WKA)
+     | 1683826581482 Read [336] bytes from client
+     | 1683826581482 (R)
+     | 1683826581482 (RP)
+     | 1683826581482 Preamble successfully parsed
+     | 1683826581482 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581482 (RWo)
+     | 1683826581482 (RC)
+     | 1683826581482 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581483 Preamble is [198] bytes long
+     | 1683826581483 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581483 Still writing preamble
+     | 1683826581483 Wrote [198] bytes to the client
+     | 1683826581483 (W)
+     | 1683826581483 Writing back bytes
+     | 1683826581483 Wrote [16392] bytes to the client
+     | 1683826581483 (W)
+     | 1683826581483 Writing back bytes
+     | 1683826581483 Wrote [16392] bytes to the client
+     | 1683826581483 (W)
+     | 1683826581483 Writing back bytes
+     | 1683826581483 Wrote [7642] bytes to the client
+     | 1683826581483 (W)
+     | 1683826581483 Writing back bytes
+     | 1683826581483 Wrote [5] bytes to the client
+     | 1683826581483 (W)
+     | 1683826581483 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581483 (WKA)
+     | 1683826581483 Read [336] bytes from client
+     | 1683826581483 (R)
+     | 1683826581483 (RP)
+     | 1683826581483 Preamble successfully parsed
+     | 1683826581483 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581483 (RWo)
+     | 1683826581483 (RC)
+     | 1683826581484 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581484 Preamble is [198] bytes long
+     | 1683826581484 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581484 Still writing preamble
+     | 1683826581484 Wrote [198] bytes to the client
+     | 1683826581484 (W)
+     | 1683826581484 Writing back bytes
+     | 1683826581484 Wrote [16392] bytes to the client
+     | 1683826581484 (W)
+     | 1683826581484 Writing back bytes
+     | 1683826581484 Wrote [16392] bytes to the client
+     | 1683826581484 (W)
+     | 1683826581484 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581484 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581484 Writing back bytes
+     | 1683826581484 Wrote [7741] bytes to the client
+     | 1683826581484 (W)
+     | 1683826581484 Writing back bytes
+     | 1683826581484 Wrote [5] bytes to the client
+     | 1683826581484 (W)
+     | 1683826581484 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581484 (WKA)
+     | 1683826581484 Read [336] bytes from client
+     | 1683826581484 (R)
+     | 1683826581484 (RP)
+     | 1683826581484 Preamble successfully parsed
+     | 1683826581484 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581484 (RWo)
+     | 1683826581484 (RC)
+     | 1683826581485 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581485 Preamble is [198] bytes long
+     | 1683826581485 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581485 Still writing preamble
+     | 1683826581485 Wrote [198] bytes to the client
+     | 1683826581485 (W)
+     | 1683826581485 Writing back bytes
+     | 1683826581485 Wrote [16392] bytes to the client
+     | 1683826581485 (W)
+     | 1683826581485 Writing back bytes
+     | 1683826581485 Wrote [16392] bytes to the client
+     | 1683826581485 (W)
+     | 1683826581485 Writing back bytes
+     | 1683826581485 Wrote [7840] bytes to the client
+     | 1683826581485 (W)
+     | 1683826581485 Writing back bytes
+     | 1683826581485 Wrote [5] bytes to the client
+     | 1683826581485 (W)
+     | 1683826581485 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581485 (WKA)
+     | 1683826581486 Read [336] bytes from client
+     | 1683826581486 (R)
+     | 1683826581486 (RP)
+     | 1683826581486 Preamble successfully parsed
+     | 1683826581486 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581486 (RWo)
+     | 1683826581486 (RC)
+     | 1683826581487 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581487 Preamble is [198] bytes long
+     | 1683826581487 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581487 Still writing preamble
+     | 1683826581487 Wrote [198] bytes to the client
+     | 1683826581487 (W)
+     | 1683826581487 Writing back bytes
+     | 1683826581487 Wrote [16392] bytes to the client
+     | 1683826581487 (W)
+     | 1683826581487 Writing back bytes
+     | 1683826581487 Wrote [16392] bytes to the client
+     | 1683826581487 (W)
+     | 1683826581487 Writing back bytes
+     | 1683826581487 Wrote [7939] bytes to the client
+     | 1683826581487 (W)
+     | 1683826581487 Writing back bytes
+     | 1683826581487 Wrote [5] bytes to the client
+     | 1683826581487 (W)
+     | 1683826581487 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581487 (WKA)
+     | 1683826581487 Read [336] bytes from client
+     | 1683826581487 (R)
+     | 1683826581487 (RP)
+     | 1683826581487 Preamble successfully parsed
+     | 1683826581487 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581487 (RWo)
+     | 1683826581487 (RC)
+     | 1683826581488 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581488 Preamble is [198] bytes long
+     | 1683826581488 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581488 Still writing preamble
+     | 1683826581488 Wrote [198] bytes to the client
+     | 1683826581488 (W)
+     | 1683826581488 Writing back bytes
+     | 1683826581488 Wrote [16392] bytes to the client
+     | 1683826581488 (W)
+     | 1683826581488 Writing back bytes
+     | 1683826581488 Wrote [16392] bytes to the client
+     | 1683826581488 (W)
+     | 1683826581488 Writing back bytes
+     | 1683826581488 Wrote [8038] bytes to the client
+     | 1683826581488 (W)
+     | 1683826581488 Writing back bytes
+     | 1683826581488 Wrote [5] bytes to the client
+     | 1683826581488 (W)
+     | 1683826581488 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581488 (WKA)
+     | 1683826581489 Read [336] bytes from client
+     | 1683826581489 (R)
+     | 1683826581489 (RP)
+     | 1683826581489 Preamble successfully parsed
+     | 1683826581489 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581489 (RWo)
+     | 1683826581489 (RC)
+     | 1683826581489 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581489 Preamble is [198] bytes long
+     | 1683826581489 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581489 Still writing preamble
+     | 1683826581489 Wrote [198] bytes to the client
+     | 1683826581489 (W)
+     | 1683826581489 Writing back bytes
+     | 1683826581489 Wrote [16392] bytes to the client
+     | 1683826581489 (W)
+     | 1683826581489 Writing back bytes
+     | 1683826581490 Wrote [16392] bytes to the client
+     | 1683826581490 (W)
+     | 1683826581490 Writing back bytes
+     | 1683826581490 Wrote [8137] bytes to the client
+     | 1683826581490 (W)
+     | 1683826581490 Writing back bytes
+     | 1683826581490 Wrote [5] bytes to the client
+     | 1683826581490 (W)
+     | 1683826581490 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581490 (WKA)
+     | 1683826581490 Read [336] bytes from client
+     | 1683826581490 (R)
+     | 1683826581490 (RP)
+     | 1683826581490 Preamble successfully parsed
+     | 1683826581490 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581490 (RWo)
+     | 1683826581490 (RC)
+     | 1683826581491 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581491 Preamble is [198] bytes long
+     | 1683826581491 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581491 Still writing preamble
+     | 1683826581491 Wrote [198] bytes to the client
+     | 1683826581491 (W)
+     | 1683826581491 Writing back bytes
+     | 1683826581491 Wrote [16392] bytes to the client
+     | 1683826581491 (W)
+     | 1683826581491 Writing back bytes
+     | 1683826581491 Wrote [16392] bytes to the client
+     | 1683826581491 (W)
+     | 1683826581491 Writing back bytes
+     | 1683826581491 Wrote [8236] bytes to the client
+     | 1683826581491 (W)
+     | 1683826581491 Writing back bytes
+     | 1683826581491 Wrote [5] bytes to the client
+     | 1683826581491 (W)
+     | 1683826581491 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581491 (WKA)
+     | 1683826581491 Read [336] bytes from client
+     | 1683826581491 (R)
+     | 1683826581491 (RP)
+     | 1683826581491 Preamble successfully parsed
+     | 1683826581491 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581491 (RWo)
+     | 1683826581491 (RC)
+     | 1683826581492 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581492 Preamble is [198] bytes long
+     | 1683826581492 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581492 Still writing preamble
+     | 1683826581492 Wrote [198] bytes to the client
+     | 1683826581492 (W)
+     | 1683826581492 Writing back bytes
+     | 1683826581492 Wrote [16392] bytes to the client
+     | 1683826581492 (W)
+     | 1683826581492 Writing back bytes
+     | 1683826581492 Wrote [16392] bytes to the client
+     | 1683826581492 (W)
+     | 1683826581492 Writing back bytes
+     | 1683826581492 Wrote [8335] bytes to the client
+     | 1683826581492 (W)
+     | 1683826581492 Writing back bytes
+     | 1683826581492 Wrote [5] bytes to the client
+     | 1683826581492 (W)
+     | 1683826581492 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581492 (WKA)
+     | 1683826581492 Read [336] bytes from client
+     | 1683826581492 (R)
+     | 1683826581492 (RP)
+     | 1683826581492 Preamble successfully parsed
+     | 1683826581492 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581492 (RWo)
+     | 1683826581492 (RC)
+     | 1683826581493 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581493 Preamble is [198] bytes long
+     | 1683826581493 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581493 Still writing preamble
+     | 1683826581493 Wrote [198] bytes to the client
+     | 1683826581493 (W)
+     | 1683826581493 Writing back bytes
+     | 1683826581493 Wrote [16392] bytes to the client
+     | 1683826581493 (W)
+     | 1683826581493 Writing back bytes
+     | 1683826581493 Wrote [16392] bytes to the client
+     | 1683826581493 (W)
+     | 1683826581493 Writing back bytes
+     | 1683826581493 Wrote [8434] bytes to the client
+     | 1683826581493 (W)
+     | 1683826581493 Writing back bytes
+     | 1683826581493 Wrote [5] bytes to the client
+     | 1683826581493 (W)
+     | 1683826581493 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581493 (WKA)
+     | 1683826581493 Read [336] bytes from client
+     | 1683826581493 (R)
+     | 1683826581493 (RP)
+     | 1683826581493 Preamble successfully parsed
+     | 1683826581493 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581493 (RWo)
+     | 1683826581493 (RC)
+     | 1683826581494 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581494 Preamble is [198] bytes long
+     | 1683826581494 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581494 Still writing preamble
+     | 1683826581494 Wrote [198] bytes to the client
+     | 1683826581494 (W)
+     | 1683826581494 Writing back bytes
+     | 1683826581494 Wrote [16392] bytes to the client
+     | 1683826581494 (W)
+     | 1683826581494 Writing back bytes
+     | 1683826581494 Wrote [16392] bytes to the client
+     | 1683826581494 (W)
+     | 1683826581494 Writing back bytes
+     | 1683826581494 Wrote [8533] bytes to the client
+     | 1683826581494 (W)
+     | 1683826581494 Writing back bytes
+     | 1683826581494 Wrote [5] bytes to the client
+     | 1683826581494 (W)
+     | 1683826581494 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581494 (WKA)
+     | 1683826581494 Read [336] bytes from client
+     | 1683826581494 (R)
+     | 1683826581494 (RP)
+     | 1683826581494 Preamble successfully parsed
+     | 1683826581494 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581494 (RWo)
+     | 1683826581494 (RC)
+     | 1683826581495 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581495 Preamble is [198] bytes long
+     | 1683826581495 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581495 Still writing preamble
+     | 1683826581495 Wrote [198] bytes to the client
+     | 1683826581495 (W)
+     | 1683826581495 Writing back bytes
+     | 1683826581495 Wrote [16392] bytes to the client
+     | 1683826581495 (W)
+     | 1683826581495 Writing back bytes
+     | 1683826581495 Wrote [16392] bytes to the client
+     | 1683826581495 (W)
+     | 1683826581495 Writing back bytes
+     | 1683826581495 Wrote [8632] bytes to the client
+     | 1683826581495 (W)
+     | 1683826581495 Writing back bytes
+     | 1683826581495 Wrote [5] bytes to the client
+     | 1683826581495 (W)
+     | 1683826581495 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581495 (WKA)
+     | 1683826581495 Read [336] bytes from client
+     | 1683826581495 (R)
+     | 1683826581495 (RP)
+     | 1683826581495 Preamble successfully parsed
+     | 1683826581495 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581495 (RWo)
+     | 1683826581495 (RC)
+     | 1683826581496 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581496 Preamble is [198] bytes long
+     | 1683826581496 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581496 Still writing preamble
+     | 1683826581496 Wrote [198] bytes to the client
+     | 1683826581496 (W)
+     | 1683826581496 Writing back bytes
+     | 1683826581496 Wrote [16392] bytes to the client
+     | 1683826581496 (W)
+     | 1683826581496 Writing back bytes
+     | 1683826581496 Wrote [16392] bytes to the client
+     | 1683826581496 (W)
+     | 1683826581496 Writing back bytes
+     | 1683826581496 Wrote [8731] bytes to the client
+     | 1683826581496 (W)
+     | 1683826581496 Writing back bytes
+     | 1683826581496 Wrote [5] bytes to the client
+     | 1683826581496 (W)
+     | 1683826581496 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581496 (WKA)
+     | 1683826581497 Read [336] bytes from client
+     | 1683826581497 (R)
+     | 1683826581497 (RP)
+     | 1683826581497 Preamble successfully parsed
+     | 1683826581497 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581497 (RWo)
+     | 1683826581497 (RC)
+     | 1683826581497 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581497 Preamble is [198] bytes long
+     | 1683826581497 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581497 Still writing preamble
+     | 1683826581497 Wrote [198] bytes to the client
+     | 1683826581497 (W)
+     | 1683826581497 Writing back bytes
+     | 1683826581497 Wrote [16392] bytes to the client
+     | 1683826581497 (W)
+     | 1683826581497 Writing back bytes
+     | 1683826581497 Wrote [16392] bytes to the client
+     | 1683826581497 (W)
+     | 1683826581497 Writing back bytes
+     | 1683826581497 Wrote [8830] bytes to the client
+     | 1683826581497 (W)
+     | 1683826581497 Writing back bytes
+     | 1683826581497 Wrote [5] bytes to the client
+     | 1683826581497 (W)
+     | 1683826581497 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581497 (WKA)
+     | 1683826581498 Read [336] bytes from client
+     | 1683826581498 (R)
+     | 1683826581498 (RP)
+     | 1683826581498 Preamble successfully parsed
+     | 1683826581498 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581498 (RWo)
+     | 1683826581498 (RC)
+     | 1683826581499 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581499 Preamble is [198] bytes long
+     | 1683826581499 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581499 Still writing preamble
+     | 1683826581499 Wrote [198] bytes to the client
+     | 1683826581499 (W)
+     | 1683826581499 Writing back bytes
+     | 1683826581499 Wrote [16392] bytes to the client
+     | 1683826581499 (W)
+     | 1683826581499 Writing back bytes
+     | 1683826581499 Wrote [16392] bytes to the client
+     | 1683826581499 (W)
+     | 1683826581499 Writing back bytes
+     | 1683826581499 Wrote [8929] bytes to the client
+     | 1683826581499 (W)
+     | 1683826581499 Writing back bytes
+     | 1683826581499 Wrote [5] bytes to the client
+     | 1683826581499 (W)
+     | 1683826581499 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581499 (WKA)
+     | 1683826581499 Read [336] bytes from client
+     | 1683826581499 (R)
+     | 1683826581499 (RP)
+     | 1683826581499 Preamble successfully parsed
+     | 1683826581499 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581499 (RWo)
+     | 1683826581499 (RC)
+     | 1683826581500 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581500 Preamble is [198] bytes long
+     | 1683826581500 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581500 Still writing preamble
+     | 1683826581500 Wrote [198] bytes to the client
+     | 1683826581500 (W)
+     | 1683826581500 Writing back bytes
+     | 1683826581500 Wrote [16392] bytes to the client
+     | 1683826581500 (W)
+     | 1683826581500 Writing back bytes
+     | 1683826581500 Wrote [16392] bytes to the client
+     | 1683826581500 (W)
+     | 1683826581500 Writing back bytes
+     | 1683826581500 Wrote [9028] bytes to the client
+     | 1683826581500 (W)
+     | 1683826581500 Writing back bytes
+     | 1683826581500 Wrote [5] bytes to the client
+     | 1683826581500 (W)
+     | 1683826581500 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581500 (WKA)
+     | 1683826581501 Read [336] bytes from client
+     | 1683826581501 (R)
+     | 1683826581501 (RP)
+     | 1683826581501 Preamble successfully parsed
+     | 1683826581501 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581501 (RWo)
+     | 1683826581501 (RC)
+     | 1683826581502 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581502 Preamble is [198] bytes long
+     | 1683826581502 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581502 Still writing preamble
+     | 1683826581502 Wrote [198] bytes to the client
+     | 1683826581502 (W)
+     | 1683826581502 Writing back bytes
+     | 1683826581502 Wrote [16392] bytes to the client
+     | 1683826581502 (W)
+     | 1683826581502 Writing back bytes
+     | 1683826581502 Wrote [16392] bytes to the client
+     | 1683826581502 (W)
+     | 1683826581502 Writing back bytes
+     | 1683826581502 Wrote [9127] bytes to the client
+     | 1683826581502 (W)
+     | 1683826581502 Writing back bytes
+     | 1683826581502 Wrote [5] bytes to the client
+     | 1683826581502 (W)
+     | 1683826581502 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581502 (WKA)
+     | 1683826581502 Read [336] bytes from client
+     | 1683826581502 (R)
+     | 1683826581502 (RP)
+     | 1683826581502 Preamble successfully parsed
+     | 1683826581502 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581502 (RWo)
+     | 1683826581502 (RC)
+     | 1683826581503 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581503 Preamble is [198] bytes long
+     | 1683826581503 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581503 Still writing preamble
+     | 1683826581503 Wrote [198] bytes to the client
+     | 1683826581503 (W)
+     | 1683826581503 Writing back bytes
+     | 1683826581503 Wrote [16392] bytes to the client
+     | 1683826581503 (W)
+     | 1683826581503 Writing back bytes
+     | 1683826581503 Wrote [16392] bytes to the client
+     | 1683826581503 (W)
+     | 1683826581503 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581503 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581503 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581503 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581503 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581503 Writing back bytes
+     | 1683826581503 Wrote [9226] bytes to the client
+     | 1683826581503 (W)
+     | 1683826581503 Writing back bytes
+     | 1683826581503 Wrote [5] bytes to the client
+     | 1683826581503 (W)
+     | 1683826581503 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581503 (WKA)
+     | 1683826581503 Read [336] bytes from client
+     | 1683826581503 (R)
+     | 1683826581503 (RP)
+     | 1683826581503 Preamble successfully parsed
+     | 1683826581503 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581503 (RWo)
+     | 1683826581503 (RC)
+     | 1683826581504 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581504 Preamble is [198] bytes long
+     | 1683826581504 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581504 Still writing preamble
+     | 1683826581504 Wrote [198] bytes to the client
+     | 1683826581504 (W)
+     | 1683826581504 Writing back bytes
+     | 1683826581504 Wrote [16392] bytes to the client
+     | 1683826581504 (W)
+     | 1683826581504 Writing back bytes
+     | 1683826581504 Wrote [16392] bytes to the client
+     | 1683826581504 (W)
+     | 1683826581504 Writing back bytes
+     | 1683826581504 Wrote [9325] bytes to the client
+     | 1683826581504 (W)
+     | 1683826581504 Writing back bytes
+     | 1683826581504 Wrote [5] bytes to the client
+     | 1683826581504 (W)
+     | 1683826581504 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581504 (WKA)
+     | 1683826581504 Read [336] bytes from client
+     | 1683826581504 (R)
+     | 1683826581504 (RP)
+     | 1683826581504 Preamble successfully parsed
+     | 1683826581504 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581504 (RWo)
+     | 1683826581504 (RC)
+     | 1683826581505 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581505 Preamble is [198] bytes long
+     | 1683826581505 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581505 Still writing preamble
+     | 1683826581505 Wrote [198] bytes to the client
+     | 1683826581505 (W)
+     | 1683826581505 Writing back bytes
+     | 1683826581505 Wrote [16392] bytes to the client
+     | 1683826581505 (W)
+     | 1683826581505 Writing back bytes
+     | 1683826581505 Wrote [16392] bytes to the client
+     | 1683826581505 (W)
+     | 1683826581505 Writing back bytes
+     | 1683826581505 Wrote [9424] bytes to the client
+     | 1683826581505 (W)
+     | 1683826581505 Writing back bytes
+     | 1683826581505 Wrote [5] bytes to the client
+     | 1683826581505 (W)
+     | 1683826581505 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581505 (WKA)
+     | 1683826581506 Read [336] bytes from client
+     | 1683826581506 (R)
+     | 1683826581506 (RP)
+     | 1683826581506 Preamble successfully parsed
+     | 1683826581506 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581506 (RWo)
+     | 1683826581506 (RC)
+     | 1683826581506 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581506 Preamble is [198] bytes long
+     | 1683826581506 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581506 Still writing preamble
+     | 1683826581506 Wrote [198] bytes to the client
+     | 1683826581506 (W)
+     | 1683826581506 Writing back bytes
+     | 1683826581506 Wrote [16392] bytes to the client
+     | 1683826581506 (W)
+     | 1683826581506 Writing back bytes
+     | 1683826581506 Wrote [16392] bytes to the client
+     | 1683826581506 (W)
+     | 1683826581506 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581506 Writing back bytes
+     | 1683826581506 Wrote [9523] bytes to the client
+     | 1683826581506 (W)
+     | 1683826581506 Writing back bytes
+     | 1683826581506 Wrote [5] bytes to the client
+     | 1683826581506 (W)
+     | 1683826581506 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581506 (WKA)
+     | 1683826581507 Read [336] bytes from client
+     | 1683826581507 (R)
+     | 1683826581507 (RP)
+     | 1683826581507 Preamble successfully parsed
+     | 1683826581507 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581507 (RWo)
+     | 1683826581507 (RC)
+     | 1683826581508 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581508 Preamble is [198] bytes long
+     | 1683826581508 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581508 Still writing preamble
+     | 1683826581508 Wrote [198] bytes to the client
+     | 1683826581508 (W)
+     | 1683826581508 Writing back bytes
+     | 1683826581508 Wrote [16392] bytes to the client
+     | 1683826581508 (W)
+     | 1683826581508 Writing back bytes
+     | 1683826581508 Wrote [16392] bytes to the client
+     | 1683826581508 (W)
+     | 1683826581508 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581508 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581508 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581508 Writing back bytes
+     | 1683826581508 Wrote [9622] bytes to the client
+     | 1683826581508 (W)
+     | 1683826581508 Writing back bytes
+     | 1683826581508 Wrote [5] bytes to the client
+     | 1683826581508 (W)
+     | 1683826581508 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581508 (WKA)
+     | 1683826581508 Read [336] bytes from client
+     | 1683826581508 (R)
+     | 1683826581508 (RP)
+     | 1683826581508 Preamble successfully parsed
+     | 1683826581508 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581508 (RWo)
+     | 1683826581508 (RC)
+     | 1683826581509 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581509 Preamble is [198] bytes long
+     | 1683826581509 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581509 Still writing preamble
+     | 1683826581509 Wrote [198] bytes to the client
+     | 1683826581509 (W)
+     | 1683826581509 Writing back bytes
+     | 1683826581509 Wrote [16392] bytes to the client
+     | 1683826581509 (W)
+     | 1683826581509 Writing back bytes
+     | 1683826581509 Wrote [16392] bytes to the client
+     | 1683826581509 (W)
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581509 Writing back bytes
+     | 1683826581509 Wrote [9721] bytes to the client
+     | 1683826581509 (W)
+     | 1683826581509 Writing back bytes
+     | 1683826581509 Wrote [5] bytes to the client
+     | 1683826581509 (W)
+     | 1683826581509 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581509 (WKA)
+     | 1683826581509 Read [336] bytes from client
+     | 1683826581509 (R)
+     | 1683826581509 (RP)
+     | 1683826581509 Preamble successfully parsed
+     | 1683826581509 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581509 (RWo)
+     | 1683826581509 (RC)
+     | 1683826581510 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581510 Preamble is [198] bytes long
+     | 1683826581510 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581510 Still writing preamble
+     | 1683826581510 Wrote [198] bytes to the client
+     | 1683826581510 (W)
+     | 1683826581510 Writing back bytes
+     | 1683826581510 Wrote [16392] bytes to the client
+     | 1683826581510 (W)
+     | 1683826581510 Writing back bytes
+     | 1683826581510 Wrote [16392] bytes to the client
+     | 1683826581510 (W)
+     | 1683826581510 Writing back bytes
+     | 1683826581510 Wrote [9820] bytes to the client
+     | 1683826581510 (W)
+     | 1683826581510 Writing back bytes
+     | 1683826581510 Wrote [5] bytes to the client
+     | 1683826581510 (W)
+     | 1683826581510 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581510 (WKA)
+     | 1683826581511 Read [336] bytes from client
+     | 1683826581511 (R)
+     | 1683826581511 (RP)
+     | 1683826581511 Preamble successfully parsed
+     | 1683826581511 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581511 (RWo)
+     | 1683826581511 (RC)
+     | 1683826581512 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581512 Preamble is [198] bytes long
+     | 1683826581512 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581512 Still writing preamble
+     | 1683826581512 Wrote [198] bytes to the client
+     | 1683826581512 (W)
+     | 1683826581512 Writing back bytes
+     | 1683826581512 Wrote [16392] bytes to the client
+     | 1683826581512 (W)
+     | 1683826581512 Writing back bytes
+     | 1683826581512 Wrote [16392] bytes to the client
+     | 1683826581512 (W)
+     | 1683826581512 Writing back bytes
+     | 1683826581512 Wrote [9919] bytes to the client
+     | 1683826581512 (W)
+     | 1683826581512 Writing back bytes
+     | 1683826581512 Wrote [5] bytes to the client
+     | 1683826581512 (W)
+     | 1683826581512 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581512 (WKA)
+     | 1683826581512 Read [336] bytes from client
+     | 1683826581512 (R)
+     | 1683826581512 (RP)
+     | 1683826581512 Preamble successfully parsed
+     | 1683826581512 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581512 (RWo)
+     | 1683826581512 (RC)
+     | 1683826581513 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581513 Preamble is [198] bytes long
+     | 1683826581513 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581513 Still writing preamble
+     | 1683826581513 Wrote [198] bytes to the client
+     | 1683826581513 (W)
+     | 1683826581513 Writing back bytes
+     | 1683826581513 Wrote [16392] bytes to the client
+     | 1683826581513 (W)
+     | 1683826581513 Writing back bytes
+     | 1683826581513 Wrote [16392] bytes to the client
+     | 1683826581513 (W)
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581513 Writing back bytes
+     | 1683826581513 Wrote [10018] bytes to the client
+     | 1683826581513 (W)
+     | 1683826581513 Writing back bytes
+     | 1683826581513 Wrote [5] bytes to the client
+     | 1683826581513 (W)
+     | 1683826581513 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581513 (WKA)
+     | 1683826581514 Read [336] bytes from client
+     | 1683826581514 (R)
+     | 1683826581514 (RP)
+     | 1683826581514 Preamble successfully parsed
+     | 1683826581514 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581514 (RWo)
+     | 1683826581514 (RC)
+     | 1683826581514 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581514 Preamble is [198] bytes long
+     | 1683826581514 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581514 Still writing preamble
+     | 1683826581514 Wrote [198] bytes to the client
+     | 1683826581514 (W)
+     | 1683826581514 Writing back bytes
+     | 1683826581514 Wrote [16392] bytes to the client
+     | 1683826581514 (W)
+     | 1683826581514 Writing back bytes
+     | 1683826581514 Wrote [16392] bytes to the client
+     | 1683826581514 (W)
+     | 1683826581514 Writing back bytes
+     | 1683826581514 Wrote [10117] bytes to the client
+     | 1683826581514 (W)
+     | 1683826581514 Writing back bytes
+     | 1683826581514 Wrote [5] bytes to the client
+     | 1683826581514 (W)
+     | 1683826581514 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581514 (WKA)
+     | 1683826581515 Read [336] bytes from client
+     | 1683826581515 (R)
+     | 1683826581515 (RP)
+     | 1683826581515 Preamble successfully parsed
+     | 1683826581515 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581515 (RWo)
+     | 1683826581515 (RC)
+     | 1683826581516 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581516 Preamble is [198] bytes long
+     | 1683826581516 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581516 Still writing preamble
+     | 1683826581516 Wrote [198] bytes to the client
+     | 1683826581516 (W)
+     | 1683826581516 Writing back bytes
+     | 1683826581516 Wrote [16392] bytes to the client
+     | 1683826581516 (W)
+     | 1683826581516 Writing back bytes
+     | 1683826581516 Wrote [16392] bytes to the client
+     | 1683826581516 (W)
+     | 1683826581516 Writing back bytes
+     | 1683826581516 Wrote [10216] bytes to the client
+     | 1683826581516 (W)
+     | 1683826581516 Writing back bytes
+     | 1683826581516 Wrote [5] bytes to the client
+     | 1683826581516 (W)
+     | 1683826581516 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581516 (WKA)
+     | 1683826581516 Read [336] bytes from client
+     | 1683826581516 (R)
+     | 1683826581516 (RP)
+     | 1683826581516 Preamble successfully parsed
+     | 1683826581516 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581516 (RWo)
+     | 1683826581516 (RC)
+     | 1683826581517 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581517 Preamble is [198] bytes long
+     | 1683826581517 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581517 Still writing preamble
+     | 1683826581517 Wrote [198] bytes to the client
+     | 1683826581517 (W)
+     | 1683826581517 Writing back bytes
+     | 1683826581517 Wrote [16392] bytes to the client
+     | 1683826581517 (W)
+     | 1683826581517 Writing back bytes
+     | 1683826581517 Wrote [16392] bytes to the client
+     | 1683826581517 (W)
+     | 1683826581517 Writing back bytes
+     | 1683826581517 Wrote [10315] bytes to the client
+     | 1683826581517 (W)
+     | 1683826581517 Writing back bytes
+     | 1683826581517 Wrote [5] bytes to the client
+     | 1683826581517 (W)
+     | 1683826581517 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581517 (WKA)
+     | 1683826581517 Read [336] bytes from client
+     | 1683826581517 (R)
+     | 1683826581517 (RP)
+     | 1683826581517 Preamble successfully parsed
+     | 1683826581517 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581517 (RWo)
+     | 1683826581517 (RC)
+     | 1683826581518 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581518 Preamble is [198] bytes long
+     | 1683826581518 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581518 Still writing preamble
+     | 1683826581518 Wrote [198] bytes to the client
+     | 1683826581518 (W)
+     | 1683826581518 Writing back bytes
+     | 1683826581518 Wrote [16392] bytes to the client
+     | 1683826581518 (W)
+     | 1683826581518 Writing back bytes
+     | 1683826581518 Wrote [16392] bytes to the client
+     | 1683826581518 (W)
+     | 1683826581518 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581518 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581518 Writing back bytes
+     | 1683826581518 Wrote [10414] bytes to the client
+     | 1683826581518 (W)
+     | 1683826581518 Writing back bytes
+     | 1683826581518 Wrote [5] bytes to the client
+     | 1683826581518 (W)
+     | 1683826581518 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581518 (WKA)
+     | 1683826581518 Read [336] bytes from client
+     | 1683826581518 (R)
+     | 1683826581518 (RP)
+     | 1683826581518 Preamble successfully parsed
+     | 1683826581518 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581518 (RWo)
+     | 1683826581518 (RC)
+     | 1683826581519 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581519 Preamble is [198] bytes long
+     | 1683826581519 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581519 Still writing preamble
+     | 1683826581519 Wrote [198] bytes to the client
+     | 1683826581519 (W)
+     | 1683826581519 Writing back bytes
+     | 1683826581519 Wrote [16392] bytes to the client
+     | 1683826581519 (W)
+     | 1683826581519 Writing back bytes
+     | 1683826581519 Wrote [16392] bytes to the client
+     | 1683826581519 (W)
+     | 1683826581519 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581519 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581519 Writing back bytes
+     | 1683826581519 Wrote [10513] bytes to the client
+     | 1683826581519 (W)
+     | 1683826581519 Writing back bytes
+     | 1683826581519 Wrote [5] bytes to the client
+     | 1683826581519 (W)
+     | 1683826581519 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581519 (WKA)
+     | 1683826581519 Read [336] bytes from client
+     | 1683826581519 (R)
+     | 1683826581519 (RP)
+     | 1683826581519 Preamble successfully parsed
+     | 1683826581519 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581519 (RWo)
+     | 1683826581519 (RC)
+     | 1683826581520 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581520 Preamble is [198] bytes long
+     | 1683826581520 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581520 Still writing preamble
+     | 1683826581520 Wrote [198] bytes to the client
+     | 1683826581520 (W)
+     | 1683826581520 Writing back bytes
+     | 1683826581520 Wrote [16392] bytes to the client
+     | 1683826581520 (W)
+     | 1683826581520 Writing back bytes
+     | 1683826581520 Wrote [16392] bytes to the client
+     | 1683826581520 (W)
+     | 1683826581520 Writing back bytes
+     | 1683826581520 Wrote [10612] bytes to the client
+     | 1683826581520 (W)
+     | 1683826581520 Writing back bytes
+     | 1683826581520 Wrote [5] bytes to the client
+     | 1683826581520 (W)
+     | 1683826581520 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581520 (WKA)
+     | 1683826581520 Read [336] bytes from client
+     | 1683826581520 (R)
+     | 1683826581520 (RP)
+     | 1683826581520 Preamble successfully parsed
+     | 1683826581520 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581520 (RWo)
+     | 1683826581521 (RC)
+     | 1683826581521 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581521 Preamble is [198] bytes long
+     | 1683826581521 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581521 Still writing preamble
+     | 1683826581521 Wrote [198] bytes to the client
+     | 1683826581521 (W)
+     | 1683826581521 Writing back bytes
+     | 1683826581521 Wrote [16392] bytes to the client
+     | 1683826581521 (W)
+     | 1683826581521 Writing back bytes
+     | 1683826581521 Wrote [16392] bytes to the client
+     | 1683826581521 (W)
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581521 Writing back bytes
+     | 1683826581521 Wrote [10711] bytes to the client
+     | 1683826581521 (W)
+     | 1683826581521 Writing back bytes
+     | 1683826581521 Wrote [5] bytes to the client
+     | 1683826581521 (W)
+     | 1683826581521 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581521 (WKA)
+     | 1683826581522 Read [336] bytes from client
+     | 1683826581522 (R)
+     | 1683826581522 (RP)
+     | 1683826581522 Preamble successfully parsed
+     | 1683826581522 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581522 (RWo)
+     | 1683826581522 (RC)
+     | 1683826581522 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581522 Preamble is [198] bytes long
+     | 1683826581522 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581522 Still writing preamble
+     | 1683826581522 Wrote [198] bytes to the client
+     | 1683826581522 (W)
+     | 1683826581522 Writing back bytes
+     | 1683826581522 Wrote [16392] bytes to the client
+     | 1683826581522 (W)
+     | 1683826581522 Writing back bytes
+     | 1683826581522 Wrote [16392] bytes to the client
+     | 1683826581522 (W)
+     | 1683826581522 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581522 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581523 Writing back bytes
+     | 1683826581523 Wrote [10810] bytes to the client
+     | 1683826581523 (W)
+     | 1683826581523 Writing back bytes
+     | 1683826581523 Wrote [5] bytes to the client
+     | 1683826581523 (W)
+     | 1683826581523 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581523 (WKA)
+     | 1683826581523 Read [336] bytes from client
+     | 1683826581523 (R)
+     | 1683826581523 (RP)
+     | 1683826581523 Preamble successfully parsed
+     | 1683826581523 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581523 (RWo)
+     | 1683826581523 (RC)
+     | 1683826581524 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581524 Preamble is [198] bytes long
+     | 1683826581524 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581524 Still writing preamble
+     | 1683826581524 Wrote [198] bytes to the client
+     | 1683826581524 (W)
+     | 1683826581524 Writing back bytes
+     | 1683826581524 Wrote [16392] bytes to the client
+     | 1683826581524 (W)
+     | 1683826581524 Writing back bytes
+     | 1683826581524 Wrote [16392] bytes to the client
+     | 1683826581524 (W)
+     | 1683826581524 Writing back bytes
+     | 1683826581524 Wrote [10909] bytes to the client
+     | 1683826581524 (W)
+     | 1683826581524 Writing back bytes
+     | 1683826581524 Wrote [5] bytes to the client
+     | 1683826581524 (W)
+     | 1683826581524 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581524 (WKA)
+     | 1683826581524 Read [336] bytes from client
+     | 1683826581524 (R)
+     | 1683826581524 (RP)
+     | 1683826581524 Preamble successfully parsed
+     | 1683826581524 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581524 (RWo)
+     | 1683826581524 (RC)
+     | 1683826581525 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581525 Preamble is [198] bytes long
+     | 1683826581525 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581525 Still writing preamble
+     | 1683826581525 Wrote [198] bytes to the client
+     | 1683826581525 (W)
+     | 1683826581525 Writing back bytes
+     | 1683826581525 Wrote [16392] bytes to the client
+     | 1683826581525 (W)
+     | 1683826581525 Writing back bytes
+     | 1683826581525 Wrote [16392] bytes to the client
+     | 1683826581525 (W)
+     | 1683826581525 Writing back bytes
+     | 1683826581525 Wrote [11008] bytes to the client
+     | 1683826581525 (W)
+     | 1683826581525 Writing back bytes
+     | 1683826581525 Wrote [5] bytes to the client
+     | 1683826581525 (W)
+     | 1683826581525 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581525 (WKA)
+     | 1683826581526 Read [336] bytes from client
+     | 1683826581526 (R)
+     | 1683826581526 (RP)
+     | 1683826581526 Preamble successfully parsed
+     | 1683826581526 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581526 (RWo)
+     | 1683826581526 (RC)
+     | 1683826581526 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581526 Preamble is [198] bytes long
+     | 1683826581526 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581526 Still writing preamble
+     | 1683826581526 Wrote [198] bytes to the client
+     | 1683826581526 (W)
+     | 1683826581527 Writing back bytes
+     | 1683826581527 Wrote [16392] bytes to the client
+     | 1683826581527 (W)
+     | 1683826581527 Writing back bytes
+     | 1683826581527 Wrote [16392] bytes to the client
+     | 1683826581527 (W)
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581527 Writing back bytes
+     | 1683826581527 Wrote [11107] bytes to the client
+     | 1683826581527 (W)
+     | 1683826581527 Writing back bytes
+     | 1683826581527 Wrote [5] bytes to the client
+     | 1683826581527 (W)
+     | 1683826581527 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581527 (WKA)
+     | 1683826581527 Read [336] bytes from client
+     | 1683826581527 (R)
+     | 1683826581527 (RP)
+     | 1683826581527 Preamble successfully parsed
+     | 1683826581527 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581527 (RWo)
+     | 1683826581527 (RC)
+     | 1683826581528 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581528 Preamble is [198] bytes long
+     | 1683826581528 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581528 Still writing preamble
+     | 1683826581528 Wrote [198] bytes to the client
+     | 1683826581528 (W)
+     | 1683826581528 Writing back bytes
+     | 1683826581528 Wrote [16392] bytes to the client
+     | 1683826581528 (W)
+     | 1683826581528 Writing back bytes
+     | 1683826581528 Wrote [16392] bytes to the client
+     | 1683826581528 (W)
+     | 1683826581528 Writing back bytes
+     | 1683826581528 Wrote [11206] bytes to the client
+     | 1683826581528 (W)
+     | 1683826581528 Writing back bytes
+     | 1683826581528 Wrote [5] bytes to the client
+     | 1683826581528 (W)
+     | 1683826581528 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581528 (WKA)
+     | 1683826581528 Read [336] bytes from client
+     | 1683826581528 (R)
+     | 1683826581528 (RP)
+     | 1683826581528 Preamble successfully parsed
+     | 1683826581528 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581528 (RWo)
+     | 1683826581528 (RC)
+     | 1683826581529 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581529 Preamble is [198] bytes long
+     | 1683826581529 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581529 Still writing preamble
+     | 1683826581529 Wrote [198] bytes to the client
+     | 1683826581529 (W)
+     | 1683826581529 Writing back bytes
+     | 1683826581529 Wrote [16392] bytes to the client
+     | 1683826581529 (W)
+     | 1683826581529 Writing back bytes
+     | 1683826581529 Wrote [16392] bytes to the client
+     | 1683826581529 (W)
+     | 1683826581529 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581529 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581529 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581529 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581529 Writing back bytes
+     | 1683826581529 Wrote [11305] bytes to the client
+     | 1683826581529 (W)
+     | 1683826581529 Writing back bytes
+     | 1683826581529 Wrote [5] bytes to the client
+     | 1683826581529 (W)
+     | 1683826581529 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581529 (WKA)
+     | 1683826581530 Read [336] bytes from client
+     | 1683826581530 (R)
+     | 1683826581530 (RP)
+     | 1683826581530 Preamble successfully parsed
+     | 1683826581530 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581530 (RWo)
+     | 1683826581530 (RC)
+     | 1683826581531 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581531 Preamble is [198] bytes long
+     | 1683826581531 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581531 Still writing preamble
+     | 1683826581531 Wrote [198] bytes to the client
+     | 1683826581531 (W)
+     | 1683826581531 Writing back bytes
+     | 1683826581531 Wrote [16392] bytes to the client
+     | 1683826581531 (W)
+     | 1683826581531 Writing back bytes
+     | 1683826581531 Wrote [16392] bytes to the client
+     | 1683826581531 (W)
+     | 1683826581531 Writing back bytes
+     | 1683826581531 Wrote [11404] bytes to the client
+     | 1683826581531 (W)
+     | 1683826581531 Writing back bytes
+     | 1683826581531 Wrote [5] bytes to the client
+     | 1683826581531 (W)
+     | 1683826581531 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581531 (WKA)
+     | 1683826581531 Read [336] bytes from client
+     | 1683826581531 (R)
+     | 1683826581531 (RP)
+     | 1683826581531 Preamble successfully parsed
+     | 1683826581531 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581531 (RWo)
+     | 1683826581531 (RC)
+     | 1683826581532 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581532 Preamble is [198] bytes long
+     | 1683826581532 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581532 Still writing preamble
+     | 1683826581532 Wrote [198] bytes to the client
+     | 1683826581532 (W)
+     | 1683826581532 Writing back bytes
+     | 1683826581532 Wrote [16392] bytes to the client
+     | 1683826581532 (W)
+     | 1683826581532 Writing back bytes
+     | 1683826581532 Wrote [16392] bytes to the client
+     | 1683826581532 (W)
+     | 1683826581532 Writing back bytes
+     | 1683826581532 Wrote [11503] bytes to the client
+     | 1683826581532 (W)
+     | 1683826581532 Writing back bytes
+     | 1683826581532 Wrote [5] bytes to the client
+     | 1683826581532 (W)
+     | 1683826581532 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581532 (WKA)
+     | 1683826581533 Read [336] bytes from client
+     | 1683826581533 (R)
+     | 1683826581533 (RP)
+     | 1683826581533 Preamble successfully parsed
+     | 1683826581533 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581533 (RWo)
+     | 1683826581533 (RC)
+     | 1683826581534 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581534 Preamble is [198] bytes long
+     | 1683826581534 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581534 Still writing preamble
+     | 1683826581534 Wrote [198] bytes to the client
+     | 1683826581534 (W)
+     | 1683826581534 Writing back bytes
+     | 1683826581534 Wrote [16392] bytes to the client
+     | 1683826581534 (W)
+     | 1683826581534 Writing back bytes
+     | 1683826581534 Wrote [16392] bytes to the client
+     | 1683826581534 (W)
+     | 1683826581534 Writing back bytes
+     | 1683826581534 Wrote [11602] bytes to the client
+     | 1683826581534 (W)
+     | 1683826581534 Writing back bytes
+     | 1683826581534 Wrote [5] bytes to the client
+     | 1683826581534 (W)
+     | 1683826581534 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581534 (WKA)
+     | 1683826581534 Read [336] bytes from client
+     | 1683826581534 (R)
+     | 1683826581534 (RP)
+     | 1683826581534 Preamble successfully parsed
+     | 1683826581534 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581534 (RWo)
+     | 1683826581534 (RC)
+     | 1683826581535 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581535 Preamble is [198] bytes long
+     | 1683826581535 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581535 Still writing preamble
+     | 1683826581535 Wrote [198] bytes to the client
+     | 1683826581535 (W)
+     | 1683826581535 Writing back bytes
+     | 1683826581535 Wrote [16392] bytes to the client
+     | 1683826581535 (W)
+     | 1683826581535 Writing back bytes
+     | 1683826581535 Wrote [16392] bytes to the client
+     | 1683826581535 (W)
+     | 1683826581535 Writing back bytes
+     | 1683826581535 Wrote [11701] bytes to the client
+     | 1683826581535 (W)
+     | 1683826581535 Writing back bytes
+     | 1683826581535 Wrote [5] bytes to the client
+     | 1683826581535 (W)
+     | 1683826581535 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581535 (WKA)
+     | 1683826581535 Read [336] bytes from client
+     | 1683826581535 (R)
+     | 1683826581535 (RP)
+     | 1683826581536 Preamble successfully parsed
+     | 1683826581536 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581536 (RWo)
+     | 1683826581536 (RC)
+     | 1683826581536 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581536 Preamble is [198] bytes long
+     | 1683826581536 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581536 Still writing preamble
+     | 1683826581537 Wrote [198] bytes to the client
+     | 1683826581537 (W)
+     | 1683826581537 Writing back bytes
+     | 1683826581537 Wrote [16392] bytes to the client
+     | 1683826581537 (W)
+     | 1683826581537 Writing back bytes
+     | 1683826581537 Wrote [16392] bytes to the client
+     | 1683826581537 (W)
+     | 1683826581537 Writing back bytes
+     | 1683826581537 Wrote [11800] bytes to the client
+     | 1683826581537 (W)
+     | 1683826581537 Writing back bytes
+     | 1683826581537 Wrote [5] bytes to the client
+     | 1683826581537 (W)
+     | 1683826581537 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581537 (WKA)
+     | 1683826581537 Read [336] bytes from client
+     | 1683826581537 (R)
+     | 1683826581537 (RP)
+     | 1683826581537 Preamble successfully parsed
+     | 1683826581537 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581537 (RWo)
+     | 1683826581537 (RC)
+     | 1683826581538 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581538 Preamble is [198] bytes long
+     | 1683826581538 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581538 Still writing preamble
+     | 1683826581538 Wrote [198] bytes to the client
+     | 1683826581538 (W)
+     | 1683826581538 Writing back bytes
+     | 1683826581538 Wrote [16392] bytes to the client
+     | 1683826581538 (W)
+     | 1683826581538 Writing back bytes
+     | 1683826581538 Wrote [16392] bytes to the client
+     | 1683826581538 (W)
+     | 1683826581538 Writing back bytes
+     | 1683826581538 Wrote [11899] bytes to the client
+     | 1683826581538 (W)
+     | 1683826581538 Writing back bytes
+     | 1683826581538 Wrote [5] bytes to the client
+     | 1683826581538 (W)
+     | 1683826581538 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581538 (WKA)
+     | 1683826581538 Read [336] bytes from client
+     | 1683826581538 (R)
+     | 1683826581538 (RP)
+     | 1683826581538 Preamble successfully parsed
+     | 1683826581538 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581538 (RWo)
+     | 1683826581539 (RC)
+     | 1683826581539 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581539 Preamble is [198] bytes long
+     | 1683826581539 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581539 Still writing preamble
+     | 1683826581539 Wrote [198] bytes to the client
+     | 1683826581539 (W)
+     | 1683826581539 Writing back bytes
+     | 1683826581539 Wrote [16392] bytes to the client
+     | 1683826581539 (W)
+     | 1683826581539 Writing back bytes
+     | 1683826581539 Wrote [16392] bytes to the client
+     | 1683826581539 (W)
+     | 1683826581539 Writing back bytes
+     | 1683826581539 Wrote [11998] bytes to the client
+     | 1683826581539 (W)
+     | 1683826581539 Writing back bytes
+     | 1683826581539 Wrote [5] bytes to the client
+     | 1683826581539 (W)
+     | 1683826581539 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581539 (WKA)
+     | 1683826581540 Read [336] bytes from client
+     | 1683826581540 (R)
+     | 1683826581540 (RP)
+     | 1683826581540 Preamble successfully parsed
+     | 1683826581540 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581540 (RWo)
+     | 1683826581540 (RC)
+     | 1683826581541 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581541 Preamble is [198] bytes long
+     | 1683826581541 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581541 Still writing preamble
+     | 1683826581541 Wrote [198] bytes to the client
+     | 1683826581541 (W)
+     | 1683826581541 Writing back bytes
+     | 1683826581541 Wrote [16392] bytes to the client
+     | 1683826581541 (W)
+     | 1683826581541 Writing back bytes
+     | 1683826581541 Wrote [16392] bytes to the client
+     | 1683826581541 (W)
+     | 1683826581541 Writing back bytes
+     | 1683826581541 Wrote [12097] bytes to the client
+     | 1683826581541 (W)
+     | 1683826581541 Writing back bytes
+     | 1683826581541 Wrote [5] bytes to the client
+     | 1683826581541 (W)
+     | 1683826581541 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581541 (WKA)
+     | 1683826581541 Read [336] bytes from client
+     | 1683826581541 (R)
+     | 1683826581541 (RP)
+     | 1683826581541 Preamble successfully parsed
+     | 1683826581541 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581541 (RWo)
+     | 1683826581541 (RC)
+     | 1683826581542 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581542 Preamble is [198] bytes long
+     | 1683826581542 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581542 Still writing preamble
+     | 1683826581542 Wrote [198] bytes to the client
+     | 1683826581542 (W)
+     | 1683826581542 Writing back bytes
+     | 1683826581542 Wrote [16392] bytes to the client
+     | 1683826581542 (W)
+     | 1683826581542 Writing back bytes
+     | 1683826581542 Wrote [16392] bytes to the client
+     | 1683826581542 (W)
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581542 Writing back bytes
+     | 1683826581542 Wrote [12196] bytes to the client
+     | 1683826581542 (W)
+     | 1683826581542 Writing back bytes
+     | 1683826581542 Wrote [5] bytes to the client
+     | 1683826581542 (W)
+     | 1683826581542 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581542 (WKA)
+     | 1683826581543 Read [336] bytes from client
+     | 1683826581543 (R)
+     | 1683826581543 (RP)
+     | 1683826581543 Preamble successfully parsed
+     | 1683826581543 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581543 (RWo)
+     | 1683826581543 (RC)
+     | 1683826581543 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581543 Preamble is [198] bytes long
+     | 1683826581543 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581543 Still writing preamble
+     | 1683826581543 Wrote [198] bytes to the client
+     | 1683826581543 (W)
+     | 1683826581543 Writing back bytes
+     | 1683826581543 Wrote [16392] bytes to the client
+     | 1683826581543 (W)
+     | 1683826581543 Writing back bytes
+     | 1683826581543 Wrote [16392] bytes to the client
+     | 1683826581543 (W)
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581543 Writing back bytes
+     | 1683826581543 Wrote [12295] bytes to the client
+     | 1683826581543 (W)
+     | 1683826581543 Writing back bytes
+     | 1683826581543 Wrote [5] bytes to the client
+     | 1683826581543 (W)
+     | 1683826581543 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581543 (WKA)
+     | 1683826581544 Read [336] bytes from client
+     | 1683826581544 (R)
+     | 1683826581544 (RP)
+     | 1683826581544 Preamble successfully parsed
+     | 1683826581544 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581544 (RWo)
+     | 1683826581544 (RC)
+     | 1683826581545 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581545 Preamble is [198] bytes long
+     | 1683826581545 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581545 Still writing preamble
+     | 1683826581545 Wrote [198] bytes to the client
+     | 1683826581545 (W)
+     | 1683826581545 Writing back bytes
+     | 1683826581545 Wrote [16392] bytes to the client
+     | 1683826581545 (W)
+     | 1683826581545 Writing back bytes
+     | 1683826581545 Wrote [16392] bytes to the client
+     | 1683826581545 (W)
+     | 1683826581545 Writing back bytes
+     | 1683826581545 Wrote [12394] bytes to the client
+     | 1683826581545 (W)
+     | 1683826581545 Writing back bytes
+     | 1683826581545 Wrote [5] bytes to the client
+     | 1683826581545 (W)
+     | 1683826581545 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581545 (WKA)
+     | 1683826581545 Read [336] bytes from client
+     | 1683826581545 (R)
+     | 1683826581545 (RP)
+     | 1683826581545 Preamble successfully parsed
+     | 1683826581545 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581545 (RWo)
+     | 1683826581545 (RC)
+     | 1683826581546 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581546 Preamble is [198] bytes long
+     | 1683826581546 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581546 Still writing preamble
+     | 1683826581546 Wrote [198] bytes to the client
+     | 1683826581546 (W)
+     | 1683826581546 Writing back bytes
+     | 1683826581546 Wrote [16392] bytes to the client
+     | 1683826581546 (W)
+     | 1683826581546 Writing back bytes
+     | 1683826581546 Wrote [16392] bytes to the client
+     | 1683826581546 (W)
+     | 1683826581546 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581546 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581546 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581546 Writing back bytes
+     | 1683826581546 Wrote [12493] bytes to the client
+     | 1683826581546 (W)
+     | 1683826581546 Writing back bytes
+     | 1683826581546 Wrote [5] bytes to the client
+     | 1683826581546 (W)
+     | 1683826581546 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581546 (WKA)
+     | 1683826581546 Read [336] bytes from client
+     | 1683826581546 (R)
+     | 1683826581546 (RP)
+     | 1683826581546 Preamble successfully parsed
+     | 1683826581546 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581546 (RWo)
+     | 1683826581546 (RC)
+     | 1683826581547 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581547 Preamble is [198] bytes long
+     | 1683826581547 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581547 Still writing preamble
+     | 1683826581547 Wrote [198] bytes to the client
+     | 1683826581547 (W)
+     | 1683826581547 Writing back bytes
+     | 1683826581547 Wrote [16392] bytes to the client
+     | 1683826581547 (W)
+     | 1683826581547 Writing back bytes
+     | 1683826581547 Wrote [16392] bytes to the client
+     | 1683826581547 (W)
+     | 1683826581547 Writing back bytes
+     | 1683826581547 Wrote [12592] bytes to the client
+     | 1683826581547 (W)
+     | 1683826581547 Writing back bytes
+     | 1683826581547 Wrote [5] bytes to the client
+     | 1683826581547 (W)
+     | 1683826581547 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581547 (WKA)
+     | 1683826581548 Read [336] bytes from client
+     | 1683826581548 (R)
+     | 1683826581548 (RP)
+     | 1683826581548 Preamble successfully parsed
+     | 1683826581548 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581548 (RWo)
+     | 1683826581548 (RC)
+     | 1683826581549 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581549 Preamble is [198] bytes long
+     | 1683826581549 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581549 Still writing preamble
+     | 1683826581549 Wrote [198] bytes to the client
+     | 1683826581549 (W)
+     | 1683826581549 Writing back bytes
+     | 1683826581549 Wrote [16392] bytes to the client
+     | 1683826581549 (W)
+     | 1683826581549 Writing back bytes
+     | 1683826581549 Wrote [16392] bytes to the client
+     | 1683826581549 (W)
+     | 1683826581549 Writing back bytes
+     | 1683826581549 Wrote [12691] bytes to the client
+     | 1683826581549 (W)
+     | 1683826581549 Writing back bytes
+     | 1683826581549 Wrote [5] bytes to the client
+     | 1683826581549 (W)
+     | 1683826581549 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581549 (WKA)
+     | 1683826581549 Read [336] bytes from client
+     | 1683826581549 (R)
+     | 1683826581549 (RP)
+     | 1683826581549 Preamble successfully parsed
+     | 1683826581549 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581549 (RWo)
+     | 1683826581549 (RC)
+     | 1683826581550 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581550 Preamble is [198] bytes long
+     | 1683826581550 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581550 Still writing preamble
+     | 1683826581550 Wrote [198] bytes to the client
+     | 1683826581550 (W)
+     | 1683826581550 Writing back bytes
+     | 1683826581550 Wrote [16392] bytes to the client
+     | 1683826581550 (W)
+     | 1683826581550 Writing back bytes
+     | 1683826581550 Wrote [16392] bytes to the client
+     | 1683826581550 (W)
+     | 1683826581550 Writing back bytes
+     | 1683826581550 Wrote [12790] bytes to the client
+     | 1683826581550 (W)
+     | 1683826581550 Writing back bytes
+     | 1683826581550 Wrote [5] bytes to the client
+     | 1683826581550 (W)
+     | 1683826581550 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581550 (WKA)
+     | 1683826581551 Read [336] bytes from client
+     | 1683826581551 (R)
+     | 1683826581551 (RP)
+     | 1683826581551 Preamble successfully parsed
+     | 1683826581551 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581551 (RWo)
+     | 1683826581551 (RC)
+     | 1683826581551 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581551 Preamble is [198] bytes long
+     | 1683826581551 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581551 Still writing preamble
+     | 1683826581551 Wrote [198] bytes to the client
+     | 1683826581551 (W)
+     | 1683826581551 Writing back bytes
+     | 1683826581551 Wrote [16392] bytes to the client
+     | 1683826581551 (W)
+     | 1683826581551 Writing back bytes
+     | 1683826581551 Wrote [16392] bytes to the client
+     | 1683826581551 (W)
+     | 1683826581551 Writing back bytes
+     | 1683826581551 Wrote [12889] bytes to the client
+     | 1683826581551 (W)
+     | 1683826581551 Writing back bytes
+     | 1683826581551 Wrote [5] bytes to the client
+     | 1683826581551 (W)
+     | 1683826581551 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581551 (WKA)
+     | 1683826581552 Read [336] bytes from client
+     | 1683826581552 (R)
+     | 1683826581552 (RP)
+     | 1683826581552 Preamble successfully parsed
+     | 1683826581552 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581552 (RWo)
+     | 1683826581552 (RC)
+     | 1683826581552 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581552 Preamble is [198] bytes long
+     | 1683826581552 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581552 Still writing preamble
+     | 1683826581552 Wrote [198] bytes to the client
+     | 1683826581552 (W)
+     | 1683826581552 Writing back bytes
+     | 1683826581552 Wrote [16392] bytes to the client
+     | 1683826581552 (W)
+     | 1683826581552 Writing back bytes
+     | 1683826581552 Wrote [16392] bytes to the client
+     | 1683826581552 (W)
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581552 Writing back bytes
+     | 1683826581552 Wrote [12988] bytes to the client
+     | 1683826581552 (W)
+     | 1683826581552 Writing back bytes
+     | 1683826581552 Wrote [5] bytes to the client
+     | 1683826581552 (W)
+     | 1683826581552 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581552 (WKA)
+     | 1683826581553 Read [336] bytes from client
+     | 1683826581553 (R)
+     | 1683826581553 (RP)
+     | 1683826581553 Preamble successfully parsed
+     | 1683826581553 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581553 (RWo)
+     | 1683826581553 (RC)
+     | 1683826581553 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581553 Preamble is [198] bytes long
+     | 1683826581553 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581553 Still writing preamble
+     | 1683826581553 Wrote [198] bytes to the client
+     | 1683826581553 (W)
+     | 1683826581553 Writing back bytes
+     | 1683826581553 Wrote [16392] bytes to the client
+     | 1683826581553 (W)
+     | 1683826581553 Writing back bytes
+     | 1683826581553 Wrote [16392] bytes to the client
+     | 1683826581553 (W)
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581553 Writing back bytes
+     | 1683826581553 Wrote [13087] bytes to the client
+     | 1683826581553 (W)
+     | 1683826581553 Writing back bytes
+     | 1683826581553 Wrote [5] bytes to the client
+     | 1683826581553 (W)
+     | 1683826581554 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581554 (WKA)
+     | 1683826581554 Read [336] bytes from client
+     | 1683826581554 (R)
+     | 1683826581554 (RP)
+     | 1683826581554 Preamble successfully parsed
+     | 1683826581554 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581554 (RWo)
+     | 1683826581554 (RC)
+     | 1683826581555 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581555 Preamble is [198] bytes long
+     | 1683826581555 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581555 Still writing preamble
+     | 1683826581555 Wrote [198] bytes to the client
+     | 1683826581555 (W)
+     | 1683826581555 Writing back bytes
+     | 1683826581555 Wrote [16392] bytes to the client
+     | 1683826581555 (W)
+     | 1683826581555 Writing back bytes
+     | 1683826581555 Wrote [16392] bytes to the client
+     | 1683826581555 (W)
+     | 1683826581555 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581555 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581555 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581555 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581555 Writing back bytes
+     | 1683826581555 Wrote [13186] bytes to the client
+     | 1683826581555 (W)
+     | 1683826581555 Writing back bytes
+     | 1683826581555 Wrote [5] bytes to the client
+     | 1683826581555 (W)
+     | 1683826581555 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581555 (WKA)
+     | 1683826581555 Read [336] bytes from client
+     | 1683826581555 (R)
+     | 1683826581555 (RP)
+     | 1683826581555 Preamble successfully parsed
+     | 1683826581555 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581555 (RWo)
+     | 1683826581555 (RC)
+     | 1683826581556 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581556 Preamble is [198] bytes long
+     | 1683826581556 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581556 Still writing preamble
+     | 1683826581556 Wrote [198] bytes to the client
+     | 1683826581556 (W)
+     | 1683826581556 Writing back bytes
+     | 1683826581556 Wrote [16392] bytes to the client
+     | 1683826581556 (W)
+     | 1683826581556 Writing back bytes
+     | 1683826581556 Wrote [16392] bytes to the client
+     | 1683826581556 (W)
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581556 Writing back bytes
+     | 1683826581556 Wrote [13285] bytes to the client
+     | 1683826581556 (W)
+     | 1683826581556 Writing back bytes
+     | 1683826581556 Wrote [5] bytes to the client
+     | 1683826581556 (W)
+     | 1683826581556 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581556 (WKA)
+     | 1683826581556 Read [336] bytes from client
+     | 1683826581556 (R)
+     | 1683826581556 (RP)
+     | 1683826581557 Preamble successfully parsed
+     | 1683826581557 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581557 (RWo)
+     | 1683826581557 (RC)
+     | 1683826581557 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581557 Preamble is [198] bytes long
+     | 1683826581557 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581557 Still writing preamble
+     | 1683826581557 Wrote [198] bytes to the client
+     | 1683826581557 (W)
+     | 1683826581557 Writing back bytes
+     | 1683826581557 Wrote [16392] bytes to the client
+     | 1683826581557 (W)
+     | 1683826581557 Writing back bytes
+     | 1683826581557 Wrote [16392] bytes to the client
+     | 1683826581557 (W)
+     | 1683826581557 Writing back bytes
+     | 1683826581557 Wrote [13384] bytes to the client
+     | 1683826581557 (W)
+     | 1683826581557 Writing back bytes
+     | 1683826581557 Wrote [5] bytes to the client
+     | 1683826581557 (W)
+     | 1683826581557 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581557 (WKA)
+     | 1683826581558 Read [336] bytes from client
+     | 1683826581558 (R)
+     | 1683826581558 (RP)
+     | 1683826581558 Preamble successfully parsed
+     | 1683826581558 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581558 (RWo)
+     | 1683826581558 (RC)
+     | 1683826581559 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581559 Preamble is [198] bytes long
+     | 1683826581559 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581559 Still writing preamble
+     | 1683826581559 Wrote [198] bytes to the client
+     | 1683826581559 (W)
+     | 1683826581559 Writing back bytes
+     | 1683826581559 Wrote [16392] bytes to the client
+     | 1683826581559 (W)
+     | 1683826581559 Writing back bytes
+     | 1683826581559 Wrote [16392] bytes to the client
+     | 1683826581559 (W)
+     | 1683826581559 Writing back bytes
+     | 1683826581559 Wrote [13483] bytes to the client
+     | 1683826581559 (W)
+     | 1683826581559 Writing back bytes
+     | 1683826581559 Wrote [5] bytes to the client
+     | 1683826581559 (W)
+     | 1683826581559 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581559 (WKA)
+     | 1683826581559 Read [336] bytes from client
+     | 1683826581559 (R)
+     | 1683826581559 (RP)
+     | 1683826581559 Preamble successfully parsed
+     | 1683826581559 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581559 (RWo)
+     | 1683826581559 (RC)
+     | 1683826581560 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581560 Preamble is [198] bytes long
+     | 1683826581560 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581560 Still writing preamble
+     | 1683826581560 Wrote [198] bytes to the client
+     | 1683826581560 (W)
+     | 1683826581560 Writing back bytes
+     | 1683826581560 Wrote [16392] bytes to the client
+     | 1683826581560 (W)
+     | 1683826581560 Writing back bytes
+     | 1683826581560 Wrote [16392] bytes to the client
+     | 1683826581560 (W)
+     | 1683826581560 Writing back bytes
+     | 1683826581560 Wrote [13582] bytes to the client
+     | 1683826581560 (W)
+     | 1683826581560 Writing back bytes
+     | 1683826581560 Wrote [5] bytes to the client
+     | 1683826581560 (W)
+     | 1683826581560 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581560 (WKA)
+     | 1683826581560 Read [336] bytes from client
+     | 1683826581560 (R)
+     | 1683826581560 (RP)
+     | 1683826581560 Preamble successfully parsed
+     | 1683826581560 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581560 (RWo)
+     | 1683826581560 (RC)
+     | 1683826581561 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581561 Preamble is [198] bytes long
+     | 1683826581561 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581561 Still writing preamble
+     | 1683826581561 Wrote [198] bytes to the client
+     | 1683826581561 (W)
+     | 1683826581561 Writing back bytes
+     | 1683826581561 Wrote [16392] bytes to the client
+     | 1683826581561 (W)
+     | 1683826581561 Writing back bytes
+     | 1683826581561 Wrote [16392] bytes to the client
+     | 1683826581561 (W)
+     | 1683826581561 Writing back bytes
+     | 1683826581561 Wrote [13681] bytes to the client
+     | 1683826581561 (W)
+     | 1683826581561 Writing back bytes
+     | 1683826581561 Wrote [5] bytes to the client
+     | 1683826581561 (W)
+     | 1683826581561 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581561 (WKA)
+     | 1683826581562 Read [336] bytes from client
+     | 1683826581562 (R)
+     | 1683826581562 (RP)
+     | 1683826581562 Preamble successfully parsed
+     | 1683826581562 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581562 (RWo)
+     | 1683826581562 (RC)
+     | 1683826581563 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581563 Preamble is [198] bytes long
+     | 1683826581563 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581563 Still writing preamble
+     | 1683826581563 Wrote [198] bytes to the client
+     | 1683826581563 (W)
+     | 1683826581563 Writing back bytes
+     | 1683826581563 Wrote [16392] bytes to the client
+     | 1683826581563 (W)
+     | 1683826581563 Writing back bytes
+     | 1683826581563 Wrote [16392] bytes to the client
+     | 1683826581563 (W)
+     | 1683826581563 Writing back bytes
+     | 1683826581563 Wrote [13780] bytes to the client
+     | 1683826581563 (W)
+     | 1683826581563 Writing back bytes
+     | 1683826581563 Wrote [5] bytes to the client
+     | 1683826581563 (W)
+     | 1683826581563 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581563 (WKA)
+     | 1683826581563 Read [336] bytes from client
+     | 1683826581563 (R)
+     | 1683826581563 (RP)
+     | 1683826581563 Preamble successfully parsed
+     | 1683826581563 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581563 (RWo)
+     | 1683826581563 (RC)
+     | 1683826581564 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581564 Preamble is [198] bytes long
+     | 1683826581564 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581564 Still writing preamble
+     | 1683826581564 Wrote [198] bytes to the client
+     | 1683826581564 (W)
+     | 1683826581564 Writing back bytes
+     | 1683826581564 Wrote [16392] bytes to the client
+     | 1683826581564 (W)
+     | 1683826581564 Writing back bytes
+     | 1683826581564 Wrote [16392] bytes to the client
+     | 1683826581564 (W)
+     | 1683826581564 Writing back bytes
+     | 1683826581564 Wrote [13879] bytes to the client
+     | 1683826581564 (W)
+     | 1683826581564 Writing back bytes
+     | 1683826581564 Wrote [5] bytes to the client
+     | 1683826581564 (W)
+     | 1683826581564 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581564 (WKA)
+     | 1683826581565 Read [336] bytes from client
+     | 1683826581565 (R)
+     | 1683826581565 (RP)
+     | 1683826581565 Preamble successfully parsed
+     | 1683826581565 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581565 (RWo)
+     | 1683826581565 (RC)
+     | 1683826581565 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581566 Preamble is [198] bytes long
+     | 1683826581566 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581566 Still writing preamble
+     | 1683826581566 Wrote [198] bytes to the client
+     | 1683826581566 (W)
+     | 1683826581566 Writing back bytes
+     | 1683826581566 Wrote [16392] bytes to the client
+     | 1683826581566 (W)
+     | 1683826581566 Writing back bytes
+     | 1683826581566 Wrote [16392] bytes to the client
+     | 1683826581566 (W)
+     | 1683826581566 Writing back bytes
+     | 1683826581566 Wrote [13978] bytes to the client
+     | 1683826581566 (W)
+     | 1683826581566 Writing back bytes
+     | 1683826581566 Wrote [5] bytes to the client
+     | 1683826581566 (W)
+     | 1683826581566 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581566 (WKA)
+     | 1683826581566 Read [336] bytes from client
+     | 1683826581566 (R)
+     | 1683826581566 (RP)
+     | 1683826581566 Preamble successfully parsed
+     | 1683826581566 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581566 (RWo)
+     | 1683826581566 (RC)
+     | 1683826581567 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581567 Preamble is [198] bytes long
+     | 1683826581567 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581567 Still writing preamble
+     | 1683826581567 Wrote [198] bytes to the client
+     | 1683826581567 (W)
+     | 1683826581567 Writing back bytes
+     | 1683826581567 Wrote [16392] bytes to the client
+     | 1683826581567 (W)
+     | 1683826581567 Writing back bytes
+     | 1683826581567 Wrote [16392] bytes to the client
+     | 1683826581567 (W)
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581567 Writing back bytes
+     | 1683826581567 Wrote [14077] bytes to the client
+     | 1683826581567 (W)
+     | 1683826581567 Writing back bytes
+     | 1683826581567 Wrote [5] bytes to the client
+     | 1683826581567 (W)
+     | 1683826581567 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581567 (WKA)
+     | 1683826581567 Read [336] bytes from client
+     | 1683826581567 (R)
+     | 1683826581567 (RP)
+     | 1683826581567 Preamble successfully parsed
+     | 1683826581567 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581567 (RWo)
+     | 1683826581567 (RC)
+     | 1683826581568 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581568 Preamble is [198] bytes long
+     | 1683826581568 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581568 Still writing preamble
+     | 1683826581568 Wrote [198] bytes to the client
+     | 1683826581568 (W)
+     | 1683826581568 Writing back bytes
+     | 1683826581568 Wrote [16392] bytes to the client
+     | 1683826581568 (W)
+     | 1683826581568 Writing back bytes
+     | 1683826581568 Wrote [16392] bytes to the client
+     | 1683826581568 (W)
+     | 1683826581568 Writing back bytes
+     | 1683826581568 Wrote [14176] bytes to the client
+     | 1683826581568 (W)
+     | 1683826581568 Writing back bytes
+     | 1683826581568 Wrote [5] bytes to the client
+     | 1683826581568 (W)
+     | 1683826581568 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581568 (WKA)
+     | 1683826581569 Read [336] bytes from client
+     | 1683826581569 (R)
+     | 1683826581569 (RP)
+     | 1683826581569 Preamble successfully parsed
+     | 1683826581569 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581569 (RWo)
+     | 1683826581569 (RC)
+     | 1683826581569 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581569 Preamble is [198] bytes long
+     | 1683826581569 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581569 Still writing preamble
+     | 1683826581569 Wrote [198] bytes to the client
+     | 1683826581569 (W)
+     | 1683826581569 Writing back bytes
+     | 1683826581569 Wrote [16392] bytes to the client
+     | 1683826581569 (W)
+     | 1683826581569 Writing back bytes
+     | 1683826581569 Wrote [16392] bytes to the client
+     | 1683826581569 (W)
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581569 Writing back bytes
+     | 1683826581569 Wrote [14275] bytes to the client
+     | 1683826581569 (W)
+     | 1683826581569 Writing back bytes
+     | 1683826581569 Wrote [5] bytes to the client
+     | 1683826581569 (W)
+     | 1683826581569 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581569 (WKA)
+     | 1683826581570 Read [336] bytes from client
+     | 1683826581570 (R)
+     | 1683826581570 (RP)
+     | 1683826581570 Preamble successfully parsed
+     | 1683826581570 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581570 (RWo)
+     | 1683826581570 (RC)
+     | 1683826581570 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581571 Preamble is [198] bytes long
+     | 1683826581571 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581571 Still writing preamble
+     | 1683826581571 Wrote [198] bytes to the client
+     | 1683826581571 (W)
+     | 1683826581571 Writing back bytes
+     | 1683826581571 Wrote [16392] bytes to the client
+     | 1683826581571 (W)
+     | 1683826581571 Writing back bytes
+     | 1683826581571 Wrote [16392] bytes to the client
+     | 1683826581571 (W)
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Nothing to write from the worker thread but the OutputStream isn't closed
+     | 1683826581571 Writing back bytes
+     | 1683826581571 Wrote [14374] bytes to the client
+     | 1683826581571 (W)
+     | 1683826581571 Writing back bytes
+     | 1683826581571 Wrote [5] bytes to the client
+     | 1683826581571 (W)
+     | 1683826581571 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581571 (WKA)
+     | 1683826581571 Read [336] bytes from client
+     | 1683826581571 (R)
+     | 1683826581571 (RP)
+     | 1683826581571 Preamble successfully parsed
+     | 1683826581571 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581571 (RWo)
+     | 1683826581571 (RC)
+     | 1683826581572 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581572 Preamble is [198] bytes long
+     | 1683826581572 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581572 Still writing preamble
+     | 1683826581572 Wrote [198] bytes to the client
+     | 1683826581572 (W)
+     | 1683826581572 Writing back bytes
+     | 1683826581572 Wrote [16392] bytes to the client
+     | 1683826581572 (W)
+     | 1683826581572 Writing back bytes
+     | 1683826581572 Wrote [16392] bytes to the client
+     | 1683826581572 (W)
+     | 1683826581572 Writing back bytes
+     | 1683826581572 Wrote [14473] bytes to the client
+     | 1683826581572 (W)
+     | 1683826581572 Writing back bytes
+     | 1683826581572 Wrote [5] bytes to the client
+     | 1683826581572 (W)
+     | 1683826581572 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581572 (WKA)
+     | 1683826581572 Read [336] bytes from client
+     | 1683826581572 (R)
+     | 1683826581572 (RP)
+     | 1683826581572 Preamble successfully parsed
+     | 1683826581572 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581572 (RWo)
+     | 1683826581572 (RC)
+     | 1683826581573 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581573 Preamble is [198] bytes long
+     | 1683826581573 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581573 Still writing preamble
+     | 1683826581573 Wrote [198] bytes to the client
+     | 1683826581573 (W)
+     | 1683826581573 Writing back bytes
+     | 1683826581573 Wrote [16392] bytes to the client
+     | 1683826581573 (W)
+     | 1683826581573 Writing back bytes
+     | 1683826581573 Wrote [16392] bytes to the client
+     | 1683826581573 (W)
+     | 1683826581573 Writing back bytes
+     | 1683826581573 Wrote [14572] bytes to the client
+     | 1683826581573 (W)
+     | 1683826581573 Writing back bytes
+     | 1683826581573 Wrote [5] bytes to the client
+     | 1683826581573 (W)
+     | 1683826581573 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581573 (WKA)
+     | 1683826581573 Read [336] bytes from client
+     | 1683826581573 (R)
+     | 1683826581573 (RP)
+     | 1683826581574 Preamble successfully parsed
+     | 1683826581574 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581574 (RWo)
+     | 1683826581574 (RC)
+     | 1683826581574 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581574 Preamble is [198] bytes long
+     | 1683826581574 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581574 Still writing preamble
+     | 1683826581574 Wrote [198] bytes to the client
+     | 1683826581574 (W)
+     | 1683826581574 Writing back bytes
+     | 1683826581574 Wrote [16392] bytes to the client
+     | 1683826581574 (W)
+     | 1683826581574 Writing back bytes
+     | 1683826581574 Wrote [16392] bytes to the client
+     | 1683826581574 (W)
+     | 1683826581574 Writing back bytes
+     | 1683826581574 Wrote [14671] bytes to the client
+     | 1683826581574 (W)
+     | 1683826581574 Writing back bytes
+     | 1683826581574 Wrote [5] bytes to the client
+     | 1683826581574 (W)
+     | 1683826581574 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581574 (WKA)
+     | 1683826581575 Read [336] bytes from client
+     | 1683826581575 (R)
+     | 1683826581575 (RP)
+     | 1683826581575 Preamble successfully parsed
+     | 1683826581575 Client indicated it was NOT sending an entity-body in the request
+     | 1683826581575 (RWo)
+     | 1683826581575 (RC)
+     | 1683826581575 The worker thread has bytes to write or has closed the stream, but the preamble hasn't been sent yet. Generating preamble
+     | 1683826581575 Preamble is [198] bytes long
+     | 1683826581575 Preamble is [
+HTTP/1.1 200
+set-cookie: prime-mvc-msg-flash=null; Max-Age=0; Path=/
+transfer-encoding: chunked
+content-type: application/json; charset=UTF-8
+connection: keep-alive
+cache-control: no-cache
+
+
+]
+     | 1683826581575 Still writing preamble
+     | 1683826581576 Wrote [198] bytes to the client
+     | 1683826581576 (W)
+     | 1683826581576 Writing back bytes
+     | 1683826581576 Wrote [16392] bytes to the client
+     | 1683826581576 (W)
+     | 1683826581576 Writing back bytes
+     | 1683826581576 Wrote [16392] bytes to the client
+     | 1683826581576 (W)
+     | 1683826581576 No more bytes from worker thread. Changing state to [KeepAlive]
+     | 1683826581576 (WKA)
+     | 1683826582577 Closing client connection [/127.0.0.1:58169] due to inactivity
+     | 1683826582581 Thread dump from server side.
+Thread[HTTP Server Worker Thread 35,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 3,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 15,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 24,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 19,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 36,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 21,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 31,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 5,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 20,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 26,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 28,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Thread,5,main] RUNNABLE
+	at java.base@17.0.3/java.lang.Thread.dumpThreads(Native Method)
+	at java.base@17.0.3/java.lang.Thread.getAllStackTraces(Thread.java:1662)
+	at app//io.fusionauth.http.server.HTTPServerThread.lambda$cleanup$2(HTTPServerThread.java:248)
+	at app//io.fusionauth.http.server.HTTPServerThread$$Lambda$306/0x00000008002ce0a8.accept(Unknown Source)
+	at java.base@17.0.3/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
+	at java.base@17.0.3/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
+	at java.base@17.0.3/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
+	at java.base@17.0.3/java.util.concurrent.ConcurrentHashMap$KeySpliterator.forEachRemaining(ConcurrentHashMap.java:3573)
+	at java.base@17.0.3/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
+	at java.base@17.0.3/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
+	at java.base@17.0.3/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
+	at java.base@17.0.3/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
+	at java.base@17.0.3/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
+	at java.base@17.0.3/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
+	at app//io.fusionauth.http.server.HTTPServerThread.cleanup(HTTPServerThread.java:241)
+	at app//io.fusionauth.http.server.HTTPServerThread.run(HTTPServerThread.java:169)
+
+Thread[HTTP Server Worker Thread 23,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 25,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Keep-Alive-Timer,8,InnocuousThreadGroup] TIMED_WAITING
+	at java.base@17.0.3/java.lang.Thread.sleep(Native Method)
+	at java.base@17.0.3/sun.net.www.http.KeepAliveCache.run(KeepAliveCache.java:191)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+	at java.base@17.0.3/jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:162)
+
+Thread[HTTP Server Worker Thread 10,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 11,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 32,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 2,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 1,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 33,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 9,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Finalizer,8,system] WAITING
+	at java.base@17.0.3/java.lang.Object.wait(Native Method)
+	at java.base@17.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
+	at java.base@17.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:176)
+	at java.base@17.0.3/java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:172)
+
+Thread[HTTP Server Worker Thread 30,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 14,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 17,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[main,5,main] RUNNABLE
+	at java.base@17.0.3/sun.nio.ch.SocketDispatcher.read0(Native Method)
+	at java.base@17.0.3/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:47)
+	at java.base@17.0.3/sun.nio.ch.NioSocketImpl.tryRead(NioSocketImpl.java:261)
+	at java.base@17.0.3/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:312)
+	at java.base@17.0.3/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:350)
+	at java.base@17.0.3/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:803)
+	at java.base@17.0.3/java.net.Socket$SocketInputStream.read(Socket.java:966)
+	at java.base@17.0.3/java.io.BufferedInputStream.fill(BufferedInputStream.java:244)
+	at java.base@17.0.3/java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
+	at java.base@17.0.3/java.io.BufferedInputStream.read(BufferedInputStream.java:343)
+	at java.base@17.0.3/sun.net.www.http.ChunkedInputStream.readAheadBlocking(ChunkedInputStream.java:554)
+	at java.base@17.0.3/sun.net.www.http.ChunkedInputStream.readAhead(ChunkedInputStream.java:611)
+	at java.base@17.0.3/sun.net.www.http.ChunkedInputStream.read(ChunkedInputStream.java:705)
+	at java.base@17.0.3/java.io.FilterInputStream.read(FilterInputStream.java:132)
+	at java.base@17.0.3/sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3663)
+	at java.base@17.0.3/sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3656)
+	at app//com.inversoft.rest.ByteArrayResponseHandler.apply(ByteArrayResponseHandler.java:37)
+	at app//com.inversoft.rest.ByteArrayResponseHandler.apply(ByteArrayResponseHandler.java:27)
+	at app//com.inversoft.rest.RESTClient.go(RESTClient.java:430)
+	at app//org.primeframework.mvc.test.RequestBuilder.run(RequestBuilder.java:766)
+	at app//org.primeframework.mvc.test.RequestBuilder.get(RequestBuilder.java:137)
+	at app//org.primeframework.mvc.PerformanceTest.get(PerformanceTest.java:30)
+	at java.base@17.0.3/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base@17.0.3/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+	at java.base@17.0.3/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base@17.0.3/java.lang.reflect.Method.invoke(Method.java:568)
+	at app//org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
+	at app//org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:677)
+	at app//org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:221)
+	at app//org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
+	at app//org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:969)
+	at app//org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:194)
+	at app//org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:148)
+	at app//org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
+	at app//org.testng.TestRunner$$Lambda$318/0x00000008002cae18.accept(Unknown Source)
+	at java.base@17.0.3/java.util.ArrayList.forEach(ArrayList.java:1511)
+	at app//org.testng.TestRunner.privateRun(TestRunner.java:829)
+	at app//org.testng.TestRunner.run(TestRunner.java:602)
+	at app//org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
+	at app//org.testng.SuiteRunner.runSequentially(SuiteRunner.java:431)
+	at app//org.testng.SuiteRunner.privateRun(SuiteRunner.java:391)
+	at app//org.testng.SuiteRunner.run(SuiteRunner.java:330)
+	at app//org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at app//org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at app//org.testng.TestNG.runSuitesSequentially(TestNG.java:1256)
+	at app//org.testng.TestNG.runSuitesLocally(TestNG.java:1176)
+	at app//org.testng.TestNG.runSuites(TestNG.java:1099)
+	at app//org.testng.TestNG.run(TestNG.java:1067)
+	at app//com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
+	at app//com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
+
+Thread[HTTP Server Worker Thread 29,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 39,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 13,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 22,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 4,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 7,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 27,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 16,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 38,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Common-Cleaner,8,InnocuousThreadGroup] TIMED_WAITING
+	at java.base@17.0.3/java.lang.Object.wait(Native Method)
+	at java.base@17.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
+	at java.base@17.0.3/jdk.internal.ref.CleanerImpl.run(CleanerImpl.java:140)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+	at java.base@17.0.3/jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:162)
+
+Thread[HTTP Server Worker Thread 18,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Reference Handler,10,system] RUNNABLE
+	at java.base@17.0.3/java.lang.ref.Reference.waitForReferencePendingList(Native Method)
+	at java.base@17.0.3/java.lang.ref.Reference.processPendingReferences(Reference.java:253)
+	at java.base@17.0.3/java.lang.ref.Reference$ReferenceHandler.run(Reference.java:215)
+
+Thread[HTTP Server Worker Thread 12,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 6,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 8,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 34,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[HTTP Server Worker Thread 37,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Signal Dispatcher,9,system] RUNNABLE
+
+Thread[HTTP Server Worker Thread 40,5,main] WAITING
+	at java.base@17.0.3/jdk.internal.misc.Unsafe.park(Native Method)
+	at java.base@17.0.3/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
+	at java.base@17.0.3/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
+	at java.base@17.0.3/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
+	at java.base@17.0.3/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1062)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1122)
+	at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
+
+Thread[Notification Thread,9,system] RUNNABLE
+
+
+     | 1683826582581 Closing connection to client [/127.0.0.1:58169]
+     | 1683826582581 (C)
+-----------------
+
+May 11, 2023 11:36:22.612 AM INFO  org.primeframework.mvc.PrimeMVCRequestHandler - Shutting down Prime MVC
+
+===============================================
+Default Suite
+Total tests run: 1, Passes: 0, Failures: 1, Skips: 0
+===============================================
+
+Disconnected from the target VM, address: '127.0.0.1:58164', transport: 'socket'
+
+Process finished with exit code 0


### PR DESCRIPTION
When waiting for bytes, yield some CPU time to avoid adding contention to the writer while we are waiting for their bytes. 