### PR TITLE
Break  Logger interface. Update logger to be more standard.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -17,7 +17,7 @@ jackson5Version = "3.0.1"
 restifyVersion = "4.1.2"
 testngVersion = "7.7.1"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.1.16", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.2.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/java-http.iml
+++ b/java-http.iml
@@ -17,7 +17,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/inversoft/restify/4.1.2/restify-4.1.2.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.1.2/restify-4.1.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -28,7 +28,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/inversoft/jackson5/3.0.1/jackson5-3.0.1.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/jackson5/3.0.1/jackson5-3.0.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -39,7 +39,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -50,7 +50,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -61,7 +61,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -72,7 +72,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/org/testng/testng/7.7.1/testng-7.7.1.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.7.1/testng-7.7.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -83,7 +83,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
@@ -105,7 +105,7 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>

--- a/src/main/java/io/fusionauth/http/log/BaseLogger.java
+++ b/src/main/java/io/fusionauth/http/log/BaseLogger.java
@@ -77,8 +77,23 @@ public abstract class BaseLogger implements Logger {
   }
 
   @Override
-  public boolean isDebuggable() {
+  public boolean isDebugEnabled() {
     return getLevelOrdinal() <= Level.Debug.ordinal();
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return getLevelOrdinal() <= Level.Error.ordinal();
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return getLevelOrdinal() <= Level.Info.ordinal();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return getLevelOrdinal() <= Level.Trace.ordinal();
   }
 
   @Override

--- a/src/main/java/io/fusionauth/http/log/Logger.java
+++ b/src/main/java/io/fusionauth/http/log/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,9 +76,46 @@ public interface Logger {
   void info(String message, Object... values);
 
   /**
-   * @return If this logger has debug enabled.
+   * @return True if this Logger is enabled for the Debug level, false otherwise.
    */
-  boolean isDebuggable();
+  boolean isDebugEnabled();
+
+  /**
+   * Returns whether this Logger is enabled for a given {@link Level}.
+   *
+   * @param level the level to check
+   * @return true if enabled, false otherwise.
+   */
+  default boolean isEnabledForLevel(Level level) {
+    return switch (level) {
+      case Trace -> isTraceEnabled();
+      case Debug -> isDebugEnabled();
+      case Info -> isInfoEnabled();
+      case Error -> isErrorEnabled();
+    };
+  }
+
+  /**
+   * @return True if this Logger is enabled for the Error level, false otherwise.
+   */
+  boolean isErrorEnabled();
+
+  /**
+   * @return True if this Logger is enabled for the Info level, false otherwise.
+   */
+  boolean isInfoEnabled();
+
+  /**
+   * @return True if this Logger is enabled for the Trace level, false otherwise.
+   */
+  boolean isTraceEnabled();
+
+  /**
+   * Sets the level of this logger (optional method).
+   *
+   * @param level The level.
+   */
+  void setLevel(Level level);
 
   /**
    * Logs a trace message with values.
@@ -94,11 +131,4 @@ public interface Logger {
    * @param message The message.
    */
   void trace(String message);
-
-  /**
-   * Sets the level of this logger (optional method).
-   *
-   * @param level The level.
-   */
-  void setLevel(Level level);
 }

--- a/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPResponseProcessor.java
@@ -80,7 +80,7 @@ public class HTTPResponseProcessor {
         }
 
         logger.debug("Preamble is [{}] bytes long", preambleBuffers[0].remaining());
-        if (logger.isDebuggable()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("Preamble is [\n{}\n]", new String(preambleBuffers[0].array(), 0, preambleBuffers[0].remaining()));
         }
 

--- a/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
+++ b/src/main/java/io/fusionauth/http/server/HTTPServerThread.java
@@ -210,7 +210,7 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
     client.configureBlocking(false);
     client.register(key.selector(), tlsProcessor.initialKeyOps(), tlsProcessor);
 
-    if (logger.isDebuggable()) {
+    if (logger.isDebugEnabled()) {
       try {
         logger.debug("Accepted connection from client [{}]", client.getRemoteAddress().toString());
       } catch (IOException e) {
@@ -226,7 +226,7 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
   private void cancelAndCloseKey(SelectionKey key) {
     if (key != null) {
       try (var client = key.channel()) {
-        if (logger.isDebuggable() && client instanceof SocketChannel socketChannel) {
+        if (logger.isDebugEnabled() && client instanceof SocketChannel socketChannel) {
           logger.debug("Closing connection to client [{}]", socketChannel.getRemoteAddress().toString());
         }
 
@@ -251,7 +251,7 @@ public class HTTPServerThread extends Thread implements Closeable, Notifier {
             .filter(key -> key.attachment() != null)
             .filter(key -> ((HTTPProcessor) key.attachment()).lastUsed() < now - clientTimeout.toMillis())
             .forEach(key -> {
-              if (logger.isDebuggable()) {
+              if (logger.isDebugEnabled()) {
                 var client = (SocketChannel) key.channel();
                 try {
                   logger.debug("Closing client connection [{}] due to inactivity", client.getRemoteAddress().toString());


### PR DESCRIPTION
I ran into problems trying to optionally log if TRACE was enabled.

This is a breaking change. Update version to 2.0.0.

This more closely replicates the SL4J `org.slf4j.Logger` API.