### PR TITLE
re-release as version 0.2.11

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -17,7 +17,7 @@ jackson5Version = "3.0.1"
 restifyVersion = "4.2.0"
 testngVersion = "7.8.0"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.3.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.2.11", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fusionauth</groupId>
   <artifactId>java-http</artifactId>
-  <version>0.3.0</version>
+  <version>0.2.11</version>
   <packaging>jar</packaging>
 
   <name>Java HTTP library (client and server)</name>


### PR DESCRIPTION
### Issue:
https://github.com/FusionAuth/fusionauth-issues/issues/2498

### Problem:
Updating applications to use latest `java-http` version of `0.3.0` would require all their dependencies (such as prime-mvc) to use version `0.3` of `java-http`.  Recent TLS updates of `java-http` are backwards compatible with previous versions, so technically, the current version should be `0.2.11`.  (Version `0.*.*` rules of Semver.)

### Solution:
Re-release `java-http` with a minor version change to `0.2.11`