### PR TITLE
Add support for non-ASCII header values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          architecture: aarch64
       - name: Install Savant Build
         run: |
           mkdir -p ~/dev/savant
@@ -29,7 +28,7 @@ jobs:
           ln -s savant-2.0.0-RC.7 current
           rm savant.tar.gz
           cat <<EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
-          17=${JAVA_HOME_17_AARCH64}
+          17=${JAVA_HOME_17_X64}
           EOF
         shell: bash
       - name: Run the build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+          arch: aarch64
       - name: Install Savant Build
         run: |
           mkdir -p ~/dev/savant
@@ -28,7 +29,7 @@ jobs:
           ln -s savant-2.0.0-RC.7 current
           rm savant.tar.gz
           cat <<EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
-          17=${JAVA_HOME_17_X64}
+          17=${JAVA_HOME_17_ARM64}
           EOF
         shell: bash
       - name: Run the build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          arch: aarch64
+          architecture: aarch64
       - name: Install Savant Build
         run: |
           mkdir -p ~/dev/savant
@@ -29,7 +29,7 @@ jobs:
           ln -s savant-2.0.0-RC.7 current
           rm savant.tar.gz
           cat <<EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
-          17=${JAVA_HOME_17_ARM64}
+          17=${JAVA_HOME_17_AARCH64}
           EOF
         shell: bash
       - name: Run the build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: test
 
-# Run the tests when code is pushed to `master`
+# Run the tests when code is pushed to `main`
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -23,9 +23,9 @@ jobs:
           mkdir -p ~/dev/savant
           mkdir -p ~/.savant/plugins
           cd ~/dev/savant
-          curl -fSL https://github.com/savant-build/savant-core/releases/download/2.0.0-RC.6/savant-2.0.0-RC.6.tar.gz > savant.tar.gz
+          curl -fSL https://github.com/savant-build/savant-core/releases/download/2.0.0-RC.7/savant-2.0.0-RC.7.tar.gz > savant.tar.gz
           tar -xzf savant.tar.gz
-          ln -s savant-2.0.0-RC.6 current
+          ln -s savant-2.0.0-RC.7 current
           rm savant.tar.gz
           cat <<EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
           17=${JAVA_HOME_17_X64}
@@ -38,7 +38,7 @@ jobs:
         shell: bash
       - name: Archive TestNG reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: testng-reports
           path: build/test-reports

--- a/build.savant
+++ b/build.savant
@@ -14,10 +14,10 @@
  * language governing permissions and limitations under the License.
  */
 jackson5Version = "3.0.1"
- restifyVersion = "4.2.1"
-testngVersion = "7.8.0"
+restifyVersion = "4.2.1"
+testngVersion = "7.10.2"
 
