### PR TITLE
original port should not be ignored (fusionauth-issues/issues/2250)

### DIFF
--- a/src/main/java/io/fusionauth/http/server/HTTPRequest.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPRequest.java
@@ -738,6 +738,9 @@ public class HTTPRequest implements Buildable<HTTPRequest> {
         int colon = value.indexOf(':');
         if (colon > 0) {
           this.host = value.substring(0, colon);
+          String portString = value.substring(colon + 1);
+          if (portString.trim().length() > 0)
+            this.port = Integer.parseInt(portString);
         } else {
           this.host = value;
         }

--- a/src/main/java/io/fusionauth/http/server/HTTPRequest.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPRequest.java
@@ -739,8 +739,13 @@ public class HTTPRequest implements Buildable<HTTPRequest> {
         if (colon > 0) {
           this.host = value.substring(0, colon);
           String portString = value.substring(colon + 1);
-          if (portString.trim().length() > 0)
-            this.port = Integer.parseInt(portString);
+          if (portString.length() > 0) {
+            try {
+              this.port = Integer.parseInt(portString);
+            } catch (NumberFormatException e) {
+              // fallback, intentionally do nothing
+            }
+          }
         } else {
           this.host = value;
         }

--- a/src/test/java/io/fusionauth/http/HTTPRequestTest.java
+++ b/src/test/java/io/fusionauth/http/HTTPRequestTest.java
@@ -57,6 +57,7 @@ public class HTTPRequestTest {
     record caseRecord(String scheme, String source, String host, int port, String baseUrl) {
     }
     List<caseRecord> testCases = new ArrayList<>();
+    // positive cases
     testCases.add(new caseRecord("http", "myhost", "myhost", -1, "http://myhost"));
     testCases.add(new caseRecord("https", "myhost", "myhost", -1, "https://myhost"));
     testCases.add(new caseRecord("http", "myhost:80", "myhost", 80, "http://myhost"));
@@ -65,6 +66,9 @@ public class HTTPRequestTest {
     testCases.add(new caseRecord("https", "myhost:443", "myhost", 443, "https://myhost"));
     testCases.add(new caseRecord("http", "myhost:9011", "myhost", 9011, "http://myhost:9011"));
     testCases.add(new caseRecord("https", "myhost:9011", "myhost", 9011, "https://myhost:9011"));
+    // negative cases
+    testCases.add(new caseRecord("http", "myhost:abc", "myhost", -1, "http://myhost"));
+    testCases.add(new caseRecord("https", "myhost:abc", "myhost", -1, "https://myhost"));
 
     for (caseRecord aCase : testCases) {
       HTTPRequest request = new HTTPRequest();

--- a/src/test/java/io/fusionauth/http/HTTPRequestTest.java
+++ b/src/test/java/io/fusionauth/http/HTTPRequestTest.java
@@ -16,6 +16,7 @@
 package io.fusionauth.http;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +50,30 @@ public class HTTPRequestTest {
 
     request.addHeader("coNTent-type", "text/html; charset=UTF-8");
     assertEquals(request.getCharacterEncoding(), StandardCharsets.UTF_8);
+  }
+
+  @Test
+  public void hostPortHandling() {
+    record caseRecord(String scheme, String source, String host, int port, String baseUrl) {
+    }
+    List<caseRecord> testCases = new ArrayList<>();
+    testCases.add(new caseRecord("http", "myhost", "myhost", -1, "http://myhost"));
+    testCases.add(new caseRecord("https", "myhost", "myhost", -1, "https://myhost"));
+    testCases.add(new caseRecord("http", "myhost:80", "myhost", 80, "http://myhost"));
+    testCases.add(new caseRecord("https", "myhost:80", "myhost", 80, "https://myhost:80"));
+    testCases.add(new caseRecord("http", "myhost:443", "myhost", 443, "http://myhost:443"));
+    testCases.add(new caseRecord("https", "myhost:443", "myhost", 443, "https://myhost"));
+    testCases.add(new caseRecord("http", "myhost:9011", "myhost", 9011, "http://myhost:9011"));
+    testCases.add(new caseRecord("https", "myhost:9011", "myhost", 9011, "https://myhost:9011"));
+
+    for (caseRecord aCase : testCases) {
+      HTTPRequest request = new HTTPRequest();
+      request.setScheme(aCase.scheme());
+      request.addHeader(Headers.HostLower, aCase.source());
+      assertEquals(request.getHost(), aCase.host());
+      assertEquals(request.getPort(), aCase.port());
+      assertEquals(request.getBaseURL(), aCase.baseUrl());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Summary
original port should not be ignored (https://github.com/FusionAuth/fusionauth-issues/issues/2250)

### Steps to reproduce
Start docker image with port mapping 2222:9011

--- docker-compose.yml ---
services:
  fusionauth:
    image: fusionauth/fusionauth-app:1.45.2
    ports:
      - 2222:9011
--- docker-compose.yml ---

Configure "Google Identity Provider" (possibly any other provider)

Goto URL http://loalhost:2222/admin

Click on "Google Identity Provider" button to log in

Login fails because of wrong redirect_uri:
redirect_uri=http://localhost:9011/oauth2/callback

#### Expected redirect_uri:
redirect_uri=http://localhost:2222/oauth2/callback

### Change in PR
Change is tested with version 1.45.2 by replacing just one java class (HTTPRequest) in docker image using the following technique:

Dockerfile
```
FROM fusionauth/fusionauth-app:1.45.2
USER root
RUN apt update && apt install unzip zip
USER fusionauth
WORKDIR /usr/local/fusionauth/fusionauth-app/lib
COPY --chown=fusionauth ./build/ ./build/
RUN unzip ./java-http-0.1.13.jar -d unzipped
RUN cp ./build/classes/io/fusionauth/http/server/HTTPRequest.class ./unzipped/io/fusionauth/http/server/HTTPRequest.class
RUN (cd ./unzipped ; zip -u ../java-http-0.1.13.jar)
RUN rm -rf ./build ./unzipped
```