-project(group: "io.fusionauth", name: "java-http", version: "0.3.4", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "java-http", version: "0.3.5", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:
@@ -54,7 +54,7 @@ project(group: "io.fusionauth", name: "java-http", version: "0.3.4", licenses: [
 }
 
 // Plugins
-dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
+dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
 java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
 javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
 idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")

--- a/java-http.iml
+++ b/java-http.iml
@@ -72,11 +72,11 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.10.2/testng-7.10.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.10.2/testng-7.10.2-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -105,11 +105,11 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.7.1/jquery-3.7.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.7.1/jquery-3.7.1-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/io/fusionauth/http/util/HTTPTools.java
+++ b/src/main/java/io/fusionauth/http/util/HTTPTools.java
@@ -119,8 +119,10 @@ public final class HTTPTools {
     return ch >= '!' && ch <= '~';
   }
 
+  // RFC9110 section-5.5 allows for "obs-text", which includes 0x80-0xFF, but really shouldn't be used.
   public static boolean isValueCharacter(byte ch) {
-    return isURICharacter(ch) || ch == ' ' || ch == '\t' || ch == '\n';
+    int intVal = ch & 0xFF;  // Convert the value into an integer without extending the sign bit.
+    return isURICharacter(ch) || intVal == ' ' || intVal == '\t' || intVal == '\n' || intVal >= 0x80;
   }
 
   /**

--- a/src/test/java/io/fusionauth/http/BaseTest.java
+++ b/src/test/java/io/fusionauth/http/BaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2024, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/fusionauth/http/BaseTest.java
+++ b/src/test/java/io/fusionauth/http/BaseTest.java
@@ -15,7 +15,6 @@
  */
 package io.fusionauth.http;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -142,6 +141,18 @@ public abstract class BaseTest {
     }
 
     return builder.connectTimeout(ClientTimeout).build();
+  }
+
+  public Socket makeClientSocket(String scheme) throws GeneralSecurityException, IOException {
+    Socket socket;
+    if (scheme.equals("https")) {
+      var ctx = SecurityTools.clientContext(rootCertificate);
+      socket = ctx.getSocketFactory().createSocket("127.0.0.1", 4242);
+    } else {
+      socket = new Socket("127.0.0.1", 4242);
+    }
+
+    return socket;
   }
 
   public HTTPServer makeServer(String scheme, HTTPHandler handler, Instrumenter instrumenter) {

--- a/src/test/java/io/fusionauth/http/CoreTest.java
+++ b/src/test/java/io/fusionauth/http/CoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2024, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/fusionauth/http/CoreTest.java
+++ b/src/test/java/io/fusionauth/http/CoreTest.java
@@ -288,53 +288,6 @@ public class CoreTest extends BaseTest {
     }
   }
 
-
-  @Test()
-  public void utf8HeaderValues() throws Exception {
-    String scheme = "http";
-    String city = "São Paulo";
-
-    HTTPHandler handler = (req, res) -> {
-      res.setHeader(Headers.ContentType, "text/plain");
-      res.setHeader(Headers.ContentLength, "" + ExpectedResponse.length());
-      res.setHeader("X-Response-Header", city);
-      res.setStatus(200);
-
-      try {
-        OutputStream outputStream = res.getOutputStream();
-        outputStream.write(ExpectedResponse.getBytes());
-        outputStream.close();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    };
-
-    // Java HTTPClient only supports ASCII header values, so send it directly
-    try (HTTPServer ignore = makeServer(scheme, handler).start(); Socket sock = new Socket("127.0.0.1", 4242)) {
-      var os = sock.getOutputStream();
-      var is = sock.getInputStream();
-      os.write("""
-          GET /api/status HTTP/1.1\r
-          Host: localhost:42\r
-          X-Foo: São Paulo\r
-          \r
-          """.getBytes(StandardCharsets.UTF_8));
-      os.flush();
-
-      var resp = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-
-      assertEquals(resp, """
-          HTTP/1.1 200 \r
-          content-length: 16\r
-          content-type: text/plain\r
-          connection: keep-alive\r
-          x-response-header: São Paulo\r
-          \r
-          {"version":"42"}""");
-    }
-  }
-
-
   @Test
   public void keepAliveTimeout() {
     AtomicBoolean called = new AtomicBoolean(false);
@@ -831,6 +784,51 @@ public class CoreTest extends BaseTest {
 
       var response = client.send(request, r -> BodySubscribers.discarding());
       assertEquals(response.statusCode(), 200);
+    }
+  }
+
+  @Test(dataProvider = "schemes")
+  public void utf8HeaderValues(String scheme) throws Exception {
+
+    String city = "São Paulo";
+
+    HTTPHandler handler = (req, res) -> {
+      res.setHeader(Headers.ContentType, "text/plain");
+      res.setHeader(Headers.ContentLength, "" + ExpectedResponse.length());
+      res.setHeader("X-Response-Header", city);
+      res.setStatus(200);
+
+      try {
+        OutputStream outputStream = res.getOutputStream();
+        outputStream.write(ExpectedResponse.getBytes());
+        outputStream.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    // Java HTTPClient only supports ASCII header values, so send it directly
+    try (HTTPServer ignore = makeServer(scheme, handler).start(); Socket sock = new Socket("127.0.0.1", 4242)) {
+      var os = sock.getOutputStream();
+      var is = sock.getInputStream();
+      os.write("""
+          GET /api/status HTTP/1.1\r
+          Host: localhost:42\r
+          X-Request-Header: São Paulo\r
+          \r
+          """.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+
+      var resp = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+
+      assertEquals(resp, """
+          HTTP/1.1 200 \r
+          content-length: 16\r
+          content-type: text/plain\r
+          connection: keep-alive\r
+          x-response-header: São Paulo\r
+          \r
+          {"version":"42"}""");
     }
   }
 


### PR DESCRIPTION
Add support for non-ASCII header values.
Update deps.
Switch from 'master' branch to 'main'

Fixes:
- https://github.com/FusionAuth/java-http/issues/25